### PR TITLE
Upgrade cfg-expr to support parsing of `target_abi` cfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,9 +359,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0357a6402b295ca3a86bc148e84df46c02e41f41fef186bda662557ef6328aa"
+checksum = "0bbc13bf6290a6b202cc3efb36f7ec2b739a80634215630c8053a313edf6abef"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -2180,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
+checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
 
 [[package]]
 name = "target-spec"

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg=doc_cfg"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cfg-expr = { version = "0.11.0", features = ["targets"] }
+cfg-expr = { version = "0.12.0", features = ["targets"] }
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.147", optional = true, features = ["derive"] }
 target-lexicon = { version = "0.12.4", features = ["std"] }

--- a/target-spec/src/spec.rs
+++ b/target-spec/src/spec.rs
@@ -177,6 +177,14 @@ mod tests {
     }
 
     #[test]
+    fn test_target_abi() {
+        assert!(matches!(
+            TargetSpec::new("cfg(any(target_arch = \"wasm32\", target_abi = \"unknown\"))"),
+            Ok(TargetSpec::Expression(_))
+        ));
+    }
+
+    #[test]
     fn test_not() {
         assert!(matches!(
             TargetSpec::new("cfg(not(windows))"),

--- a/target-spec/src/spec.rs
+++ b/target-spec/src/spec.rs
@@ -149,7 +149,7 @@ impl FromStr for TargetExpression {
 mod tests {
     use super::*;
     use cfg_expr::{
-        targets::{Family, Os},
+        targets::{Abi, Arch, Family, Os},
         Predicate, TargetPredicate,
     };
 
@@ -178,10 +178,23 @@ mod tests {
 
     #[test]
     fn test_target_abi() {
-        assert!(matches!(
-            TargetSpec::new("cfg(any(target_arch = \"wasm32\", target_abi = \"unknown\"))"),
-            Ok(TargetSpec::Expression(_))
-        ));
+        let expr =
+            match TargetSpec::new("cfg(any(target_arch = \"wasm32\", target_abi = \"unknown\"))")
+                .unwrap()
+            {
+                TargetSpec::Triple(triple) => {
+                    panic!("expected expression, got triple: {:?}", triple)
+                }
+                TargetSpec::Expression(expr) => expr,
+            };
+
+        assert_eq!(
+            expr.inner.predicates().collect::<Vec<_>>(),
+            vec![
+                Predicate::Target(TargetPredicate::Arch(Arch("wasm32".into()))),
+                Predicate::Target(TargetPredicate::Abi(Abi("unknown".into()))),
+            ],
+        );
     }
 
     #[test]


### PR DESCRIPTION
Hi!! 

Over at IOx, we tried to upgrade to `ahash` 0.8.1. [`ahash` v0.8.1 uses `target_abi` in some of its `cfg`s](https://github.com/tkaitchuck/aHash/blob/673c17c930ef201233c14ee81136bad447cc2a5c/Cargo.toml#L83-L89).

`target_abi` is currently unstable, but is described in:

- [RFC 2992](https://github.com/rust-lang/rfcs/pull/2992)
- [The associated tracking issue](https://github.com/rust-lang/rust/issues/80970)
- [The initial implementation](https://github.com/rust-lang/rust/pull/86922)

`cargo hakari` couldn't parse `target_abi` and fails with this error:

```
Error: 
   0: building package graph failed
   1: failed to construct package graph: for package 'ahash 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)': for dependency 'getrandom', parsing target 'cfg(any(target_arch = "wasm32", target_abi = "unknown"))' failed: invalid cfg() expression
```

I [sent a PR to `cfg-expr`](https://github.com/EmbarkStudios/cfg-expr/pull/52) and [it got merged](https://github.com/EmbarkStudios/cfg-expr/pull/54) and released as `cfg-expr` 0.12.0.

This PR upgrades `target-spec` to that version and adds a regression test that `TargetSpec` will parse `target_abi` correctly.

Thank you!!!