### PR TITLE
hakari: fix canonicalized paths on windows

### DIFF
--- a/tools/hakari/src/cli_ops/workspace_ops.rs
+++ b/tools/hakari/src/cli_ops/workspace_ops.rs
@@ -391,8 +391,12 @@ fn canonical_rel_path(path: &Utf8Path, base: &Utf8Path) -> Result<Utf8PathBuf, A
         .map_err(|err| ApplyError::io("error reading path", &abs_path, err))?;
     let canonical_path = Utf8PathBuf::try_from(canonical_path)
         .map_err(|_| ApplyError::misc("canonical path is invalid UTF-8", &abs_path))?;
+    let canonical_base = base.canonicalize()
+        .map_err(|err| ApplyError::io("error reading path", &base, err))?;
+    let canonical_base = Utf8PathBuf::try_from(canonical_base)
+        .map_err(|_| ApplyError::misc("canonical base path is invalid UTF-8", &base))?;
     canonical_path
-        .strip_prefix(base)
+        .strip_prefix(canonical_base)
         .map_err(|_| {
             // This can happen under some symlink scenarios.
             ApplyError::misc(


### PR DESCRIPTION
Encountered error while running on windows `cargo hakari init my-workspace-hack`:
`G:\proj\myrust\my-workspace-hack, canonical path is not within base path G:\proj\myrust`

which isn't helpful, adding custom print for canonical versions was helpful:
`canonical_path=\\?\G:\proj\myrust\my-workspace-hack, base=G:\proj\myrust`

Solution is canonicalize `base` path too. Doing so on every call of `canonical_rel_path` isn't optimal, probably it's better `base` be canonicalized somewhere before.