### PR TITLE
Update cfg-expr to 0.11.0 to get latest target triples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aacacf4d96c24b2ad6eb8ee6df040e4f27b0d0b39a5710c30091baa830485db"
+checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
 dependencies = [
  "smallvec",
  "target-lexicon",

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg=doc_cfg"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cfg-expr = { version = "0.10.3", features = ["targets"] }
+cfg-expr = { version = "0.11.0", features = ["targets"] }
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.137", optional = true, features = ["derive"] }
 target-lexicon = { version = "0.12.4", features = ["std"] }


### PR DESCRIPTION
## What happened

[Dependabot tried to upgrade the windows-sys crate](https://github.com/influxdata/influxdb_iox/pull/5752) to 0.42.0, and `cargo hakari generate` stopped working with this error:

```
Error:
   0: building package graph failed
   1: failed to construct package graph: for package 'windows-sys 0.42.0 (registry+https://github.com/rust-lang/crates.io-index)': for dependency 'windows_aarch64_gnullvm', parsing target 'aarch64-pc-windows-gnullvm' failed: unknown target triple
```

This can be reproduced with a `Cargo.toml` containing:

```
[dependencies]
windows-sys = "0.42.0"
```

This happens because [windows-sys now uses the target `aarch64-pc-windows-gnullvm`](https://github.com/microsoft/windows-rs/commit/c55af265f2e3c75e973946230fe6e60a20961ed9), which [was added in Rust 1.62.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1620-2022-06-30).

[Version 0.11.0 of cfg-expr supports targets up to Rust 1.64.0](https://github.com/EmbarkStudios/cfg-expr/pull/51#pullrequestreview-1121877627) (the README on crates.io says it only supports up to 1.58.0 but [that was fixed](https://github.com/EmbarkStudios/cfg-expr/commit/1065ebcc4991ff88147c0d73792a6595ec11a258) [after the release](https://github.com/EmbarkStudios/cfg-expr/commit/1c7eda7192b927b3245f56f4da176d040d0cd038)).