### PR TITLE
[hakari] add a new format version that sorts dependencies alphabetically

### DIFF
--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc-wrs-vxworks-spe', 'thumbv7em-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['aarch64-unknown-freebsd', 'armv7-apple-ios']
 #
 # [traversal-excludes]

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'guppy-cmdlib'

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['aarch64-fuchsia']
 #
 # [traversal-excludes]
@@ -76,8 +76,8 @@ idna = { version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jobserver = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
@@ -228,8 +228,8 @@ idna = { version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jobserver = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
@@ -286,8 +286,8 @@ rusty-fork = { version = "0.3", default-features = false, features = ["timeout"]
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard = { version = "1", default-features = false }
-semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-274715c4dabd11b0 = { package = "semver", version = "0.9" }
+semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_cbor = { version = "0.11" }
@@ -321,8 +321,8 @@ unicode-bidi = { version = "0.3" }
 unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
-unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unreachable = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['powerpc-unknown-freebsd', 'x86_64-unknown-redox', 'aarch64-wrs-vxworks']
 # [[traversal-excludes.ids]]
 # name = 'fixtures'

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['x86_64-wrs-vxworks', 'aarch64_be-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'bit-set'

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['wasm32-wasi']
 # [[traversal-excludes.ids]]
 # name = 'byteorder'
@@ -27,51 +27,51 @@
 # crates-io = true
 
 [dependencies]
-aho-corasick = { version = "0.7", features = ["std"] }
+aho-corasick = { version = "0.7" }
 ansi_term = { version = "0.11", default-features = false }
-anyhow = { version = "1", features = ["std"] }
+anyhow = { version = "1" }
 ascii = { version = "0.9", default-features = false, features = ["std"] }
 assert_matches = { version = "1", default-features = false }
 atty = { version = "0.2", default-features = false }
-bit-set = { version = "0.5", features = ["std"] }
+bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
-bitmaps = { version = "2", features = ["std"] }
-bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+bitmaps = { version = "2" }
+bstr = { version = "0.2", features = ["serde1"] }
 bytesize = { version = "1", default-features = false }
 cargo = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
 cargo-platform = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
 cargo_metadata = { version = "0.11" }
-cast = { version = "0.2", features = ["std"] }
+cast = { version = "0.2" }
 cfg-expr = { version = "0.4" }
 cfg-if = { version = "0.1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "libc", "oldtime", "std", "time", "winapi"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
-combine = { version = "3", features = ["std"] }
-console = { version = "0.11", features = ["ansi-parsing", "regex", "unicode-width", "winapi-util", "windows-console-colors"] }
+chrono = { version = "0.4" }
+clap = { version = "2" }
+combine = { version = "3" }
+console = { version = "0.11" }
 crates-io = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-crc32fast = { version = "1", features = ["std"] }
+crc32fast = { version = "1" }
 criterion = { version = "0.3" }
 criterion-plot = { version = "0.4", default-features = false }
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-epoch = { version = "0.8" }
+crossbeam-utils = { version = "0.7" }
 crypto-hash = { version = "0.3", default-features = false }
 csv-core = { version = "0.1" }
-curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
-curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
 dialoguer = { version = "0.6", default-features = false }
 difference = { version = "2" }
 diffus = { version = "0.9" }
-either = { version = "1", features = ["use_std"] }
-env_logger = { version = "0.7", features = ["atty", "humantime", "regex", "termcolor"] }
+either = { version = "1" }
+env_logger = { version = "0.7" }
 filetime = { version = "0.2", default-features = false }
 fixedbitset = { version = "0.2", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["any_zlib", "libz-sys", "zlib"] }
-fnv = { version = "1", features = ["std"] }
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
+fnv = { version = "1" }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-git2 = { version = "0.13", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2 = { version = "0.13" }
 git2-curl = { version = "0.14", default-features = false }
 glob = { version = "0.3", default-features = false }
 globset = { version = "0.4", default-features = false }
@@ -85,14 +85,14 @@ idna = { version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
+itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itoa = { version = "0.4" }
 jobserver = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
 lazycell = { version = "1", default-features = false }
-libc = { version = "0.2", features = ["std"] }
-libgit2-sys = { version = "0.12", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+libc = { version = "0.2" }
+libgit2-sys = { version = "0.12", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.2", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
@@ -100,13 +100,13 @@ linked-hash-map = { version = "0.5", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
 matches = { version = "0.1", default-features = false }
 maybe-uninit = { version = "2", default-features = false }
-memchr = { version = "2", features = ["std", "use_std"] }
+memchr = { version = "2", features = ["use_std"] }
 memoffset = { version = "0.5" }
 nested = { version = "0.1", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-num-traits = { version = "0.2", features = ["std"] }
+num-traits = { version = "0.2" }
 num_cpus = { version = "1", default-features = false }
-once_cell = { version = "1", features = ["std"] }
+once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 opener = { version = "0.4", default-features = false }
 pathdiff = { version = "0.2", default-features = false }
@@ -115,33 +115,33 @@ petgraph = { version = "0.5", default-features = false }
 plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 pretty_assertions = { version = "0.6", default-features = false }
-proptest = { version = "0.10", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+proptest = { version = "0.10" }
 quick-error = { version = "1", default-features = false }
-rand = { version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "std"] }
+rand = { version = "0.7" }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
-rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core = { version = "0.5", default-features = false, features = ["std"] }
 rand_xorshift = { version = "0.2", default-features = false }
 rand_xoshiro = { version = "0.4", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex = { version = "1" }
 regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6" }
 remove_dir_all = { version = "0.5", default-features = false }
 rustc-workspace-hack = { version = "1", default-features = false }
 rustfix = { version = "0.5", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard = { version = "1", default-features = false }
 semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-parser = { version = "0.7", default-features = false }
-serde = { version = "1", features = ["derive", "serde_derive", "std"] }
-serde_cbor = { version = "0.11", features = ["std"] }
+serde = { version = "1", features = ["derive"] }
+serde_cbor = { version = "0.11" }
 serde_ignored = { version = "0.1", default-features = false }
-serde_json = { version = "1", features = ["raw_value", "std"] }
+serde_json = { version = "1", features = ["raw_value"] }
 shell-escape = { version = "0.1", default-features = false }
-sized-chunks = { version = "0.6", features = ["std"] }
+sized-chunks = { version = "0.6" }
 smallvec = { version = "1", default-features = false }
 socket2 = { version = "0.3", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
@@ -161,7 +161,7 @@ toml = { version = "0.5" }
 toml_edit = { version = "0.2", default-features = false }
 typenum = { version = "1", default-features = false }
 unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1", features = ["std"] }
+unicode-normalization = { version = "0.1" }
 unicode-width = { version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 unreachable = { version = "1", default-features = false }
@@ -174,24 +174,24 @@ wait-timeout = { version = "0.2", default-features = false }
 
 [build-dependencies]
 autocfg = { version = "1", default-features = false }
-cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
 heck = { version = "0.3", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
-proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
+proc-macro-error = { version = "1" }
 proc-macro-error-attr = { version = "1", default-features = false }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
+proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
+proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1" }
 proptest-derive = { version = "0.2", default-features = false }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
+quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 rustc_version = { version = "0.2", default-features = false }
 semver-274715c4dabd11b0 = { package = "semver", version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
 serde_derive = { version = "1" }
 structopt-derive = { version = "0.4", default-features = false }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["full", "visit"] }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
@@ -205,10 +205,10 @@ js-sys = { version = "0.3", default-features = false }
 miniz_oxide = { version = "0.4", default-features = false }
 openssl = { version = "0.10", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
-wasi-93f6ce9d446188ac = { package = "wasi", version = "0.10", features = ["std"] }
-wasi-274715c4dabd11b0 = { package = "wasi", version = "0.9", features = ["std"] }
-wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
-web-sys = { version = "0.3", default-features = false, features = ["CanvasRenderingContext2d", "Document", "DomRect", "DomRectReadOnly", "Element", "EventTarget", "HtmlCanvasElement", "HtmlElement", "Node", "Window"] }
+wasi-93f6ce9d446188ac = { package = "wasi", version = "0.10" }
+wasi-274715c4dabd11b0 = { package = "wasi", version = "0.9" }
+wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3", default-features = false, features = ["CanvasRenderingContext2d", "Document", "DomRect", "HtmlCanvasElement", "Window"] }
 
 [target.wasm32-wasi.build-dependencies]
 bumpalo = { version = "3" }

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'winapi-i686-pc-windows-gnu'
@@ -76,8 +76,8 @@ idna = { version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jobserver = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
@@ -229,8 +229,8 @@ idna = { version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jobserver = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
@@ -287,8 +287,8 @@ rusty-fork = { version = "0.3", default-features = false, features = ["timeout"]
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard = { version = "1", default-features = false }
-semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-274715c4dabd11b0 = { package = "semver", version = "0.9" }
+semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_cbor = { version = "0.11" }
@@ -322,8 +322,8 @@ unicode-bidi = { version = "0.3" }
 unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
-unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unreachable = { version = "1", default-features = false }
 url = { version = "2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-nintendo-switch-freestanding', 'i686-unknown-haiku', 'x86_64-unknown-illumos']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
@@ -36,27 +36,27 @@
 
 [dependencies]
 ansi_term = { version = "0.11", default-features = false }
-anyhow = { version = "1", features = ["std"] }
+anyhow = { version = "1" }
 ascii = { version = "0.9", default-features = false, features = ["std"] }
 assert_matches = { version = "1", default-features = false }
 atty = { version = "0.2", default-features = false }
 bitflags = { version = "1" }
-bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+bstr = { version = "0.2", features = ["serde1"] }
 byteorder = { version = "1", default-features = false, features = ["std"] }
 cargo_metadata = { version = "0.11" }
-cast = { version = "0.2", features = ["std"] }
+cast = { version = "0.2" }
 cfg-expr = { version = "0.4" }
 cfg-if = { version = "0.1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "libc", "oldtime", "std", "time", "winapi"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
-combine = { version = "3", features = ["std"] }
-console = { version = "0.11", features = ["ansi-parsing", "regex", "unicode-width", "winapi-util", "windows-console-colors"] }
+chrono = { version = "0.4" }
+clap = { version = "2" }
+combine = { version = "3" }
+console = { version = "0.11" }
 criterion = { version = "0.3" }
 criterion-plot = { version = "0.4", default-features = false }
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-epoch = { version = "0.8" }
+crossbeam-utils = { version = "0.7" }
 csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 dialoguer = { version = "0.6", default-features = false }
@@ -68,27 +68,27 @@ getrandom = { version = "0.1", default-features = false, features = ["std"] }
 half = { version = "1", default-features = false }
 hashbrown = { version = "0.9", default-features = false, features = ["raw"] }
 indexmap = { version = "1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
+itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itoa = { version = "0.4" }
 lazy_static = { version = "1", default-features = false }
-libc = { version = "0.2", features = ["std"] }
+libc = { version = "0.2" }
 linked-hash-map = { version = "0.5", default-features = false }
 maybe-uninit = { version = "2", default-features = false }
-memchr = { version = "2", default-features = false, features = ["std", "use_std"] }
+memchr = { version = "2", default-features = false, features = ["use_std"] }
 memoffset = { version = "0.5" }
 nested = { version = "0.1", default-features = false }
 num-integer = { version = "0.1", default-features = false }
-num-traits = { version = "0.2", features = ["std"] }
+num-traits = { version = "0.2" }
 num_cpus = { version = "1", default-features = false }
-once_cell = { version = "1", features = ["std"] }
+once_cell = { version = "1" }
 oorandom = { version = "11", default-features = false }
 pathdiff = { version = "0.2", default-features = false }
 petgraph = { version = "0.5", default-features = false }
 plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
 pretty_assertions = { version = "0.6", default-features = false }
-rand = { version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "std"] }
-rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand = { version = "0.7" }
+rand_core = { version = "0.5", default-features = false, features = ["std"] }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 regex = { version = "1", default-features = false, features = ["std"] }
@@ -99,9 +99,9 @@ ryu = { version = "1", default-features = false }
 scopeguard = { version = "1", default-features = false }
 semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
 semver-parser = { version = "0.7", default-features = false }
-serde = { version = "1", features = ["derive", "serde_derive", "std"] }
-serde_cbor = { version = "0.11", features = ["std"] }
-serde_json = { version = "1", features = ["std"] }
+serde = { version = "1", features = ["derive"] }
+serde_cbor = { version = "0.11" }
+serde_json = { version = "1" }
 smallvec = { version = "1", default-features = false }
 strsim = { version = "0.8", default-features = false }
 structopt = { version = "0.3" }
@@ -122,20 +122,20 @@ walkdir = { version = "2", default-features = false }
 [build-dependencies]
 autocfg = { version = "1", default-features = false }
 heck = { version = "0.3", default-features = false }
-proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
+proc-macro-error = { version = "1" }
 proc-macro-error-attr = { version = "1", default-features = false }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
+proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
+proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1" }
 proptest-derive = { version = "0.2", default-features = false }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
+quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 rustc_version = { version = "0.2", default-features = false }
 semver-274715c4dabd11b0 = { package = "semver", version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
 serde_derive = { version = "1" }
 structopt-derive = { version = "0.4", default-features = false }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["full", "visit"] }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }

--- a/fixtures/large/hakari/metadata_libra-1.toml
+++ b/fixtures/large/hakari/metadata_libra-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'backoff'

--- a/fixtures/large/hakari/metadata_libra-3.toml
+++ b/fixtures/large/hakari/metadata_libra-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'atty'
@@ -53,66 +53,66 @@
 
 [dependencies]
 adler32 = { version = "1", default-features = false }
-aho-corasick = { version = "0.7", features = ["std"] }
-anyhow = { version = "1", features = ["std"] }
+aho-corasick = { version = "0.7" }
+anyhow = { version = "1" }
 arc-swap = { version = "0.4", default-features = false }
 arrayref = { version = "0.3", default-features = false }
 arrayvec = { version = "0.4", default-features = false }
 assert_approx_eq = { version = "1", default-features = false }
 assert_matches = { version = "1", default-features = false }
 backoff = { version = "0.1", default-features = false }
-backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
+backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false }
 base64 = { version = "0.10", default-features = false }
 bech32 = { version = "0.6", default-features = false }
 bincode = { version = "1", default-features = false }
-bit-set = { version = "0.5", features = ["std"] }
+bit-set = { version = "0.5" }
 bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
-bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
+bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
 bitflags = { version = "1" }
-bitvec = { version = "0.10", features = ["alloc", "std"] }
+bitvec = { version = "0.10" }
 blake2 = { version = "0.8", default-features = false }
-blake2-rfc = { version = "0.2", features = ["std"] }
+blake2-rfc = { version = "0.2" }
 block-buffer = { version = "0.7", default-features = false }
 block-padding = { version = "0.1", default-features = false }
 bs58 = { version = "0.2" }
-bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+bstr = { version = "0.2", features = ["serde1"] }
 byte-tools = { version = "0.3", default-features = false }
-byteorder = { version = "1", features = ["i128", "std"] }
+byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "0.4", default-features = false, features = ["either"] }
 bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
 c_linked_list = { version = "1", default-features = false }
 cached = { version = "0.9", default-features = false }
-cast = { version = "0.2", features = ["std"] }
+cast = { version = "0.2" }
 cfg-if = { version = "0.1", default-features = false }
 chacha20-poly1305-aead = { version = "0.1", default-features = false }
 chashmap = { version = "2", default-features = false }
-chrono = { version = "0.4", features = ["clock", "serde", "time"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "2" }
 clear_on_drop = { version = "0.2", default-features = false }
-codespan = { version = "0.2", default-features = false, features = ["serde", "serde_derive", "serialization"] }
+codespan = { version = "0.2", default-features = false, features = ["serialization"] }
 codespan-reporting = { version = "0.2", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
-cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
+cookie = { version = "0.12", default-features = false, features = ["percent-encode"] }
 cookie_store = { version = "0.7", default-features = false }
-crc = { version = "1", features = ["std"] }
-crc32fast = { version = "1", features = ["std"] }
+crc = { version = "1" }
+crc32fast = { version = "1" }
 criterion = { version = "0.3" }
 criterion-plot = { version = "0.4", default-features = false }
-crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
+crossbeam = { version = "0.7" }
 crossbeam-channel = { version = "0.3", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-epoch = { version = "0.7" }
 crossbeam-queue = { version = "0.1", default-features = false }
-crossbeam-utils = { version = "0.6", features = ["lazy_static", "std"] }
-crunchy = { version = "0.2", features = ["limit_128"] }
+crossbeam-utils = { version = "0.6" }
+crunchy = { version = "0.2" }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
-csv-core = { version = "0.1", features = ["libc"] }
+csv-core = { version = "0.1" }
 ct-logs = { version = "0.6", default-features = false }
 ctrlc = { version = "3", default-features = false }
-curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
-curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["alloc", "std", "u64_backend"] }
+curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["std", "u64_backend"] }
 data-encoding = { version = "2", default-features = false }
 digest = { version = "0.8", default-features = false, features = ["std"] }
 dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
@@ -120,31 +120,31 @@ dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = fa
 dirs-sys = { version = "0.3", default-features = false }
 dtoa = { version = "0.4", default-features = false }
 ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1", features = ["std", "u64_backend"] }
-either = { version = "1", features = ["use_std"] }
+ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1" }
+either = { version = "1" }
 encoding_rs = { version = "0.8", default-features = false }
 endian-type = { version = "0.1", default-features = false }
-env_logger = { version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
+env_logger = { version = "0.6" }
 errno = { version = "0.2", default-features = false }
-error-chain = { version = "0.12", features = ["backtrace", "example_generated"] }
-failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
+error-chain = { version = "0.12" }
+failure = { version = "0.1" }
 fake-simd = { version = "0.1", default-features = false }
 filecheck = { version = "0.4", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 fnv = { version = "1", default-features = false }
-futures = { version = "0.1", features = ["use_std", "with-deprecated"] }
-futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["alloc", "futures-sink-preview", "sink", "std"] }
-futures-core-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
-futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
+futures = { version = "0.1" }
+futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["sink", "std"] }
+futures-core-preview = { version = "0.3.0-alpha.19" }
+futures-cpupool = { version = "0.1" }
 futures-io-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["std"] }
-futures-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "compat", "io-compat", "std"] }
-futures-sink-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
-futures-util-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "channel", "compat", "futures-channel-preview", "futures-io-preview", "futures-join-macro-preview", "futures-select-macro-preview", "futures-sink-preview", "futures_01", "io", "io-compat", "join-macro", "memchr", "proc-macro-hack", "proc-macro-nested", "select-macro", "sink", "slab", "std", "tokio-io"] }
+futures-preview = { version = "0.3.0-alpha.19", features = ["async-await", "io-compat"] }
+futures-sink-preview = { version = "0.3.0-alpha.19" }
+futures-util-preview = { version = "0.3.0-alpha.19", features = ["channel", "io-compat", "join-macro", "select-macro", "sink"] }
 generic-array = { version = "0.12", default-features = false }
 get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["bytes", "prost", "prost-codec", "protobuf", "protobuf-codec"] }
+grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["prost-codec", "protobuf-codec"] }
 grpcio-sys = { version = "0.5.0-alpha.4" }
 h2 = { version = "0.1", default-features = false }
 hex = { version = "0.3", default-features = false }
@@ -152,21 +152,21 @@ hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
 http = { version = "0.1", default-features = false }
 http-body = { version = "0.1", default-features = false }
-httparse = { version = "1", features = ["std"] }
+httparse = { version = "1" }
 humantime = { version = "1", default-features = false }
-hyper = { version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
-hyper-rustls = { version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
+hyper = { version = "0.12" }
+hyper-rustls = { version = "0.17" }
 idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools = { version = "0.8", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
+itertools = { version = "0.8" }
+itoa = { version = "0.4" }
 jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
-jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 keccak = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-libc = { version = "0.2", features = ["std"] }
+lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
+libc = { version = "0.2" }
 librocksdb_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
 libtitan_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
@@ -178,29 +178,29 @@ lru-cache = { version = "0.1", default-features = false }
 lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
 matches = { version = "0.1", default-features = false }
 md5 = { version = "0.6", default-features = false }
-memchr = { version = "2", features = ["libc", "use_std"] }
+memchr = { version = "2", features = ["libc"] }
 memoffset = { version = "0.5", default-features = false }
-memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
+memsec = { version = "0.5" }
 mime = { version = "0.3", default-features = false }
-mime_guess = { version = "2", features = ["rev-mappings"] }
+mime_guess = { version = "2" }
 miniz_oxide = { version = "0.3", default-features = false }
-mio = { version = "0.6", features = ["with-deprecated"] }
+mio = { version = "0.6" }
 mirai-annotations = { version = "1", default-features = false }
-net2 = { version = "0.2", features = ["duration"] }
+net2 = { version = "0.2" }
 nibble_vec = { version = "0.0.4", default-features = false }
 nodrop = { version = "0.1", default-features = false }
 nohash-hasher = { version = "0.1", default-features = false }
-num = { version = "0.2", features = ["num-bigint", "std"] }
+num = { version = "0.2" }
 num-bigint = { version = "0.2", default-features = false, features = ["std"] }
 num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-integer = { version = "0.1", default-features = false, features = ["std"] }
 num-iter = { version = "0.1", default-features = false, features = ["std"] }
-num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
-num-traits = { version = "0.2", features = ["std"] }
+num-rational = { version = "0.2", default-features = false, features = ["bigint", "std"] }
+num-traits = { version = "0.2" }
 num_cpus = { version = "1", default-features = false }
-num_enum = { version = "0.4", features = ["std"] }
+num_enum = { version = "0.4" }
 numtoa = { version = "0.1", default-features = false, features = ["std"] }
-once_cell = { version = "0.1", features = ["parking_lot"] }
+once_cell = { version = "0.1" }
 opaque-debug = { version = "0.2", default-features = false }
 ordermap = { version = "0.3", default-features = false }
 owning_ref-468e82937335b1c9 = { package = "owning_ref", version = "0.3", default-features = false }
@@ -208,9 +208,9 @@ owning_ref-9fbad63c4bcf4a8f = { package = "owning_ref", version = "0.4", default
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.5", default-features = false }
 parity-multihash = { version = "0.1", default-features = false }
-parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4", features = ["owning_ref"] }
-parking_lot-3b31131e45eafb45 = { package = "parking_lot", version = "0.6", features = ["owning_ref"] }
-parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7", features = ["owning_ref"] }
+parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4" }
+parking_lot-3b31131e45eafb45 = { package = "parking_lot", version = "0.6" }
+parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7" }
 parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
 parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-468e82937335b1c9 = { package = "parking_lot_core", version = "0.3", default-features = false }
@@ -218,29 +218,29 @@ parking_lot_core-9fbad63c4bcf4a8f = { package = "parking_lot_core", version = "0
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
 percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
-petgraph = { version = "0.4", features = ["graphmap", "ordermap", "stable_graph"] }
+petgraph = { version = "0.4" }
 pin-project = { version = "0.4", default-features = false }
 pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 proc-macro-nested = { version = "0.1", default-features = false }
 prometheus = { version = "0.7", default-features = false }
-proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
-prost = { version = "0.5", features = ["prost-derive"] }
+proptest = { version = "0.9" }
+prost = { version = "0.5" }
 protobuf = { version = "2", default-features = false }
 publicsuffix = { version = "1", default-features = false }
 quick-error-c65f7effa3be6d31 = { package = "quick-error", version = "0.1", default-features = false }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
 rand-468e82937335b1c9 = { package = "rand", version = "0.3", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
-rand04_compat = { version = "0.1", features = ["std"] }
+rand04_compat = { version = "0.1" }
 rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
@@ -251,19 +251,19 @@ rand_xorshift = { version = "0.1", default-features = false }
 rand_xoshiro = { version = "0.3", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex = { version = "1" }
 regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6" }
 remove_dir_all = { version = "0.5", default-features = false }
-rental = { version = "0.5", features = ["std"] }
-reqwest = { version = "0.9", default-features = false, features = ["hyper-rustls", "rustls", "rustls-tls", "tls", "tokio-rustls", "webpki-roots"] }
+rental = { version = "0.5" }
+reqwest = { version = "0.9", default-features = false, features = ["rustls-tls"] }
 retry = { version = "0.5", default-features = false }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
-ripemd160 = { version = "0.8", features = ["std"] }
+ring = { version = "0.16", features = ["std"] }
+ripemd160 = { version = "0.8" }
 rmp = { version = "0.8", default-features = false }
 rmp-serde = { version = "0.13", default-features = false }
 rocksdb = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
-rusoto_core = { version = "0.41", default-features = false, features = ["hyper-rustls", "rustls"] }
+rusoto_core = { version = "0.41", default-features = false, features = ["rustls"] }
 rusoto_credential = { version = "0.41", default-features = false }
 rusoto_ec2 = { version = "0.41", default-features = false, features = ["rustls"] }
 rusoto_ecr = { version = "0.41", default-features = false, features = ["rustls"] }
@@ -271,43 +271,43 @@ rusoto_ecs = { version = "0.41", default-features = false, features = ["rustls"]
 rusoto_kinesis = { version = "0.41", default-features = false, features = ["rustls"] }
 rusoto_logs = { version = "0.41", default-features = false, features = ["rustls"] }
 rust-crypto = { version = "0.2", default-features = false }
-rust_decimal = { version = "1", features = ["serde"] }
+rust_decimal = { version = "1" }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", default-features = false }
-rustyline = { version = "5", features = ["dirs", "with-dirs"] }
+rustyline = { version = "5" }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard-468e82937335b1c9 = { package = "scopeguard", version = "0.3", default-features = false }
 scopeguard-dff4ba8e3ae991db = { package = "scopeguard", version = "1", default-features = false }
 sct = { version = "0.6", default-features = false }
-serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1" }
 serde_urlencoded = { version = "0.5", default-features = false }
 sha-1 = { version = "0.8", default-features = false }
-sha2 = { version = "0.8", features = ["std"] }
-sha3 = { version = "0.8", features = ["std"] }
+sha2 = { version = "0.8" }
+sha3 = { version = "0.8" }
 shlex = { version = "0.1", default-features = false }
 signal-hook = { version = "0.1", default-features = false }
 signal-hook-registry = { version = "1", default-features = false }
 siphasher = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
-slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
+slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug"] }
 slog-async = { version = "2" }
-slog-envlogger = { version = "2", features = ["regex"] }
+slog-envlogger = { version = "2" }
 slog-scope = { version = "4", default-features = false }
 slog-stdlog = { version = "4", default-features = false }
 slog-term = { version = "2", default-features = false }
-smallvec = { version = "0.6", features = ["std"] }
+smallvec = { version = "0.6" }
 snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
 spin = { version = "0.5", default-features = false }
-stable_deref_trait = { version = "1", features = ["std"] }
+stable_deref_trait = { version = "1" }
 statistical = { version = "1", default-features = false }
 stats_alloc = { version = "0.1" }
-string = { version = "0.2", features = ["bytes"] }
+string = { version = "0.2" }
 strsim = { version = "0.8", default-features = false }
 structopt = { version = "0.3" }
 subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
-subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2" }
 take_mut = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
 term = { version = "0.5" }
@@ -319,39 +319,39 @@ thread_local = { version = "0.3", default-features = false }
 threadpool = { version = "1", default-features = false }
 threshold_crypto = { version = "0.3", default-features = false }
 time = { version = "0.1", default-features = false }
-tiny-keccak = { version = "1", features = ["keccak"] }
+tiny-keccak = { version = "1" }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
-tokio-1048d4db57848387 = { package = "tokio", version = "0.2.0-alpha.6", features = ["bytes", "codec", "fs", "io", "macros", "net", "num_cpus", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-executor", "tokio-fs", "tokio-io", "tokio-macros", "tokio-net", "tokio-sync", "tokio-timer", "tracing-core", "udp", "uds"] }
-tokio-buf = { version = "0.1", features = ["either", "util"] }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
+tokio-1048d4db57848387 = { package = "tokio", version = "0.2.0-alpha.6" }
+tokio-buf = { version = "0.1" }
 tokio-codec-c65f7effa3be6d31 = { package = "tokio-codec", version = "0.1", default-features = false }
 tokio-codec-1048d4db57848387 = { package = "tokio-codec", version = "0.2.0-alpha.6", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor-c65f7effa3be6d31 = { package = "tokio-executor", version = "0.1", default-features = false }
-tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "crossbeam-utils", "current-thread", "futures-core-preview", "lazy_static", "num_cpus", "slab", "threadpool", "tokio-sync", "tracing"] }
+tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "current-thread", "threadpool", "tracing"] }
 tokio-fs-c65f7effa3be6d31 = { package = "tokio-fs", version = "0.1", default-features = false }
 tokio-fs-1048d4db57848387 = { package = "tokio-fs", version = "0.2.0-alpha.6", default-features = false }
 tokio-io-c65f7effa3be6d31 = { package = "tokio-io", version = "0.1", default-features = false }
-tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["memchr", "pin-project", "util"] }
-tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "bytes", "futures-sink-preview", "iovec", "libc", "mio-uds", "tcp", "tracing", "udp", "uds"] }
+tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["util"] }
+tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "tcp", "tracing", "udp", "uds"] }
 tokio-process = { version = "0.2", default-features = false }
 tokio-reactor = { version = "0.1", default-features = false }
 tokio-retry = { version = "0.2", default-features = false }
 tokio-rustls = { version = "0.10", default-features = false }
 tokio-sync-c65f7effa3be6d31 = { package = "tokio-sync", version = "0.1", default-features = false }
-tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "futures-sink-preview"] }
+tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits"] }
 tokio-tcp = { version = "0.1", default-features = false }
 tokio-threadpool = { version = "0.1", default-features = false }
 tokio-timer-6f8ce4dd05d13bba = { package = "tokio-timer", version = "0.2", default-features = false }
 tokio-timer-411ef6e417c0d908 = { package = "tokio-timer", version = "0.3.0-alpha.6", default-features = false, features = ["async-traits"] }
 tokio-udp = { version = "0.1", default-features = false }
 toml = { version = "0.5" }
-tracing = { version = "0.1", features = ["log", "std"] }
-tracing-core = { version = "0.1", features = ["std"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-core = { version = "0.1" }
 try-lock = { version = "0.2", default-features = false }
 try_from = { version = "0.3", default-features = false }
 ttl_cache = { version = "0.4" }
-typed-arena = { version = "1", features = ["std"] }
+typed-arena = { version = "1" }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
 unicode-bidi = { version = "0.3" }
@@ -361,39 +361,39 @@ unsigned-varint = { version = "0.2", default-features = false }
 untrusted = { version = "0.7", default-features = false }
 url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
 url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
-uuid = { version = "0.7", features = ["rand", "std", "v4"] }
+uuid = { version = "0.7", features = ["v4"] }
 vec_map = { version = "0.8", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.2", default-features = false }
-webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
+webpki = { version = "0.21" }
 webpki-roots = { version = "0.17", default-features = false }
 x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
-x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
+x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5" }
 xml-rs = { version = "0.8", default-features = false }
 yamux = { version = "0.2", default-features = false }
-zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
+zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git" }
 
 [build-dependencies]
-aho-corasick = { version = "0.7", features = ["std"] }
-backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
+aho-corasick = { version = "0.7" }
+backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false }
 bindgen = { version = "0.51", default-features = false }
 bitflags = { version = "1" }
-build_const = { version = "0.2", features = ["std"] }
-byteorder = { version = "1", features = ["i128", "std"] }
+build_const = { version = "0.2" }
+byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "0.4", default-features = false, features = ["either"] }
-cc = { version = "1", default-features = false, features = ["jobserver", "num_cpus", "parallel"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
 cexpr = { version = "0.3", default-features = false }
 cfg-if = { version = "0.1", default-features = false }
-clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
+clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "runtime"] }
 clear_on_drop = { version = "0.2", default-features = false }
 cmake = { version = "0.1", default-features = false }
 derivative = { version = "1", default-features = false, features = ["use_core"] }
-derive-new = { version = "0.5", features = ["std"] }
+derive-new = { version = "0.5" }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-either = { version = "1", features = ["use_std"] }
-failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
+either = { version = "1" }
+failure = { version = "0.1" }
 failure_derive = { version = "0.1", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
 fs_extra = { version = "1", default-features = false }
@@ -403,47 +403,47 @@ gcc = { version = "0.3", default-features = false }
 generic-array = { version = "0.12", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
-grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost", "prost-build", "prost-codec", "prost-types"] }
+grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
 heck = { version = "0.3", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools = { version = "0.8", features = ["use_std"] }
+itertools = { version = "0.8" }
 jobserver = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-libc = { version = "0.2", features = ["std"] }
+lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
+libc = { version = "0.2" }
 libloading = { version = "0.5", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["libc", "use_std"] }
+memchr = { version = "2", features = ["libc"] }
 multimap = { version = "0.4", default-features = false }
-nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
+nom = { version = "4", features = ["verbose-errors"] }
 num-derive = { version = "0.2", default-features = false }
 num_cpus = { version = "1", default-features = false }
 num_enum_derive = { version = "0.4", default-features = false, features = ["std"] }
 ordermap = { version = "0.3", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
-petgraph = { version = "0.4", features = ["graphmap", "ordermap", "stable_graph"] }
+petgraph = { version = "0.4" }
 pin-project-internal = { version = "0.4", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
 proc-macro-crate = { version = "0.1", default-features = false }
 proc-macro-error = { version = "0.2", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
+proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
+proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1" }
 proc-quote = { version = "0.2", default-features = false }
 proc-quote-impl = { version = "0.2", default-features = false }
 proptest-derive = { version = "0.1", default-features = false }
-prost = { version = "0.5", features = ["prost-derive"] }
+prost = { version = "0.5" }
 prost-build = { version = "0.5", default-features = false }
 prost-derive = { version = "0.5", default-features = false }
 prost-types = { version = "0.5", default-features = false }
 protobuf = { version = "2", default-features = false }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
+quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
+quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
+regex = { version = "1" }
+regex-syntax = { version = "0.6" }
 remove_dir_all = { version = "0.5", default-features = false }
 rental-impl = { version = "0.5", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
@@ -452,14 +452,14 @@ rustc_version = { version = "0.2", default-features = false }
 same-file = { version = "1", default-features = false }
 semver = { version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
-serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_derive = { version = "1" }
 shlex = { version = "0.1", default-features = false }
 spin = { version = "0.5", default-features = false }
 structopt-derive = { version = "0.3", default-features = false }
-subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2" }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "fold", "full", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full", "visit", "visit-mut"] }
 synstructure = { version = "0.10", default-features = false }
 tempfile = { version = "3", default-features = false }
 thread_local = { version = "0.3", default-features = false }

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['x86_64-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'num-derive'
@@ -43,14 +43,14 @@ async-stream = { version = "0.2", default-features = false }
 atty = { version = "0.2", default-features = false }
 backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false, features = ["backtrace-sys"] }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
+base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12" }
 base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
 base64-a6292c17cd707f01 = { package = "base64", version = "0.11" }
-base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12" }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 bincode = { version = "1", default-features = false }
 bit-set = { version = "0.5" }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
 bitvec = { version = "0.17" }
 blake2 = { version = "0.8", default-features = false }
@@ -114,8 +114,8 @@ flate2 = { version = "1" }
 fnv = { version = "1", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-468e82937335b1c9 = { package = "futures", version = "0.3" }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-cpupool = { version = "0.1" }
@@ -130,30 +130,30 @@ get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
 goldenfile = { version = "1", default-features = false }
-h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 headers = { version = "0.3", default-features = false }
 headers-core = { version = "0.2", default-features = false }
 hex = { version = "0.4" }
 hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
-http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
-http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
 http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 httparse = { version = "1" }
 humantime = { version = "1", default-features = false }
-hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13" }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-rustls-9067fe90e8c1f593 = { package = "hyper-rustls", version = "0.17" }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 include_dir = { version = "0.5" }
 indexmap = { version = "1", default-features = false }
 input_buffer = { version = "0.3", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
@@ -174,8 +174,8 @@ md5 = { version = "0.7" }
 memchr = { version = "2", features = ["use_std"] }
 memoffset = { version = "0.5", default-features = false }
 memsec = { version = "0.5" }
-mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
 mime-468e82937335b1c9 = { package = "mime", version = "0.3", default-features = false }
+mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
 mime_guess-dff4ba8e3ae991db = { package = "mime_guess", version = "1", default-features = false }
 mime_guess-f595c2ba2a3f28df = { package = "mime_guess", version = "2" }
 miniz_oxide = { version = "0.3", default-features = false }
@@ -204,8 +204,8 @@ ordered-float = { version = "1" }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.7", default-features = false }
 parity-multihash = { version = "0.2", default-features = false }
-parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 paste = { version = "0.1", default-features = false }
@@ -230,10 +230,10 @@ qstring = { version = "0.7", default-features = false }
 quick-error = { version = "1", default-features = false }
 radium = { version = "0.3", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
 rand04_compat = { version = "0.1" }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
@@ -244,8 +244,8 @@ rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os = { version = "0.1", default-features = false }
-rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
@@ -298,29 +298,29 @@ statistical = { version = "1", default-features = false }
 stats_alloc = { version = "0.1" }
 string = { version = "0.2" }
 strsim = { version = "0.8", default-features = false }
-structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
 structopt-468e82937335b1c9 = { package = "structopt", version = "0.3" }
+structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
 strum = { version = "0.18", default-features = false }
 subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
 subtle-f595c2ba2a3f28df = { package = "subtle", version = "2" }
 tempfile = { version = "3", default-features = false }
-term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
 term-3b31131e45eafb45 = { package = "term", version = "0.6" }
+term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
 termcolor = { version = "1", default-features = false }
 termion = { version = "1", default-features = false }
 textwrap = { version = "0.11", default-features = false }
 thiserror = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 threshold_crypto = { version = "0.3", default-features = false }
-time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-6f8ce4dd05d13bba = { package = "time", version = "0.2" }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-macros = { version = "0.1", default-features = false }
 tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1" }
 tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["full"] }
 tokio-buf = { version = "0.1" }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-codec = { version = "0.1", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", default-features = false }
@@ -335,8 +335,8 @@ tokio-tcp = { version = "0.1", default-features = false }
 tokio-threadpool = { version = "0.1", default-features = false }
 tokio-timer = { version = "0.2", default-features = false }
 tokio-tungstenite = { version = "0.10", default-features = false }
-tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
 tokio-util-468e82937335b1c9 = { package = "tokio-util", version = "0.3", features = ["codec"] }
+tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
 toml = { version = "0.5" }
 tonic = { version = "0.1" }
 tower = { version = "0.3" }
@@ -378,14 +378,14 @@ utf-8 = { version = "0.7", default-features = false }
 vec_map = { version = "0.8", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 warp = { version = "0.2" }
 webpki = { version = "0.21" }
 webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
 webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6" }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 yamux = { version = "0.4", default-features = false }
@@ -412,15 +412,15 @@ autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-featu
 autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false, features = ["backtrace-sys"] }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
+base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12" }
 base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
 base64-a6292c17cd707f01 = { package = "base64", version = "0.11" }
-base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12" }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 bincode = { version = "1", default-features = false }
 bindgen = { version = "0.53" }
 bit-set = { version = "0.5" }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
 bitvec = { version = "0.17" }
 blake2 = { version = "0.8", default-features = false }
@@ -489,8 +489,8 @@ fnv = { version = "1", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 fs_extra = { version = "1", default-features = false }
-futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-468e82937335b1c9 = { package = "futures", version = "0.3" }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-cpupool = { version = "0.1" }
@@ -506,32 +506,32 @@ get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
 goldenfile = { version = "1", default-features = false }
-h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 headers = { version = "0.3", default-features = false }
 headers-core = { version = "0.2", default-features = false }
 heck = { version = "0.3", default-features = false }
 hex = { version = "0.4" }
 hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
-http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
-http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
 http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 httparse = { version = "1" }
 humantime = { version = "1", default-features = false }
-hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13" }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-rustls-9067fe90e8c1f593 = { package = "hyper-rustls", version = "0.17" }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 include_dir = { version = "0.5" }
 include_dir_impl = { version = "0.5", default-features = false }
 indexmap = { version = "1", default-features = false }
 input_buffer = { version = "0.3", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
 jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
@@ -554,8 +554,8 @@ md5 = { version = "0.7" }
 memchr = { version = "2", features = ["use_std"] }
 memoffset = { version = "0.5", default-features = false }
 memsec = { version = "0.5" }
-mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
 mime-468e82937335b1c9 = { package = "mime", version = "0.3", default-features = false }
+mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
 mime_guess-dff4ba8e3ae991db = { package = "mime_guess", version = "1", default-features = false }
 mime_guess-f595c2ba2a3f28df = { package = "mime_guess", version = "2" }
 miniz_oxide = { version = "0.3", default-features = false }
@@ -586,8 +586,8 @@ ordered-float = { version = "1" }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.7", default-features = false }
 parity-multihash = { version = "0.2", default-features = false }
-parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 paste = { version = "0.1", default-features = false }
@@ -628,10 +628,10 @@ quick-error = { version = "1", default-features = false }
 quote = { version = "1" }
 radium = { version = "0.3", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
 rand04_compat = { version = "0.1" }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
@@ -642,8 +642,8 @@ rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os = { version = "0.1", default-features = false }
-rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
@@ -704,8 +704,8 @@ statistical = { version = "1", default-features = false }
 stats_alloc = { version = "0.1" }
 string = { version = "0.2" }
 strsim = { version = "0.8", default-features = false }
-structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
 structopt-468e82937335b1c9 = { package = "structopt", version = "0.3" }
+structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
 structopt-derive-6f8ce4dd05d13bba = { package = "structopt-derive", version = "0.2", default-features = false }
 structopt-derive-9fbad63c4bcf4a8f = { package = "structopt-derive", version = "0.4", default-features = false }
 strum = { version = "0.18", default-features = false }
@@ -717,8 +717,8 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-trai
 syn-mid = { version = "0.5", default-features = false }
 synstructure = { version = "0.12" }
 tempfile = { version = "3", default-features = false }
-term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
 term-3b31131e45eafb45 = { package = "term", version = "0.6" }
+term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
 termcolor = { version = "1", default-features = false }
 termion = { version = "1", default-features = false }
 textwrap = { version = "0.11", default-features = false }
@@ -726,16 +726,16 @@ thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 threshold_crypto = { version = "0.3", default-features = false }
-time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-6f8ce4dd05d13bba = { package = "time", version = "0.2" }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-macros = { version = "0.1", default-features = false }
 time-macros-impl = { version = "0.1", default-features = false }
 tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1" }
 tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["full"] }
 tokio-buf = { version = "0.1" }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-codec = { version = "0.1", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", default-features = false }
@@ -751,8 +751,8 @@ tokio-tcp = { version = "0.1", default-features = false }
 tokio-threadpool = { version = "0.1", default-features = false }
 tokio-timer = { version = "0.2", default-features = false }
 tokio-tungstenite = { version = "0.10", default-features = false }
-tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
 tokio-util-468e82937335b1c9 = { package = "tokio-util", version = "0.3", features = ["codec"] }
+tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
 toml = { version = "0.5" }
 tonic = { version = "0.1" }
 tonic-build = { version = "0.1" }
@@ -786,8 +786,8 @@ unicode-bidi = { version = "0.3" }
 unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
-unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unsigned-varint = { version = "0.3", default-features = false }
 untrusted = { version = "0.7", default-features = false }
 ureq = { version = "0.11", features = ["json"] }
@@ -796,19 +796,19 @@ url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = fals
 urlencoding = { version = "1", default-features = false }
 utf-8 = { version = "0.7", default-features = false }
 vec_map = { version = "0.8", default-features = false }
-version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", default-features = false }
 version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
+version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 warp = { version = "0.2" }
 webpki = { version = "0.21" }
 webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
 webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
 which = { version = "3", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6" }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
 yamux = { version = "0.4", default-features = false }
@@ -823,8 +823,8 @@ hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20" }
 hyper-tls = { version = "0.4", default-features = false }
 kernel32-sys = { version = "0.2", default-features = false }
 mio-named-pipes = { version = "0.1", default-features = false }
-miow-6f8ce4dd05d13bba = { package = "miow", version = "0.2", default-features = false }
 miow-468e82937335b1c9 = { package = "miow", version = "0.3", default-features = false }
+miow-6f8ce4dd05d13bba = { package = "miow", version = "0.2", default-features = false }
 native-tls = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
@@ -834,8 +834,8 @@ schannel = { version = "0.1", default-features = false }
 socket2 = { version = "0.3", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
-winapi-6f8ce4dd05d13bba = { package = "winapi", version = "0.2", default-features = false }
 winapi-468e82937335b1c9 = { package = "winapi", version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi-6f8ce4dd05d13bba = { package = "winapi", version = "0.2", default-features = false }
 winapi-util = { version = "0.1", default-features = false }
 winreg = { version = "0.6", default-features = false }
 ws2_32-sys = { version = "0.2", default-features = false }
@@ -848,8 +848,8 @@ hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20" }
 hyper-tls = { version = "0.4", default-features = false }
 kernel32-sys = { version = "0.2", default-features = false }
 mio-named-pipes = { version = "0.1", default-features = false }
-miow-6f8ce4dd05d13bba = { package = "miow", version = "0.2", default-features = false }
 miow-468e82937335b1c9 = { package = "miow", version = "0.3", default-features = false }
+miow-6f8ce4dd05d13bba = { package = "miow", version = "0.2", default-features = false }
 native-tls = { version = "0.2", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
@@ -860,8 +860,8 @@ socket2 = { version = "0.3", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
-winapi-6f8ce4dd05d13bba = { package = "winapi", version = "0.2", default-features = false }
 winapi-468e82937335b1c9 = { package = "winapi", version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi-6f8ce4dd05d13bba = { package = "winapi", version = "0.2", default-features = false }
 winapi-build = { version = "0.1", default-features = false }
 winapi-util = { version = "0.1", default-features = false }
 winreg = { version = "0.6", default-features = false }

--- a/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['armv7r-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'crossbeam-deque'

--- a/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'bytecode-to-boogie'
@@ -70,13 +70,13 @@ async-stream = { version = "0.2", default-features = false }
 atty = { version = "0.2", default-features = false }
 backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
 base64-a6292c17cd707f01 = { package = "base64", version = "0.11" }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 bincode = { version = "1", default-features = false }
 bit-set = { version = "0.5" }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
 bitvec = { version = "0.10" }
 blake2 = { version = "0.8", default-features = false }
@@ -132,8 +132,8 @@ dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = fa
 dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
 dirs-sys = { version = "0.3", default-features = false }
 dtoa = { version = "0.4", default-features = false }
-ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 ed25519-dalek-64d47c1a8d1e1aed = { package = "ed25519-dalek", version = "1.0.0-pre.3" }
+ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 either = { version = "1" }
 endian-type = { version = "0.1", default-features = false }
 errno = { version = "0.2", default-features = false }
@@ -143,8 +143,8 @@ filecheck = { version = "0.4", default-features = false }
 fixedbitset = { version = "0.2", default-features = false }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 fnv = { version = "1", default-features = false }
-futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-468e82937335b1c9 = { package = "futures", version = "0.3", features = ["io-compat"] }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-cpupool = { version = "0.1" }
@@ -156,21 +156,21 @@ futures-util = { version = "0.3", features = ["channel", "io-compat", "sink"] }
 generic-array = { version = "0.12", default-features = false }
 get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 hex = { version = "0.4" }
 hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
-http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
-http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
 http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 httparse = { version = "1" }
-hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13" }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-rustls = { version = "0.17" }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
 itertools = { version = "0.8" }
@@ -217,11 +217,11 @@ owning_ref = { version = "0.3", default-features = false }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.7", default-features = false }
 parity-multihash = { version = "0.2", default-features = false }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
 parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4" }
-parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
-parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
+parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 pbkdf2 = { version = "0.3" }
 percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
@@ -237,10 +237,10 @@ prost = { version = "0.6" }
 qstring = { version = "0.7", default-features = false }
 quick-error = { version = "1", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand04_compat = { version = "0.1" }
 rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
@@ -249,10 +249,10 @@ rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-f
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
-rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
 rand_os-6f8ce4dd05d13bba = { package = "rand_os", version = "0.2", default-features = false }
-rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
 rand_xoshiro = { version = "0.3", default-features = false }
 rayon = { version = "1", default-features = false }
@@ -325,9 +325,9 @@ time = { version = "0.1", default-features = false }
 tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1" }
 tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["full"] }
 tokio-buf = { version = "0.1" }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-codec = { version = "0.1", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", default-features = false }
@@ -377,13 +377,13 @@ url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = fals
 vec_map = { version = "0.8", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 webpki = { version = "0.21" }
 webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
 webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6" }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yamux = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
@@ -406,14 +406,14 @@ atty = { version = "0.2", default-features = false }
 autocfg = { version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["serialize-serde"] }
 backtrace-sys = { version = "0.1", default-features = false }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
 base64-a6292c17cd707f01 = { package = "base64", version = "0.11" }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 bincode = { version = "1", default-features = false }
 bindgen = { version = "0.51" }
 bit-set = { version = "0.5" }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
 bitvec = { version = "0.10" }
 blake2 = { version = "0.8", default-features = false }
@@ -475,8 +475,8 @@ dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = fa
 dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
 dirs-sys = { version = "0.3", default-features = false }
 dtoa = { version = "0.4", default-features = false }
-ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 ed25519-dalek-64d47c1a8d1e1aed = { package = "ed25519-dalek", version = "1.0.0-pre.3" }
+ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 either = { version = "1" }
 endian-type = { version = "0.1", default-features = false }
 env_logger = { version = "0.6" }
@@ -489,8 +489,8 @@ fixedbitset = { version = "0.2", default-features = false }
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 fnv = { version = "1", default-features = false }
 fs_extra = { version = "1", default-features = false }
-futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-468e82937335b1c9 = { package = "futures", version = "0.3", features = ["io-compat"] }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
 futures-cpupool = { version = "0.1" }
@@ -504,23 +504,23 @@ generic-array = { version = "0.12", default-features = false }
 get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
-h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
 heck = { version = "0.3", default-features = false }
 hex = { version = "0.4" }
 hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
-http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
-http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
 http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 httparse = { version = "1" }
 humantime = { version = "1", default-features = false }
-hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13" }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12" }
 hyper-rustls = { version = "0.17" }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
 itertools = { version = "0.8" }
@@ -573,11 +573,11 @@ owning_ref = { version = "0.3", default-features = false }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.7", default-features = false }
 parity-multihash = { version = "0.2", default-features = false }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
 parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
 parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4" }
-parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
-parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
+parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 pbkdf2 = { version = "0.3" }
 peeking_take_while = { version = "0.1", default-features = false }
@@ -608,10 +608,10 @@ quick-error = { version = "1", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
 radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
 rand04_compat = { version = "0.1" }
 rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
@@ -620,10 +620,10 @@ rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-f
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
-rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
 rand_os-6f8ce4dd05d13bba = { package = "rand_os", version = "0.2", default-features = false }
-rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
 rand_xoshiro = { version = "0.3", default-features = false }
 rayon = { version = "1", default-features = false }
@@ -711,9 +711,9 @@ time = { version = "0.1", default-features = false }
 tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1" }
 tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["full"] }
 tokio-buf = { version = "0.1" }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
 tokio-codec = { version = "0.1", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor = { version = "0.1", default-features = false }
@@ -758,8 +758,8 @@ unicode-bidi = { version = "0.3" }
 unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
-unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unsigned-varint = { version = "0.3", default-features = false }
 untrusted = { version = "0.7", default-features = false }
 ureq = { version = "0.11", features = ["json"] }
@@ -769,14 +769,14 @@ vec_map = { version = "0.8", default-features = false }
 version_check = { version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
 webpki = { version = "0.21" }
 webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
 webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
 which = { version = "3", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6" }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yamux = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['riscv64gc-unknown-none-elf', 'armv7k-apple-watchos']
 # [[traversal-excludes.ids]]
 # name = 'linked-hash-map'

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['x86_64-uwp-windows-msvc', 'aarch64-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'quote'

--- a/fixtures/small/hakari/metadata1-2.toml
+++ b/fixtures/small/hakari/metadata1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['aarch64-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'regex'

--- a/fixtures/small/hakari/metadata1-3.toml
+++ b/fixtures/small/hakari/metadata1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['x86_64-pc-windows-msvc', 'i686-linux-android', 'armv7a-kmc-solid_asp3-eabi']
 # [[traversal-excludes.ids]]
 # name = 'bitflags'

--- a/fixtures/small/hakari/metadata2-2.toml
+++ b/fixtures/small/hakari/metadata2-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['i686-apple-darwin', 'riscv64gc-unknown-linux-musl']
 #
 # [traversal-excludes]
@@ -45,15 +45,15 @@
 # crates-io = true
 
 [dependencies]
-aho-corasick = { version = "0.7", features = ["std"] }
+aho-corasick = { version = "0.7" }
 dtoa = { version = "0.4", default-features = false }
 lazy_static = { version = "1", default-features = false }
 linked-hash-map = { version = "0.5", default-features = false }
-memchr = { version = "2", features = ["use_std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+memchr = { version = "2" }
+regex = { version = "1" }
 regex-syntax = { version = "0.6", default-features = false, features = ["unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 same-file = { version = "1", default-features = false }
-serde = { version = "1", features = ["std"] }
+serde = { version = "1" }
 serde_yaml = { version = "0.8", default-features = false }
 thread_local = { version = "0.3", default-features = false }
 walkdir-cd6c3afff8ff167c = { package = "walkdir", path = "/Users/fakeuser/local/testworkspace/../walkdir", default-features = false }
@@ -61,16 +61,16 @@ walkdir-f595c2ba2a3f28df = { package = "walkdir", version = "2", default-feature
 yaml-rust = { version = "0.4", default-features = false }
 
 [build-dependencies]
-aho-corasick = { version = "0.7", features = ["std"] }
+aho-corasick = { version = "0.7" }
 datatest-derive = { version = "0.4", default-features = false }
 dtoa = { version = "0.4", default-features = false }
 lazy_static = { version = "1", default-features = false }
 linked-hash-map = { version = "0.5", default-features = false }
-memchr = { version = "2", features = ["use_std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+memchr = { version = "2" }
+regex = { version = "1" }
 regex-syntax = { version = "0.6", default-features = false, features = ["unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 same-file = { version = "1", default-features = false }
-serde = { version = "1", features = ["std"] }
+serde = { version = "1" }
 serde_yaml = { version = "0.8", default-features = false }
 thread_local = { version = "0.3", default-features = false }
 unicode-xid = { version = "0.2" }

--- a/fixtures/small/hakari/metadata2-3.toml
+++ b/fixtures/small/hakari/metadata2-3.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['aarch64-uwp-windows-msvc', 'mipsel-sony-psp', 'riscv32gc-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'quote'
@@ -49,7 +49,7 @@
 [dependencies]
 datatest = { version = "0.4" }
 linked-hash-map = { version = "0.5", default-features = false }
-serde = { version = "1", features = ["std"] }
+serde = { version = "1" }
 walkdir-cd6c3afff8ff167c = { package = "walkdir", path = "/Users/fakeuser/local/testworkspace/../walkdir", default-features = false }
 walkdir-f595c2ba2a3f28df = { package = "walkdir", version = "2", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
@@ -57,8 +57,8 @@ yaml-rust = { version = "0.4", default-features = false }
 [build-dependencies]
 ctor = { version = "0.1", default-features = false }
 datatest-derive = { version = "0.4", default-features = false }
-proc-macro2 = { version = "1", features = ["proc-macro"] }
-syn = { version = "1", features = ["clone-impls", "derive", "fold", "full", "parsing", "printing", "proc-macro", "quote"] }
+proc-macro2 = { version = "1" }
+syn = { version = "1", features = ["fold", "full"] }
 unicode-xid = { version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 

--- a/fixtures/small/hakari/metadata_alternate_registries-0.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['armv7r-none-eabi', 'powerpc64le-unknown-linux-musl', 'powerpc64-unknown-linux-musl']
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_alternate_registries-3.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['powerpc64-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'proc-macro2'

--- a/fixtures/small/hakari/metadata_build_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'testcrate'

--- a/fixtures/small/hakari/metadata_build_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_build_targets1-3.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['thumbv7m-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'

--- a/fixtures/small/hakari/metadata_builddep-0.toml
+++ b/fixtures/small/hakari/metadata_builddep-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['powerpc-unknown-openbsd', 'mipsisa64r6el-unknown-linux-gnuabi64', 'i686-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['wasm32-unknown-unknown', 'armv5te-none-eabi', 'riscv64gc-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_builddep-2.toml
+++ b/fixtures/small/hakari/metadata_builddep-2.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'builddep'

--- a/fixtures/small/hakari/metadata_cycle1-0.toml
+++ b/fixtures/small/hakari/metadata_cycle1-0.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['thumbv8m.main-none-eabihf', 'x86_64-apple-ios-macabi']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'

--- a/fixtures/small/hakari/metadata_cycle1-2.toml
+++ b/fixtures/small/hakari/metadata_cycle1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_cycle1-3.toml
+++ b/fixtures/small/hakari/metadata_cycle1-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['aarch64-apple-ios-macabi', 'x86_64-pc-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'

--- a/fixtures/small/hakari/metadata_cycle2-3.toml
+++ b/fixtures/small/hakari/metadata_cycle2-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'

--- a/fixtures/small/hakari/metadata_cycle_features-1.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['x86_64-apple-watchos-sim', 'mips-unknown-linux-uclibc']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'

--- a/fixtures/small/hakari/metadata_dups-0.toml
+++ b/fixtures/small/hakari/metadata_dups-0.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['mipsisa32r6el-unknown-linux-gnu', 'i686-unknown-uefi']
 # [[traversal-excludes.ids]]
 # name = 'bytes'

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['armv4t-unknown-linux-gnueabi']
 # [[traversal-excludes.ids]]
 # name = 'bytes'

--- a/fixtures/small/hakari/metadata_proc_macro1-0.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['aarch64-wrs-vxworks', 'x86_64-wrs-vxworks', 'powerpc-wrs-vxworks-spe']
 #
 # [traversal-excludes]

--- a/fixtures/small/hakari/metadata_proc_macro1-2.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # platforms = ['mipsel-unknown-none', 'powerpc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'build-user'

--- a/fixtures/small/hakari/metadata_proc_macro1-3.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-3.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['arm64_32-apple-watchos', 'armv7-unknown-netbsd-eabihf', 'aarch64-unknown-redox']
 # [[traversal-excludes.ids]]
 # name = 'build-user'

--- a/fixtures/small/hakari/metadata_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_targets1-0.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['aarch64-apple-ios-macabi', 'armv7-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'

--- a/fixtures/small/hakari/metadata_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_targets1-1.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = ['armv7a-kmc-solid_asp3-eabi', 'mips64el-unknown-linux-muslabi64', 'i686-pc-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'serde'

--- a/fixtures/small/hakari/metadata_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_targets1-2.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['i686-pc-windows-msvc', 'armv4t-none-eabi', 'powerpc-wrs-vxworks-spe']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'
@@ -22,8 +22,8 @@
 # crates-io = true
 
 [dependencies]
-bytes = { version = "0.5", features = ["serde", "std"] }
-serde = { version = "1", features = ["std"] }
+bytes = { version = "0.5", features = ["serde"] }
+serde = { version = "1" }
 
 [target.i686-pc-windows-msvc.dependencies]
 lazy_static = { version = "0.1", default-features = false }

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
@@ -5,7 +5,7 @@
 # resolver = 'install'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
@@ -5,7 +5,7 @@
 # resolver = '1'
 # unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '3'
+# dep-format-version = '4'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
@@ -5,7 +5,7 @@
 # resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '3'
 # platforms = ['sparc64-unknown-netbsd', 'riscv32imc-esp-espidf', 'powerpc64le-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'

--- a/tools/cargo-hakari/CHANGELOG.md
+++ b/tools/cargo-hakari/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.9.22] - 2023-01-18
+
+### Added
+
+Introduced a new `dep-format-version`, version 4, with a change to always sort outputs alphabetically. This
+matches the order produced by [cargo-sort](https://crates.io/crates/cargo-sort) ([#65]).
+
+[#65]: https://github.com/guppy-rs/guppy/issues/65
+
 ## [0.9.21] - 2023-01-14
 
 ### Fixed
@@ -190,6 +199,7 @@ This was tagged, but never released due to
 
 Initial release.
 
+[0.9.22]: https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.22
 [0.9.21]: https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.21
 [0.9.20]: https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.20
 [0.9.19]: https://github.com/guppy-rs/guppy/releases/tag/cargo-hakari-0.9.19

--- a/tools/cargo-hakari/src/command.rs
+++ b/tools/cargo-hakari/src/command.rs
@@ -317,12 +317,12 @@ impl CommandWithBuilder {
                     write_to_cargo_toml(existing_toml, &toml_out, diff, output.clone())?;
                 if hakari.builder().dep_format_version() < DepFormatVersion::latest() {
                     info!(
-                        "new hakari format version available: {} (current: {})\n\
-                        (add or update `dep-format-version = \"3\"` in {}, then run \
+                        "new hakari format version available: {latest} (current: {})\n\
+                        (add or update `dep-format-version = \"{latest}\"` in {}, then run \
                         `cargo hakari generate && cargo hakari manage-deps`)",
-                        DepFormatVersion::latest(),
                         hakari.builder().dep_format_version(),
                         "hakari.toml".style(output.styles.config_path),
+                        latest = DepFormatVersion::latest(),
                     );
                 }
 

--- a/tools/cargo-hakari/src/docs/config.rs
+++ b/tools/cargo-hakari/src/docs/config.rs
@@ -50,6 +50,8 @@
 //!   `cargo hakari init` set it to "2".
 //! - starting `cargo hakari 0.9.18`, `.config/hakari.toml` files created by
 //!   `cargo hakari init` set it to "3".
+//! - starting `cargo hakari 0.9.22`, `.config/hakari.toml` files created by
+//!   `cargo hakari init` set it to "4".
 //!
 //! In general, it is best to be on the latest version.
 //!

--- a/tools/hakari/src/cli_ops/manage_deps.rs
+++ b/tools/hakari/src/cli_ops/manage_deps.rs
@@ -37,7 +37,7 @@ impl<'g> HakariBuilder<'g> {
                     (Some(_), false) => Some(false),
                     (Some(link), true) => match self.dep_format_version {
                         DepFormatVersion::V1 => None,
-                        DepFormatVersion::V2 | DepFormatVersion::V3 => {
+                        DepFormatVersion::V2 | DepFormatVersion::V3 | DepFormatVersion::V4 => {
                             needs_update_v2(hakari_package, link).then_some(true)
                         }
                     },

--- a/tools/hakari/src/hakari.rs
+++ b/tools/hakari/src/hakari.rs
@@ -524,13 +524,21 @@ pub enum DepFormatVersion {
     /// Elides build metadata. This was introduced in `cargo hakari 0.9.18`.
     #[cfg_attr(feature = "cli-support", serde(rename = "3"))]
     V3,
+
+    /// Sorts dependency names alphabetically. This was introduced in `cargo hakari 0.9.22`.
+    ///
+    /// (Dependency names were usually produced in sorted order before V4, but there are
+    /// some edge cases where they weren't: see [issue
+    /// #65](https://github.com/guppy-rs/guppy/issues/65).
+    #[cfg_attr(feature = "cli-support", serde(rename = "4"))]
+    V4,
 }
 
 impl DepFormatVersion {
     /// Returns the highest format version supported by this version of `cargo hakari`.
     #[inline]
     pub fn latest() -> Self {
-        DepFormatVersion::V3
+        DepFormatVersion::V4
     }
 }
 
@@ -546,6 +554,7 @@ impl fmt::Display for DepFormatVersion {
             DepFormatVersion::V1 => write!(f, "1"),
             DepFormatVersion::V2 => write!(f, "2"),
             DepFormatVersion::V3 => write!(f, "3"),
+            DepFormatVersion::V4 => write!(f, "4"),
         }
     }
 }

--- a/tools/hakari/src/toml_out.rs
+++ b/tools/hakari/src/toml_out.rs
@@ -461,6 +461,10 @@ pub(crate) fn write_toml(
 
             dep_table.insert(name.as_ref(), Item::Value(Value::InlineTable(itable)));
         }
+
+        if dep_format >= DepFormatVersion::V4 {
+            dep_table.sort_values();
+        }
     }
 
     // Match formatting with older versions of hakari: if the document is non-empty, print out a


### PR DESCRIPTION
In some cases, we weren't producing output that was exactly sorted.

Fixes https://github.com/guppy-rs/guppy/issues/65.