### PR TITLE
[hakari] elide build metadata when printing dep versions

### DIFF
--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'cargo-hakari'

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['aarch64-unknown-freebsd', 'armv7-apple-ios']
 #
 # [traversal-excludes]

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'guppy-cmdlib'

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['powerpc-wrs-vxworks-spe', 'riscv64gc-unknown-linux-gnu', 'mipsel-unknown-none']
 # [[traversal-excludes.ids]]
 # name = 'pathdiff'

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-fuchsia']
 #
 # [traversal-excludes]

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc-unknown-freebsd', 'x86_64-unknown-redox', 'aarch64-wrs-vxworks']
 # [[traversal-excludes.ids]]
 # name = 'fixtures'

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['x86_64-wrs-vxworks', 'aarch64_be-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'bit-set'

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['aarch64_be-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'openssl'

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'winapi-i686-pc-windows-gnu'

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'cargo-guppy'

--- a/fixtures/large/hakari/metadata_libra-1.toml
+++ b/fixtures/large/hakari/metadata_libra-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'backoff'

--- a/fixtures/large/hakari/metadata_libra-2.toml
+++ b/fixtures/large/hakari/metadata_libra-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'adler32'

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['aarch64-nintendo-switch-freestanding', 'x86_64-apple-watchos-sim']
 # [[traversal-excludes.ids]]
 # name = 'criterion-plot'

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['riscv32imc-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'csv-core'

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'async-compression'

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['x86_64-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'num-derive'

--- a/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc-unknown-linux-musl', 'sparcv9-sun-solaris']
 # [[traversal-excludes.ids]]
 # name = 'arrayref'

--- a/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['armv7r-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'crossbeam-deque'

--- a/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'bytecode-to-boogie'

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['riscv64gc-unknown-none-elf', 'armv7k-apple-watchos']
 # [[traversal-excludes.ids]]
 # name = 'linked-hash-map'

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['x86_64-uwp-windows-msvc', 'aarch64-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'quote'

--- a/fixtures/small/hakari/metadata1-2.toml
+++ b/fixtures/small/hakari/metadata1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'regex'

--- a/fixtures/small/hakari/metadata1-3.toml
+++ b/fixtures/small/hakari/metadata1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['x86_64-pc-windows-msvc', 'i686-linux-android', 'armv7a-kmc-solid_asp3-eabi']
 # [[traversal-excludes.ids]]
 # name = 'bitflags'

--- a/fixtures/small/hakari/metadata2-0.toml
+++ b/fixtures/small/hakari/metadata2-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata2-1.toml
+++ b/fixtures/small/hakari/metadata2-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['aarch64-apple-tvos', 'armv7-unknown-linux-uclibceabi']
 # [[traversal-excludes.ids]]
 # name = 'quote'

--- a/fixtures/small/hakari/metadata_alternate_registries-0.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['armv7r-none-eabi', 'powerpc64le-unknown-linux-musl', 'powerpc64-unknown-linux-musl']
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_alternate_registries-2.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_alternate_registries-3.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc64-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'proc-macro2'

--- a/fixtures/small/hakari/metadata_build_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'testcrate'

--- a/fixtures/small/hakari/metadata_build_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_build_targets1-3.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['thumbv7m-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['wasm32-unknown-unknown', 'armv5te-none-eabi', 'riscv64gc-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_builddep-2.toml
+++ b/fixtures/small/hakari/metadata_builddep-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_builddep-3.toml
+++ b/fixtures/small/hakari/metadata_builddep-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['i686-unknown-freebsd', 'riscv64gc-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_cycle1-1.toml
+++ b/fixtures/small/hakari/metadata_cycle1-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['s390x-unknown-linux-gnu', 'x86_64-apple-ios', 'mips64el-unknown-linux-gnuabi64']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'

--- a/fixtures/small/hakari/metadata_cycle1-2.toml
+++ b/fixtures/small/hakari/metadata_cycle1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_cycle1-3.toml
+++ b/fixtures/small/hakari/metadata_cycle1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['aarch64-apple-ios-macabi', 'x86_64-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'

--- a/fixtures/small/hakari/metadata_cycle2-1.toml
+++ b/fixtures/small/hakari/metadata_cycle2-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['armv7-linux-androideabi']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'

--- a/fixtures/small/hakari/metadata_cycle2-3.toml
+++ b/fixtures/small/hakari/metadata_cycle2-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'

--- a/fixtures/small/hakari/metadata_cycle_features-0.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['armv7-apple-ios', 'riscv32gc-unknown-linux-musl', 'x86_64-apple-ios']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-helper'

--- a/fixtures/small/hakari/metadata_dups-1.toml
+++ b/fixtures/small/hakari/metadata_dups-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['hexagon-unknown-linux-musl', 'riscv32imac-unknown-xous-elf', 'armv4t-unknown-linux-gnueabi']
 # [[traversal-excludes.ids]]
 # name = 'lazy_static'

--- a/fixtures/small/hakari/metadata_dups-2.toml
+++ b/fixtures/small/hakari/metadata_dups-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['x86_64-unknown-none']
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['armv4t-unknown-linux-gnueabi']
 # [[traversal-excludes.ids]]
 # name = 'bytes'

--- a/fixtures/small/hakari/metadata_proc_macro1-0.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-wrs-vxworks', 'x86_64-wrs-vxworks', 'powerpc-wrs-vxworks-spe']
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_proc_macro1-1.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['x86_64-apple-tvos', 'armv7a-none-eabi', 'armv7-unknown-linux-uclibceabihf']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'

--- a/fixtures/small/hakari/metadata_proc_macro1-2.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '1'
 # platforms = ['mipsel-unknown-none', 'powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'build-user'

--- a/fixtures/small/hakari/metadata_proc_macro1-3.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['arm64_32-apple-watchos', 'armv7-unknown-netbsd-eabihf', 'aarch64-unknown-redox']
 # [[traversal-excludes.ids]]
 # name = 'build-user'

--- a/fixtures/small/hakari/metadata_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_targets1-0.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-apple-ios-macabi', 'armv7-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'

--- a/fixtures/small/hakari/metadata_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_targets1-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['armv7a-kmc-solid_asp3-eabi', 'mips64el-unknown-linux-muslabi64', 'i686-pc-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'serde'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'

--- a/tools/cargo-hakari/src/docs/config.rs
+++ b/tools/cargo-hakari/src/docs/config.rs
@@ -32,18 +32,26 @@
 //!
 //! ## dep-format-version
 //!
-//! The version of `workspace-hack = ...` lines in other `Cargo.toml` files to use.
+//! The format version to use
 //!
 //! Possible values:
-//! * *"1"*: `workspace-hack = { path = ...}`. (Note the lack of a trailing space.)
-//! * *"2"*: `workspace-hack = { version = "0.1", path = ... }`. This is required for the advanced
-//!   setup documented in the [Publishing](crate::publishing) section.
+//! * *"1"*: `workspace-hack = { path = ...}` in other `Cargo.toml` files. (Note the lack of a
+//!   trailing space.)
+//! * *"2"*: `workspace-hack = { version = "0.1", path = ... }` in other `Cargo.toml` files. This is
+//!   required for the advanced setup documented in the [Publishing](crate::publishing) section.
+//! * *"3"*: Elides build metadata from version strings in the workspace-hack's `Cargo.toml`. Cargo
+//!   warns if build metadata is added to version strings.
 //!
-//! Defaults to "1", but starting `cargo hakari 0.9.8`, `.config/hakari.toml` files created by
-//! `cargo hakari init` set it to "2".
+//! Defaults to "1", but
+//! - starting `cargo hakari 0.9.8`, `.config/hakari.toml` files created by
+//!   `cargo hakari init` set it to "2".
+//! - starting `cargo hakari 0.9.18`, `.config/hakari.toml` files created by
+//!   `cargo hakari init` set it to "3".
+//!
+//! In general, it is best to be on the latest version.
 //!
 //! ```toml
-//! dep-format-version = "2"
+//! dep-format-version = "3"
 //! ```
 //!
 //! ## platforms

--- a/tools/hakari/src/cli_ops/manage_deps.rs
+++ b/tools/hakari/src/cli_ops/manage_deps.rs
@@ -37,7 +37,7 @@ impl<'g> HakariBuilder<'g> {
                     (Some(_), false) => Some(false),
                     (Some(link), true) => match self.dep_format_version {
                         DepFormatVersion::V1 => None,
-                        DepFormatVersion::V2 => {
+                        DepFormatVersion::V2 | DepFormatVersion::V3 => {
                             needs_update_v2(hakari_package, link).then_some(true)
                         }
                     },

--- a/tools/hakari/src/helpers.rs
+++ b/tools/hakari/src/helpers.rs
@@ -48,15 +48,16 @@ mod tests {
     #[test]
     fn min_version() {
         let versions = vec![
-            ("1.4.0", "1"),
-            ("2.8.0", "2"),
-            ("0.4.2", "0.4"),
-            ("0.0.7", "0.0.7"),
-            ("1.4.0-b1", "1.4.0-b1"),
-            ("4.2.3+g456", "4"),
+            ("1.4.0", "1", "1.4.0"),
+            ("2.8.0", "2", "2.8.0"),
+            ("0.4.2", "0.4", "0.4.2"),
+            ("0.0.7", "0.0.7", "0.0.7"),
+            ("1.4.0-b1", "1.4.0-b1", "1.4.0-b1"),
+            ("2.8.0-a.1+v123", "2.8.0-a.1+v123", "2.8.0-a.1+v123"),
+            ("4.2.3+g456", "4", "4.2.3+g456"),
         ];
 
-        for (version_str, min) in versions {
+        for (version_str, min, exact) in versions {
             let version = Version::parse(version_str).expect("valid version");
             let version_req = VersionReq::parse(min).expect("valid version req");
             assert!(
@@ -66,10 +67,7 @@ mod tests {
                 version
             );
             assert_eq!(&format!("{}", VersionDisplay::new(&version, false)), min);
-            assert_eq!(
-                &format!("{}", VersionDisplay::new(&version, true)),
-                version_str
-            );
+            assert_eq!(&format!("{}", VersionDisplay::new(&version, true)), exact);
         }
     }
 

--- a/tools/hakari/src/helpers.rs
+++ b/tools/hakari/src/helpers.rs
@@ -9,33 +9,48 @@ use std::fmt;
 pub(crate) struct VersionDisplay<'a> {
     version: &'a Version,
     exact_versions: bool,
+    // Adding build metadata is incorrect (Cargo emits a warning when build metadata is present in a
+    // dependency specification), but support this for compatibility with older versions of hakari.
+    with_build_metadata: bool,
 }
 
 impl<'a> VersionDisplay<'a> {
-    pub(crate) fn new(version: &'a Version, exact_versions: bool) -> Self {
+    pub(crate) fn new(
+        version: &'a Version,
+        exact_versions: bool,
+        with_build_metadata: bool,
+    ) -> Self {
         Self {
             version,
             exact_versions,
+            with_build_metadata,
         }
     }
 }
 
 impl<'a> fmt::Display for VersionDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.exact_versions || !self.version.pre.is_empty() {
-            // Preserve the version exactly.
-            write!(f, "{}", self.version)
-        } else if self.version.major >= 1 {
-            write!(f, "{}", self.version.major)
-        } else if self.version.minor >= 1 {
-            write!(f, "{}.{}", self.version.major, self.version.minor)
-        } else {
-            write!(
-                f,
-                "{}.{}.{}",
-                self.version.major, self.version.minor, self.version.patch
-            )
+        if !self.exact_versions && self.version.pre.is_empty() {
+            // Minimal versions permitted, so attempt to minimize the version.
+            if self.version.major >= 1 {
+                return write!(f, "{}", self.version.major);
+            }
+            if self.version.minor >= 1 {
+                return write!(f, "{}.{}", self.version.major, self.version.minor);
+            }
         }
+        write!(
+            f,
+            "{}.{}.{}",
+            self.version.major, self.version.minor, self.version.patch
+        )?;
+        if !self.version.pre.is_empty() {
+            write!(f, "-{}", self.version.pre)?;
+        }
+        if self.with_build_metadata && !self.version.build.is_empty() {
+            write!(f, "+{}", self.version.build)?;
+        }
+        Ok(())
     }
 }
 
@@ -48,16 +63,24 @@ mod tests {
     #[test]
     fn min_version() {
         let versions = vec![
-            ("1.4.0", "1", "1.4.0"),
-            ("2.8.0", "2", "2.8.0"),
-            ("0.4.2", "0.4", "0.4.2"),
-            ("0.0.7", "0.0.7", "0.0.7"),
-            ("1.4.0-b1", "1.4.0-b1", "1.4.0-b1"),
-            ("2.8.0-a.1+v123", "2.8.0-a.1+v123", "2.8.0-a.1+v123"),
-            ("4.2.3+g456", "4", "4.2.3+g456"),
+            ("1.4.0", "1", "1.4.0", "1", "1.4.0"),
+            ("2.8.0", "2", "2.8.0", "2", "2.8.0"),
+            ("0.4.2", "0.4", "0.4.2", "0.4", "0.4.2"),
+            ("0.0.7", "0.0.7", "0.0.7", "0.0.7", "0.0.7"),
+            ("1.4.0-b1", "1.4.0-b1", "1.4.0-b1", "1.4.0-b1", "1.4.0-b1"),
+            (
+                "2.8.0-a.1+v123",
+                "2.8.0-a.1",
+                "2.8.0-a.1",
+                "2.8.0-a.1+v123",
+                "2.8.0-a.1+v123",
+            ),
+            ("4.2.3+g456", "4", "4.2.3", "4", "4.2.3+g456"),
         ];
 
-        for (version_str, min, exact) in versions {
+        for (version_str, min, exact, min_with_build_metadata, exact_with_build_metadata) in
+            versions
+        {
             let version = Version::parse(version_str).expect("valid version");
             let version_req = VersionReq::parse(min).expect("valid version req");
             assert!(
@@ -66,8 +89,22 @@ mod tests {
                 min,
                 version
             );
-            assert_eq!(&format!("{}", VersionDisplay::new(&version, false)), min);
-            assert_eq!(&format!("{}", VersionDisplay::new(&version, true)), exact);
+            assert_eq!(
+                &format!("{}", VersionDisplay::new(&version, false, false)),
+                min
+            );
+            assert_eq!(
+                &format!("{}", VersionDisplay::new(&version, true, false)),
+                exact
+            );
+            assert_eq!(
+                &format!("{}", VersionDisplay::new(&version, false, true)),
+                min_with_build_metadata
+            );
+            assert_eq!(
+                &format!("{}", VersionDisplay::new(&version, true, true)),
+                exact_with_build_metadata
+            );
         }
     }
 
@@ -77,12 +114,26 @@ mod tests {
             let graph = fixture.graph();
             for package in graph.resolve_all().packages(DependencyDirection::Forward) {
                 let version = package.version();
-                let min_version = format!("{}", VersionDisplay::new(version, false));
+                let min_version = format!("{}", VersionDisplay::new(version, false, false));
                 let version_req = VersionReq::parse(&min_version).expect("valid version req");
 
                 assert!(
                     version_req.matches(version),
                     "for fixture '{}', for package '{}', min version req {} should match version {}",
+                    name,
+                    package.id(),
+                    min_version,
+                    version,
+                );
+
+                let min_version_with_build_metadata =
+                    format!("{}", VersionDisplay::new(version, false, true));
+                let version_req =
+                    VersionReq::parse(&min_version_with_build_metadata).expect("valid version req");
+
+                assert!(
+                    version_req.matches(version),
+                    "for fixture '{}', for package '{}', min version (with build metadata) req {} should match version {}",
                     name,
                     package.id(),
                     min_version,

--- a/tools/hakari/src/proptest_helpers.rs
+++ b/tools/hakari/src/proptest_helpers.rs
@@ -40,6 +40,7 @@ impl<'g> HakariBuilder<'g> {
             hash_set(graph.prop010_id_strategy(), 0..8),
             any::<UnifyTargetHost>(),
             any::<bool>(),
+            any::<DepFormatVersion>(),
         )
             .prop_map(
                 move |(
@@ -50,6 +51,7 @@ impl<'g> HakariBuilder<'g> {
                     final_excludes,
                     unify_target_host,
                     output_single_feature,
+                    dep_format_version,
                 )| {
                     let mut builder = HakariBuilder::new(graph, hakari_id)
                         .expect("HakariBuilder::new returned an error");
@@ -66,7 +68,7 @@ impl<'g> HakariBuilder<'g> {
                         .add_final_excludes(final_excludes)
                         .expect("final excludes obtained from PackageGraph should work")
                         .set_unify_target_host(unify_target_host)
-                        .set_dep_format_version(DepFormatVersion::V2)
+                        .set_dep_format_version(dep_format_version)
                         .set_output_single_feature(output_single_feature);
                     builder
                 },


### PR DESCRIPTION
@sunshowers I wasn't sure how to tackle the format version stuff you mentioned in #52. The existing `dep-format-version` is documented to only impact the format of the `workspace-hack = ...` line that gets added to _other_ crates, and now the format of dependencies in the workspace-hack crate itself. Wasn't sure if you wanted to add a new format version option, or just generalize the `dep-format-version` option and update the various docstrings.

----

This commit elides build metadata when printing dependency versions for the workspace-hack crate's Cargo.toml. Without this change, `cargo build` in the resulting workspace will produce a warning about superfluous build metadata (if a dependency under management has a version that includes build metadata).

Fix #52.