### PR TITLE
[guppy] handle binary-only dependencies

### DIFF
--- a/fixtures/large/hakari/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-0.toml
@@ -1,0 +1,1248 @@
+# This file is @generated. To regenerate, run:
+#    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
+
+### BEGIN HAKARI SECTION
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = true
+# dep-format-version = '4'
+# workspace-hack-line-style = 'version-only'
+# platforms = ['armv6k-nintendo-3ds', 's390x-unknown-linux-musl']
+# [[traversal-excludes.ids]]
+# name = 'string_cache_codegen'
+# version = '0.5.2'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'cargo-platform'
+# version = '0.1.3'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'gcd'
+# version = '2.3.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'semver'
+# version = '1.0.18'
+# crates-io = true
+
+[dependencies]
+acpi = { version = "4", default-features = false }
+addr2line = { version = "0.20" }
+adler = { version = "1", default-features = false }
+adler32 = { version = "1" }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1" }
+async-channel = { version = "1", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-std = { version = "1", features = ["unstable"] }
+atty = { version = "0.2", default-features = false }
+axum = { version = "0.6", features = ["ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+backtrace-ext = { version = "0.2", default-features = false }
+bare-metal = { version = "1", default-features = false }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
+bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
+bincode = { version = "1", default-features = false }
+bit-set = { version = "0.5" }
+bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit_field = { version = "0.10", default-features = false }
+bitfield = { version = "0.14", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
+bootloader_api = { version = "0.11", default-features = false }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+byteorder = { version = "1" }
+bytes = { version = "1" }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
+cobs = { version = "0.2" }
+color_quant = { version = "1", default-features = false }
+colorchoice = { version = "1", default-features = false }
+concurrent-queue = { version = "2" }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
+console-subscriber = { version = "0.1" }
+console_error_panic_hook = { version = "0.1", default-features = false }
+const_format = { version = "0.2" }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+crc32fast = { version = "1" }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+crossbeam-channel = { version = "0.5" }
+crossbeam-deque = { version = "0.8" }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8" }
+d1-pac = { version = "0.0.31", default-features = false }
+deflate = { version = "0.8", default-features = false }
+defmt = { version = "0.3", default-features = false }
+dirs = { version = "4", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+either = { version = "1" }
+embedded-dma = { version = "0.2", default-features = false }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
+embedded-graphics-simulator = { version = "0.3" }
+embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
+embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+embedded-io = { version = "0.5", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-alloc = { version = "0.3", default-features = false }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-println = { version = "0.5", features = ["esp32c3"] }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
+esp32c3 = { version = "0.16", features = ["critical-section"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
+event-listener = { version = "2", default-features = false }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
+flate2 = { version = "1" }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
+fugit = { version = "0.3", default-features = false }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+gif = { version = "0.11" }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+gloo = { version = "0.9", features = ["futures"] }
+gloo-console = { version = "0.2", default-features = false }
+gloo-dialogs = { version = "0.1", default-features = false }
+gloo-events = { version = "0.1", default-features = false }
+gloo-file = { version = "0.2", features = ["futures"] }
+gloo-history = { version = "0.1" }
+gloo-net = { version = "0.3" }
+gloo-render = { version = "0.1", default-features = false }
+gloo-storage = { version = "0.2", default-features = false }
+gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
+gloo-worker = { version = "0.3", features = ["futures"] }
+h2 = { version = "0.3", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["serde"] }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+httparse = { version = "1" }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
+hyper = { version = "0.14", features = ["full"] }
+hyper-timeout = { version = "0.4", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+image = { version = "0.23" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1" }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
+js-sys = { version = "0.3", default-features = false }
+kv-log-macro = { version = "1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2" }
+libm = { version = "0.2" }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+matchers = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
+memchr = { version = "2", features = ["use_std"] }
+memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
+miette = { version = "5", features = ["fancy"] }
+mime = { version = "0.3", default-features = false }
+minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
+miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
+modality-ingest-client = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
+nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
+nom = { version = "7" }
+nu-ansi-term = { version = "0.46", default-features = false }
+num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1", features = ["i128"] }
+num-iter = { version = "0.1" }
+num-rational = { version = "0.3", default-features = false }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+num_cpus = { version = "1", default-features = false }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1" }
+os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
+overload = { version = "0.1", default-features = false }
+ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
+pin-project = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pinned = { version = "0.1", default-features = false }
+png = { version = "0.16" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
+postcard-cobs = { version = "0.1.5-pre", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+profont = { version = "0.6", default-features = false }
+proptest = { version = "1" }
+prost = { version = "0.11" }
+prost-types = { version = "0.11" }
+quick-error = { version = "1", default-features = false }
+r0 = { version = "1", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+regex = { version = "1" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.11", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
+ryu = { version = "1", default-features = false }
+scoped_threadpool = { version = "0.1", default-features = false }
+scopeguard = { version = "1" }
+sdl2 = { version = "0.32" }
+sdl2-sys = { version = "0.32" }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde-wasm-bindgen = { version = "0.5", default-features = false }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
+sharded-slab = { version = "0.1", default-features = false }
+slab = { version = "0.4" }
+smallvec = { version = "1", default-features = false }
+smawk = { version = "0.3", default-features = false }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
+stable_deref_trait = { version = "1" }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
+sync_wrapper = { version = "0.1", default-features = false }
+tempfile = { version = "3", default-features = false }
+termcolor = { version = "1", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+thiserror = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+tiff = { version = "0.6", default-features = false }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+tinyvec = { version = "1", features = ["alloc"] }
+tinyvec_macros = { version = "0.1", default-features = false }
+tokio = { version = "1", features = ["full", "tracing"] }
+tokio-io-timeout = { version = "1", default-features = false }
+tokio-native-tls = { version = "0.3", default-features = false }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tonic = { version = "0.9" }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-wasm = { version = "0.2", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+unarray = { version = "0.1", default-features = false }
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
+unicode-linebreak = { version = "0.1", default-features = false }
+unicode-normalization = { version = "0.1" }
+unicode-width = { version = "0.1" }
+url = { version = "2" }
+utf8parse = { version = "0.2" }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+value-bag = { version = "1", default-features = false }
+vcell = { version = "0.1", default-features = false }
+void = { version = "1", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+wait-timeout = { version = "0.2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
+weezl = { version = "0.1" }
+winnow = { version = "0.5" }
+
+[build-dependencies]
+acpi = { version = "4", default-features = false }
+addr2line = { version = "0.20" }
+adler = { version = "1", default-features = false }
+aes = { version = "0.8", default-features = false }
+aho-corasick = { version = "1" }
+ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1" }
+arrayvec = { version = "0.5", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-process = { version = "1", default-features = false }
+async-scoped = { version = "0.7", default-features = false, features = ["use-tokio"] }
+async-trait = { version = "0.1", default-features = false }
+atomicwrites = { version = "0.4", default-features = false }
+atty = { version = "0.2", default-features = false }
+autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
+autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
+axum = { version = "0.6", features = ["ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+backtrace-ext = { version = "0.2", default-features = false }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
+base64ct = { version = "1", default-features = false }
+basic-toml = { version = "0.1", default-features = false }
+bincode = { version = "1", default-features = false }
+binread = { version = "2" }
+binread_derive = { version = "2", default-features = false }
+bit_field = { version = "0.10", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
+bitvec = { version = "1" }
+block-buffer = { version = "0.10", default-features = false }
+bootloader = { version = "0.11" }
+bootloader-boot-config = { version = "0.11", default-features = false }
+bootloader_api = { version = "0.11", default-features = false }
+bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["unicode"] }
+bumpalo = { version = "3" }
+bytecount = { version = "0.6", default-features = false }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+bytemuck_derive = { version = "1", default-features = false }
+byteorder = { version = "1" }
+bytes = { version = "1" }
+bzip2 = { version = "0.4", default-features = false }
+bzip2-sys = { version = "0.1", default-features = false }
+camino = { version = "1", default-features = false, features = ["serde1"] }
+camino-tempfile = { version = "1", default-features = false }
+cargo-binutils = { version = "0.3", default-features = false }
+cargo-espflash = { version = "2", default-features = false }
+cargo-lock = { version = "9", default-features = false }
+cargo-nextest = { version = "0.9" }
+cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
+cargo_metadata-582f2526e08bb6a0 = { package = "cargo_metadata", version = "0.14" }
+cargo_metadata-9067fe90e8c1f593 = { package = "cargo_metadata", version = "0.17" }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
+cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
+cipher = { version = "0.4", default-features = false }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+clap_complete = { version = "4" }
+clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
+clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
+cobs = { version = "0.2" }
+color-eyre = { version = "0.6", default-features = false }
+colorchoice = { version = "1", default-features = false }
+comfy-table = { version = "7" }
+config = { version = "0.13", default-features = false, features = ["toml"] }
+console = { version = "0.15" }
+const_format = { version = "0.2" }
+const_format_proc_macros = { version = "0.2" }
+constant_time_eq = { version = "0.1", default-features = false }
+convert_case = { version = "0.4", default-features = false }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"] }
+crc = { version = "3", default-features = false }
+crc-catalog = { version = "2", default-features = false }
+crc32fast = { version = "1" }
+crossbeam-channel = { version = "0.5" }
+crossbeam-utils = { version = "0.8" }
+crossterm-2f80eeee3b1b6c7e = { package = "crossterm", version = "0.26", default-features = false }
+crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
+crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+cssparser = { version = "0.27", default-features = false }
+cssparser-macros = { version = "0.6", default-features = false }
+csv = { version = "1", default-features = false }
+csv-core = { version = "0.1" }
+ctrlc = { version = "3", default-features = false, features = ["termination"] }
+cvt = { version = "0.1", default-features = false }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20" }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14" }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["suggestions"] }
+darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+data-encoding = { version = "2" }
+debug-ignore = { version = "1", default-features = false }
+defmt = { version = "0.3", default-features = false }
+defmt-macros = { version = "0.3", default-features = false }
+defmt-parser = { version = "0.3", default-features = false, features = ["unstable"] }
+deku = { version = "0.16" }
+deku_derive = { version = "0.16", default-features = false, features = ["std"] }
+derivative = { version = "2", default-features = false }
+derive_more = { version = "0.99" }
+dialoguer = { version = "0.10" }
+digest = { version = "0.10", features = ["mac", "std"] }
+directories = { version = "5", default-features = false }
+dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
+doc-comment = { version = "0.3", default-features = false }
+dotenvy = { version = "0.15", default-features = false }
+dtoa = { version = "1", default-features = false }
+dtoa-short = { version = "0.3", default-features = false }
+duct = { version = "0.13", default-features = false }
+dunce = { version = "1", default-features = false }
+edit-distance = { version = "2", default-features = false }
+either = { version = "1" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+enable-ansi-support = { version = "0.2", default-features = false }
+env_logger = { version = "0.10" }
+envy = { version = "0.4", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["interrupt"] }
+esp-idf-part = { version = "0.4" }
+espflash = { version = "2" }
+event-listener = { version = "2", default-features = false }
+eyre = { version = "0.6" }
+failure = { version = "0.1" }
+failure_derive = { version = "0.1", default-features = false }
+fallible-iterator = { version = "0.2", default-features = false, features = ["std"] }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
+fatfs = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+file-id = { version = "0.2", default-features = false }
+filetime = { version = "0.2", default-features = false }
+fixedbitset = { version = "0.4", default-features = false }
+flate2 = { version = "1" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
+fs_at = { version = "0.1" }
+fs_extra = { version = "1", default-features = false }
+funty = { version = "2", default-features = false }
+futf = { version = "0.1", default-features = false }
+future-queue = { version = "0.3", default-features = false }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-concurrency = { version = "7", default-features = false }
+futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3" }
+futures-lite = { version = "1" }
+futures-macro = { version = "0.3", default-features = false }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+fxhash = { version = "0.2", default-features = false }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+gloo-worker-macros = { version = "0.1", default-features = false }
+gpt = { version = "3", default-features = false }
+guppy = { version = "0.17", default-features = false }
+guppy-workspace-hack = { version = "0.1", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["raw"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+heck = { version = "0.4" }
+hex = { version = "0.4", features = ["serde"] }
+hmac = { version = "0.12", default-features = false, features = ["reset"] }
+home = { version = "0.5", default-features = false }
+html5ever = { version = "0.25", default-features = false }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+http-range-header = { version = "0.3", default-features = false }
+httparse = { version = "1" }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
+humantime-serde = { version = "1", default-features = false }
+hyper = { version = "0.14", features = ["full"] }
+ident_case = { version = "1", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+indent_write = { version = "2" }
+indenter = { version = "0.3" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+indicatif = { version = "0.17" }
+inout = { version = "0.1", default-features = false }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1" }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", default-features = false, features = ["use_alloc"] }
+itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11" }
+itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jobserver = { version = "0.1", default-features = false }
+just = { version = "1" }
+lazy_static = { version = "1", default-features = false }
+lexiclean = { version = "0.0.1", default-features = false }
+libc = { version = "0.2" }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+llvm-tools = { version = "0.1", default-features = false }
+local-ip-address = { version = "0.5", default-features = false }
+lock_api = { version = "0.4" }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+mac = { version = "0.1", default-features = false }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+markup5ever = { version = "0.10", default-features = false }
+matchers = { version = "0.1", default-features = false }
+matches = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
+mbrman = { version = "0.5", default-features = false }
+md5 = { version = "0.7", default-features = false, features = ["std"] }
+memchr = { version = "2", features = ["use_std"] }
+memmap2 = { version = "0.5", default-features = false }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+miette = { version = "5", features = ["fancy"] }
+miette-derive = { version = "5", default-features = false }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", default-features = false }
+minicbor-derive = { version = "0.8", default-features = false }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
+mukti-metadata = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+nested = { version = "0.1", default-features = false }
+new_debug_unreachable = { version = "1", default-features = false }
+nextest-filtering = { version = "0.5" }
+nextest-metadata = { version = "0.9", default-features = false }
+nextest-runner = { version = "0.45", default-features = false, features = ["self-update"] }
+nextest-workspace-hack = { version = "0.1", default-features = false }
+nipper = { version = "0.1", default-features = false }
+nodrop = { version = "0.1" }
+nom = { version = "7" }
+nom-tracable = { version = "0.9" }
+nom-tracable-macros = { version = "0.9", default-features = false }
+nom_locate = { version = "4" }
+normpath = { version = "1", default-features = false }
+notify = { version = "6" }
+notify-debouncer-full = { version = "0.3" }
+nu-ansi-term = { version = "0.46", default-features = false }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+num_cpus = { version = "1", default-features = false }
+number_prefix = { version = "0.4" }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1" }
+open = { version = "5", default-features = false }
+option-ext = { version = "0.2", default-features = false }
+os_pipe = { version = "1", default-features = false }
+overload = { version = "0.1", default-features = false }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+parking = { version = "2", default-features = false }
+parking_lot = { version = "0.12" }
+parking_lot_core = { version = "0.9", default-features = false }
+parse_int = { version = "0.6" }
+password-hash = { version = "0.4", default-features = false, features = ["rand_core"] }
+paste = { version = "1", default-features = false }
+pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
+pbkdf2 = { version = "0.11" }
+percent-encoding = { version = "2" }
+petgraph = { version = "0.6", default-features = false }
+phf = { version = "0.8", features = ["macros"] }
+phf_codegen = { version = "0.8", default-features = false }
+phf_generator = { version = "0.8", default-features = false }
+phf_macros = { version = "0.8", default-features = false }
+phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
+phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8" }
+pin-project = { version = "1", default-features = false }
+pin-project-internal = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard-derive = { version = "0.1", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+precomputed-hash = { version = "0.1", default-features = false }
+proc-macro-crate = { version = "1", default-features = false }
+proc-macro-error = { version = "1" }
+proc-macro-error-attr = { version = "1", default-features = false }
+proc-macro-hack = { version = "0.5", default-features = false }
+proc-macro2 = { version = "1" }
+profont = { version = "0.6", default-features = false }
+proptest-derive = { version = "0.4", default-features = false }
+prost-derive = { version = "0.11", default-features = false }
+quick-junit = { version = "0.3", default-features = false }
+quick-xml-2b5c6dc72f624058 = { package = "quick-xml", version = "0.23" }
+quick-xml-b73a96c0a5f6a7d9 = { package = "quick-xml", version = "0.29" }
+quote = { version = "1" }
+radium = { version = "0.7", default-features = false }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+recursion = { version = "0.4" }
+regex = { version = "1" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+remove_dir_all = { version = "0.8" }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls", "stream", "trust-dns"] }
+ring = { version = "0.16" }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
+riscv-rt-macros = { version = "0.2", default-features = false }
+riscv-target = { version = "0.1", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-cfg = { version = "0.4", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rustc_version = { version = "0.4", default-features = false }
+rustls = { version = "0.21" }
+rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100" }
+rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101" }
+rustversion = { version = "1", default-features = false }
+ruzstd = { version = "0.3", default-features = false }
+ryu = { version = "1", default-features = false }
+same-file = { version = "1", default-features = false }
+scopeguard = { version = "1" }
+sct = { version = "0.7", default-features = false }
+seahash = { version = "4" }
+selectors = { version = "0.22", default-features = false }
+self_update = { version = "0.37", default-features = false, features = ["archive-tar", "compression-flate2"] }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde-big-array = { version = "0.4", default-features = false }
+serde_derive = { version = "1" }
+serde_ignored = { version = "0.1", default-features = false }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_path_to_error = { version = "0.1", default-features = false }
+serde_plain = { version = "1", default-features = false }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+servo_arc = { version = "0.1", default-features = false }
+sha1 = { version = "0.10" }
+sha2 = { version = "0.10" }
+sharded-slab = { version = "0.1", default-features = false }
+shared_child = { version = "1", default-features = false }
+shell-words = { version = "1" }
+similar = { version = "2", features = ["unicode"] }
+siphasher = { version = "0.3" }
+slab = { version = "0.4" }
+slip-codec = { version = "0.3" }
+smallvec = { version = "1", default-features = false }
+smawk = { version = "0.3", default-features = false }
+smol_str = { version = "0.2", features = ["serde"] }
+snafu = { version = "0.7" }
+snafu-derive = { version = "0.7", default-features = false, features = ["rust_1_39", "rust_1_46"] }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
+stable_deref_trait = { version = "1" }
+static_assertions = { version = "1", default-features = false }
+string_cache = { version = "0.8" }
+strip-ansi-escapes = { version = "0.1", default-features = false }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
+strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
+strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
+subtle = { version = "2", default-features = false }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+sync_wrapper = { version = "0.1", default-features = false }
+synstructure = { version = "0.12" }
+tap = { version = "1", default-features = false }
+tar = { version = "0.4" }
+target = { version = "2", default-features = false }
+target-lexicon = { version = "0.12", features = ["std"] }
+target-spec = { version = "3", default-features = false, features = ["custom", "summaries"] }
+target-spec-miette = { version = "0.3", default-features = false }
+tempfile = { version = "3", default-features = false }
+tendril = { version = "0.4", default-features = false }
+term_size = { version = "0.3" }
+termcolor = { version = "1", default-features = false }
+terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
+thin-slice = { version = "0.1", default-features = false }
+thiserror = { version = "1", default-features = false }
+thiserror-impl = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "parsing"] }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+time-core = { version = "0.1", default-features = false }
+tinyvec = { version = "1", features = ["alloc"] }
+tinyvec_macros = { version = "0.1", default-features = false }
+tokio = { version = "1", features = ["full", "tracing"] }
+tokio-macros = { version = "2", default-features = false }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-tungstenite = { version = "0.19" }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
+toml-d8f496e17d97b5cb = { package = "toml", version = "0.5" }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tower-http = { version = "0.4", features = ["fs", "trace"] }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
+tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+trunk = { version = "0.17", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+tungstenite = { version = "0.19", default-features = false, features = ["handshake"] }
+twox-hash = { version = "1", default-features = false }
+typed-arena = { version = "2" }
+typenum = { version = "1", default-features = false }
+unicase = { version = "2", default-features = false }
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
+unicode-ident = { version = "1", default-features = false }
+unicode-linebreak = { version = "0.1", default-features = false }
+unicode-normalization = { version = "0.1" }
+unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
+unicode-xid = { version = "0.2" }
+untrusted = { version = "0.7", default-features = false }
+update-informer = { version = "1" }
+ureq = { version = "2", default-features = false, features = ["gzip", "json", "tls"] }
+url = { version = "2" }
+urlencoding = { version = "2", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
+utf8parse = { version = "0.2" }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+vec_map = { version = "0.8", default-features = false }
+vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc"] }
+version_check = { version = "0.9", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+vte = { version = "0.10" }
+vte_generate_state_changes = { version = "0.1", default-features = false }
+waker-fn = { version = "1", default-features = false }
+walkdir = { version = "2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen-backend = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-macro = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-macro-support = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-shared = { version = "0.2", default-features = false }
+webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
+which = { version = "4", default-features = false }
+winnow = { version = "0.5" }
+wyz = { version = "0.5", default-features = false }
+xmas-elf = { version = "0.9", default-features = false }
+zero = { version = "0.1", default-features = false }
+zeroize = { version = "1" }
+zip = { version = "0.6" }
+zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["zstdmt"] }
+zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11" }
+zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
+zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
+
+[target.armv6k-nintendo-3ds.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1" }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+mio = { version = "0.8" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+once_cell = { version = "1", default-features = false, features = ["unstable"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+signal-hook-registry = { version = "1", default-features = false }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+static_assertions = { version = "1", default-features = false }
+unicode-bidi = { version = "0.3" }
+waker-fn = { version = "1", default-features = false }
+
+[target.armv6k-nintendo-3ds.build-dependencies]
+ahash = { version = "0.8" }
+arc-swap = { version = "1", default-features = false }
+async-io = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+bitmaps = { version = "2" }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", default-features = false, features = ["std", "unicode"] }
+btoi = { version = "0.4" }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+concurrent-queue = { version = "2" }
+const-oid = { version = "0.9", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
+der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
+digest = { version = "0.10", default-features = false, features = ["oid"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
+encoding_rs = { version = "0.8" }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+faster-hex = { version = "0.8" }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+generic-array = { version = "0.14", default-features = false, features = ["zeroize"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
+git2 = { version = "0.17" }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4" }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+h2 = { version = "0.3", default-features = false }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1" }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kstring = { version = "2" }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+linked-hash-map = { version = "0.5", default-features = false }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1" }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+mio = { version = "0.8" }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+once_cell = { version = "1", default-features = false, features = ["unstable"] }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+ordered-float = { version = "2" }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3" }
+p384 = { version = "0.13" }
+pasetors = { version = "0.6", features = ["serde", "v3"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
+polling = { version = "2" }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+quick-error = { version = "1", default-features = false }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+self_update = { version = "0.37", default-features = false, features = ["rustls"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3" }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6" }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", default-features = false, features = ["visit-mut"] }
+time-468e82937335b1c9 = { package = "time", version = "0.3", default-features = false, features = ["local-offset", "macros"] }
+time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
+unicode-bidi = { version = "0.3" }
+unicode-bom = { version = "2", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1" }
+
+[target.s390x-unknown-linux-musl.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1" }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["general", "ioctl", "no_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+mio = { version = "0.8" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+once_cell = { version = "1", default-features = false, features = ["unstable"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+signal-hook-registry = { version = "1", default-features = false }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+static_assertions = { version = "1", default-features = false }
+unicode-bidi = { version = "0.3" }
+waker-fn = { version = "1", default-features = false }
+
+[target.s390x-unknown-linux-musl.build-dependencies]
+ahash = { version = "0.8" }
+arc-swap = { version = "1", default-features = false }
+async-io = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+bitmaps = { version = "2" }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
+btoi = { version = "0.4" }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+concurrent-queue = { version = "2" }
+const-oid = { version = "0.9", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
+der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
+digest = { version = "0.10", default-features = false, features = ["oid"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
+encoding_rs = { version = "0.8" }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+faster-hex = { version = "0.8" }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["zlib"] }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+generic-array = { version = "0.14", default-features = false, features = ["zeroize"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
+git2 = { version = "0.17" }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4" }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+h2 = { version = "0.3", default-features = false }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1" }
+inotify = { version = "0.9", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2" }
+is-docker = { version = "0.2", default-features = false }
+is-wsl = { version = "0.4", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kstring = { version = "2" }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+linked-hash-map = { version = "0.5", default-features = false }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["general", "ioctl", "no_std"] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["general", "ioctl", "no_std"] }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1" }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+mio = { version = "0.8" }
+neli = { version = "0.6" }
+neli-proc-macros = { version = "0.1", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+once_cell = { version = "1", default-features = false, features = ["unstable"] }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+ordered-float = { version = "2" }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3" }
+p384 = { version = "0.13" }
+pasetors = { version = "0.6", features = ["serde", "v3"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
+polling = { version = "2" }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+quick-error = { version = "1", default-features = false }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+self_update = { version = "0.37", default-features = false, features = ["rustls"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3" }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6" }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", default-features = false, features = ["visit-mut"] }
+time-468e82937335b1c9 = { package = "time", version = "0.3", default-features = false, features = ["local-offset", "macros"] }
+time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
+unicode-bidi = { version = "0.3" }
+unicode-bom = { version = "2", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1" }
+
+### END HAKARI SECTION
+
+# This part of the file should be preserved at the end.

--- a/fixtures/large/hakari/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-1.toml
@@ -1,0 +1,190 @@
+# This file is @generated. To regenerate, run:
+#    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
+
+### BEGIN HAKARI SECTION
+# resolver = '1'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = false
+# dep-format-version = '3'
+# workspace-hack-line-style = 'full'
+# platforms = ['powerpc-unknown-linux-gnuspe']
+# [[traversal-excludes.ids]]
+# name = 'riscv-atomic-emulation-trap'
+# version = '0.4.0'
+# crates-io = true
+#
+# [final-excludes]
+
+[dependencies]
+addr2line = { version = "0.20" }
+axum = { version = "0.6", features = ["ws"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+byteorder = { version = "1" }
+clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+cobs = { version = "0.2" }
+cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+digest = { version = "0.10", features = ["mac", "oid", "std"] }
+either = { version = "1" }
+embedded-hal = { version = "0.2", default-features = false, features = ["unproven"] }
+flate2 = { version = "1", features = ["zlib"] }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-io = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom = { version = "0.2", default-features = false, features = ["js", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["serde"] }
+hyper = { version = "0.14", features = ["full"] }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+memchr = { version = "2", features = ["use_std"] }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", features = ["net", "os-ext"] }
+nb = { version = "0.1", default-features = false, features = ["unstable"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1", features = ["unstable"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard = { version = "1", features = ["experimental-derive", "use-std"] }
+rand = { version = "0.8", features = ["small_rng"] }
+regex = { version = "1" }
+regex-automata = { version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.7" }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+scopeguard = { version = "1" }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+stable_deref_trait = { version = "1" }
+strum = { version = "0.25", features = ["derive"] }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+tokio = { version = "1", features = ["full", "tracing"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-core = { version = "0.1" }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1" }
+uuid = { version = "1", features = ["serde", "v4"] }
+zeroize = { version = "1" }
+
+[build-dependencies]
+addr2line = { version = "0.20" }
+axum = { version = "0.6", features = ["ws"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+bitvec = { version = "1" }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+byteorder = { version = "1" }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+cobs = { version = "0.2" }
+cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+digest = { version = "0.10", features = ["mac", "oid", "std"] }
+either = { version = "1" }
+flate2 = { version = "1", features = ["zlib"] }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-io = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom = { version = "0.2", default-features = false, features = ["js", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["serde"] }
+hyper = { version = "0.14", features = ["full"] }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+memchr = { version = "2", features = ["use_std"] }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", features = ["net", "os-ext"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1", features = ["unstable"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard = { version = "1", features = ["experimental-derive", "use-std"] }
+rand = { version = "0.8", features = ["small_rng"] }
+regex = { version = "1" }
+regex-automata = { version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.7" }
+scopeguard = { version = "1" }
+semver = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+stable_deref_trait = { version = "1" }
+strum = { version = "0.25", features = ["derive"] }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["full", "tracing"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-core = { version = "0.1" }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1" }
+uuid = { version = "1", features = ["serde", "v4"] }
+zeroize = { version = "1" }
+
+[target.powerpc-unknown-linux-gnuspe.dependencies]
+crossbeam-utils = { version = "0.8" }
+io-lifetimes = { version = "1" }
+libc = { version = "0.2", features = ["extra_traits", "use_std"] }
+nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+
+[target.powerpc-unknown-linux-gnuspe.build-dependencies]
+crossbeam-utils = { version = "0.8" }
+io-lifetimes = { version = "1" }
+itertools = { version = "0.10" }
+libc = { version = "0.2", features = ["extra_traits", "use_std"] }
+nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+
+### END HAKARI SECTION
+
+# This part of the file should be preserved at the end.

--- a/fixtures/large/hakari/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-2.toml
@@ -1,0 +1,1388 @@
+# This file is @generated. To regenerate, run:
+#    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
+
+### BEGIN HAKARI SECTION
+# resolver = '1'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = true
+# dep-format-version = '2'
+# workspace-hack-line-style = 'workspace-dotted'
+# platforms = ['mipsel-unknown-linux-musl', 'thumbv4t-none-eabi', 'i686-unknown-linux-gnu']
+# [[traversal-excludes.ids]]
+# name = 'cargo_metadata'
+# version = '0.14.2'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'cfg-if'
+# version = '0.1.10'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'hal-core'
+# version = '0.1.0'
+# source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+
+[dependencies]
+acpi = { version = "4", default-features = false }
+addr2line = { version = "0.20", features = ["cpp_demangle", "fallible-iterator", "memmap2", "object", "rustc-demangle", "smallvec", "std", "std-object"] }
+adler = { version = "1", default-features = false }
+adler32 = { version = "1", features = ["std"] }
+anstream = { version = "0.5", features = ["auto", "wincon"] }
+anstyle = { version = "1", features = ["std"] }
+anstyle-parse = { version = "0.2", features = ["utf8"] }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1", features = ["std"] }
+async-channel = { version = "1", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-std = { version = "1", features = ["alloc", "async-channel", "async-global-executor", "async-io", "async-lock", "async-process", "crossbeam-utils", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "unstable", "wasm-bindgen-futures"] }
+atty = { version = "0.2", default-features = false }
+axum = { version = "0.6", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
+backtrace = { version = "0.3", features = ["gimli-symbolize", "std"] }
+backtrace-ext = { version = "0.2", default-features = false }
+bare-metal = { version = "1", default-features = false }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["std"] }
+base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
+bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
+bincode = { version = "1", default-features = false }
+bit-set = { version = "0.5", features = ["std"] }
+bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit_field = { version = "0.10", default-features = false }
+bitfield = { version = "0.14", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+bootloader_api = { version = "0.11", default-features = false }
+bytemuck = { version = "1", default-features = false, features = ["bytemuck_derive", "derive"] }
+byteorder = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["std"] }
+cfg-if = { version = "1", default-features = false }
+chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
+cobs = { version = "0.2", features = ["use_std"] }
+color_quant = { version = "1", default-features = false }
+colorchoice = { version = "1", default-features = false }
+concurrent-queue = { version = "2", features = ["std"] }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
+console-subscriber = { version = "0.1", features = ["env-filter"] }
+console_error_panic_hook = { version = "0.1", default-features = false }
+const_format = { version = "0.2" }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+crc32fast = { version = "1", features = ["std"] }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
+crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "std"] }
+crossbeam-utils = { version = "0.8", features = ["std"] }
+d1-pac = { version = "0.0.31", default-features = false }
+deflate = { version = "0.8", default-features = false }
+defmt = { version = "0.3", default-features = false }
+dirs = { version = "4", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+either = { version = "1", features = ["use_std"] }
+embedded-dma = { version = "0.2", default-features = false }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
+embedded-graphics-simulator = { version = "0.3", features = ["sdl2", "with-sdl"] }
+embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
+embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+embedded-io = { version = "0.5", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-alloc = { version = "0.3", default-features = false }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp-println", "esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp-riscv-rt", "esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-println = { version = "0.5", features = ["colors", "critical-section", "esp32c3", "uart"] }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
+esp32c3 = { version = "0.16", features = ["critical-section"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", features = ["rt", "vectored"] }
+event-listener = { version = "2", default-features = false }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
+flate2 = { version = "1", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9", features = ["num-traits", "ratio"] }
+fnv = { version = "1", features = ["std"] }
+form_urlencoded = { version = "1", features = ["alloc", "std"] }
+fugit = { version = "0.3", default-features = false }
+futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3", features = ["std"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+gcd = { version = "2", default-features = false }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "std", "wasm-bindgen"] }
+gif = { version = "0.11", features = ["raii_no_panic", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "fallible-iterator", "read", "read-core", "stable_deref_trait", "std"] }
+gloo = { version = "0.9", features = ["console", "dialogs", "events", "file", "futures", "gloo-console", "gloo-dialogs", "gloo-events", "gloo-file", "gloo-history", "gloo-net", "gloo-render", "gloo-storage", "gloo-timers", "gloo-utils", "gloo-worker", "history", "net", "render", "storage", "timers", "utils", "worker"] }
+gloo-console = { version = "0.2", default-features = false }
+gloo-dialogs = { version = "0.1", default-features = false }
+gloo-events = { version = "0.1", default-features = false }
+gloo-file = { version = "0.2", features = ["futures", "futures-channel"] }
+gloo-history = { version = "0.1", features = ["query", "serde_urlencoded", "thiserror"] }
+gloo-net = { version = "0.3", features = ["eventsource", "futures-channel", "futures-core", "futures-sink", "http", "json", "pin-project", "serde", "serde_json", "websocket"] }
+gloo-render = { version = "0.1", default-features = false }
+gloo-storage = { version = "0.2", default-features = false }
+gloo-timers = { version = "0.2", features = ["futures", "futures-channel", "futures-core"] }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1", features = ["serde"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2", features = ["serde"] }
+gloo-worker = { version = "0.3", features = ["futures"] }
+h2 = { version = "0.3", default-features = false }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["base64", "flate2", "nom", "serialization"] }
+heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["alloc", "serde", "std"] }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+httparse = { version = "1", features = ["std"] }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
+hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+hyper-timeout = { version = "0.4", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
+image = { version = "0.23", features = ["bmp", "dds", "dxt", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "png", "pnm", "scoped_threadpool", "tga", "tiff", "webp"] }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
+js-sys = { version = "0.3", default-features = false }
+kv-log-macro = { version = "1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["extra_traits", "std"] }
+libm = { version = "0.2" }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std", "value-bag"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc", "tracing-01"] }
+matchers = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
+memchr = { version = "2", features = ["std", "use_std"] }
+memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
+miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
+mime = { version = "0.3", default-features = false }
+minicbor = { version = "0.13", default-features = false, features = ["alloc", "derive", "minicbor-derive", "std"] }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
+miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", features = ["log", "net", "os-ext", "os-poll"] }
+modality-ingest-client = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
+nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
+nom = { version = "7", features = ["alloc", "std"] }
+nu-ansi-term = { version = "0.46", default-features = false }
+num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1", features = ["i128", "std"] }
+num-iter = { version = "0.1", features = ["std"] }
+num-rational = { version = "0.3", default-features = false }
+num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
+num_cpus = { version = "1", default-features = false }
+object = { version = "0.31", default-features = false, features = ["archive", "coff", "compression", "elf", "flate2", "macho", "pe", "read", "read_core", "ruzstd", "std", "unaligned", "xcoff"] }
+once_cell = { version = "1", features = ["alloc", "race", "std", "unstable"] }
+os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
+overload = { version = "0.1", default-features = false }
+ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
+owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
+percent-encoding = { version = "2", features = ["alloc", "std"] }
+pin-project = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pinned = { version = "0.1", default-features = false }
+png = { version = "0.16", features = ["deflate", "png-encoding"] }
+portable-atomic = { version = "1", features = ["critical-section", "fallback", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["heapless", "heapless-cas", "use-std"] }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
+postcard-cobs = { version = "0.1.5-pre", default-features = false }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+profont = { version = "0.6", default-features = false }
+proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+prost = { version = "0.11", features = ["prost-derive", "std"] }
+prost-types = { version = "0.11", features = ["std"] }
+quick-error = { version = "1", default-features = false }
+r0 = { version = "1", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+regex = { version = "1", features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"] }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.11", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
+ryu = { version = "1", default-features = false }
+scoped_threadpool = { version = "0.1", default-features = false }
+scopeguard = { version = "1", features = ["use_std"] }
+sdl2 = { version = "0.32" }
+sdl2-sys = { version = "0.32" }
+serde = { version = "1", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+serde-wasm-bindgen = { version = "0.5", default-features = false }
+serde_json = { version = "1", features = ["raw_value", "std", "unbounded_depth"] }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f", features = ["libudev"] }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
+sharded-slab = { version = "0.1", default-features = false }
+slab = { version = "0.4", features = ["std"] }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+smawk = { version = "0.3", default-features = false }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
+stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive", "std", "strum_macros"] }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
+sync_wrapper = { version = "0.1", default-features = false }
+tempfile = { version = "3", default-features = false }
+termcolor = { version = "1", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
+textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+thiserror = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+tiff = { version = "0.6", default-features = false }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
+tinyvec_macros = { version = "0.1", default-features = false }
+tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "tracing", "windows-sys"] }
+tokio-io-timeout = { version = "1", default-features = false }
+tokio-native-tls = { version = "0.3", default-features = false }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
+tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tonic = { version = "0.9", features = ["channel", "codegen", "prost", "transport"] }
+tower = { version = "0.4", default-features = false, features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std", "valuable"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", features = ["std"] }
+tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
+tracing-wasm = { version = "0.2", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+unarray = { version = "0.1", default-features = false }
+unicode-bidi = { version = "0.3", features = ["hardcoded-data", "std"] }
+unicode-linebreak = { version = "0.1", default-features = false }
+unicode-normalization = { version = "0.1", features = ["std"] }
+unicode-width = { version = "0.1" }
+url = { version = "2" }
+utf8parse = { version = "0.2" }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["getrandom", "std", "v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
+value-bag = { version = "1", default-features = false }
+vcell = { version = "0.1", default-features = false }
+void = { version = "1", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+wait-timeout = { version = "0.2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "Blob", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "Element", "ErrorEvent", "Event", "EventSource", "EventTarget", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "Node", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "UiEvent", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerGlobalScope", "WorkerOptions", "console"] }
+weezl = { version = "0.1", features = ["alloc", "std"] }
+winnow = { version = "0.5", features = ["alloc", "std"] }
+
+[build-dependencies]
+acpi = { version = "4", default-features = false }
+addr2line = { version = "0.20", features = ["cpp_demangle", "fallible-iterator", "memmap2", "object", "rustc-demangle", "smallvec", "std", "std-object"] }
+adler = { version = "1", default-features = false }
+adler32 = { version = "1", features = ["std"] }
+aes = { version = "0.8", default-features = false }
+aho-corasick = { version = "1", features = ["perf-literal", "std"] }
+ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.5", features = ["auto", "wincon"] }
+anstyle = { version = "1", features = ["std"] }
+anstyle-parse = { version = "0.2", features = ["utf8"] }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1", features = ["std"] }
+arrayvec = { version = "0.5", default-features = false }
+async-channel = { version = "1", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-process = { version = "1", default-features = false }
+async-scoped = { version = "0.7", default-features = false, features = ["tokio", "use-tokio"] }
+async-std = { version = "1", features = ["alloc", "async-channel", "async-global-executor", "async-io", "async-lock", "async-process", "crossbeam-utils", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "unstable", "wasm-bindgen-futures"] }
+async-trait = { version = "0.1", default-features = false }
+atomicwrites = { version = "0.4", default-features = false }
+atty = { version = "0.2", default-features = false }
+autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
+autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
+axum = { version = "0.6", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
+backtrace = { version = "0.3", features = ["gimli-symbolize", "std"] }
+backtrace-ext = { version = "0.2", default-features = false }
+bare-metal = { version = "1", default-features = false }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["std"] }
+base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
+basic-toml = { version = "0.1", default-features = false }
+bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
+bincode = { version = "1", default-features = false }
+binread = { version = "2", features = ["std"] }
+binread_derive = { version = "2", default-features = false }
+bit-set = { version = "0.5", features = ["std"] }
+bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit_field = { version = "0.10", default-features = false }
+bitfield = { version = "0.14", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+bitvec = { version = "1", features = ["alloc", "atomic", "std"] }
+block-buffer = { version = "0.10", default-features = false }
+bootloader = { version = "0.11", features = ["bios", "uefi"] }
+bootloader-boot-config = { version = "0.11", default-features = false }
+bootloader_api = { version = "0.11", default-features = false }
+bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["lazy_static", "regex-automata", "unicode"] }
+bumpalo = { version = "3" }
+bytecount = { version = "0.6", default-features = false }
+bytemuck = { version = "1", default-features = false, features = ["bytemuck_derive", "derive"] }
+bytemuck_derive = { version = "1", default-features = false }
+byteorder = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["std"] }
+bzip2 = { version = "0.4", default-features = false }
+bzip2-sys = { version = "0.1", default-features = false }
+camino = { version = "1", default-features = false, features = ["serde", "serde1"] }
+camino-tempfile = { version = "1", default-features = false }
+cargo-binutils = { version = "0.3", default-features = false }
+cargo-espflash = { version = "2", default-features = false }
+cargo-lock = { version = "9", default-features = false }
+cargo-nextest = { version = "0.9", features = ["default-no-update", "self-update"] }
+cargo-platform = { version = "0.1", default-features = false }
+cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
+cargo_metadata-9067fe90e8c1f593 = { package = "cargo_metadata", version = "0.17" }
+cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
+cfg-expr = { version = "0.15", features = ["target-lexicon", "targets"] }
+cfg-if = { version = "1", default-features = false }
+chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
+cipher = { version = "0.4", default-features = false }
+clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "term_size", "vec_map", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap_complete = { version = "4" }
+clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
+clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
+clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
+cobs = { version = "0.2", features = ["use_std"] }
+color-eyre = { version = "0.6", default-features = false }
+color_quant = { version = "1", default-features = false }
+colorchoice = { version = "1", default-features = false }
+comfy-table = { version = "7", features = ["crossterm", "tty"] }
+concurrent-queue = { version = "2", features = ["std"] }
+config = { version = "0.13", default-features = false, features = ["toml"] }
+console = { version = "0.15", features = ["ansi-parsing", "unicode-width"] }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
+console-subscriber = { version = "0.1", features = ["env-filter"] }
+console_error_panic_hook = { version = "0.1", default-features = false }
+const-oid = { version = "0.9", default-features = false }
+const_format = { version = "0.2" }
+const_format_proc_macros = { version = "0.2" }
+constant_time_eq = { version = "0.1", default-features = false }
+convert_case = { version = "0.4", default-features = false }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"] }
+crc = { version = "3", default-features = false }
+crc-catalog = { version = "2", default-features = false }
+crc32fast = { version = "1", features = ["std"] }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
+crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "std"] }
+crossbeam-utils = { version = "0.8", features = ["std"] }
+crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25", features = ["bracketed-paste"] }
+crossterm-2f80eeee3b1b6c7e = { package = "crossterm", version = "0.26", default-features = false }
+crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+cssparser = { version = "0.27", default-features = false }
+cssparser-macros = { version = "0.6", default-features = false }
+csv = { version = "1", default-features = false }
+csv-core = { version = "0.1" }
+ctrlc = { version = "3", default-features = false, features = ["termination"] }
+cvt = { version = "0.1", default-features = false }
+d1-pac = { version = "0.0.31", default-features = false }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20", features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["strsim", "suggestions"] }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["strsim", "suggestions"] }
+darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+data-encoding = { version = "2", features = ["alloc", "std"] }
+debug-ignore = { version = "1", default-features = false }
+deflate = { version = "0.8", default-features = false }
+defmt = { version = "0.3", default-features = false }
+defmt-macros = { version = "0.3", default-features = false }
+defmt-parser = { version = "0.3", default-features = false, features = ["unstable"] }
+deku = { version = "0.16", features = ["alloc", "const_generics", "std"] }
+deku_derive = { version = "0.16", default-features = false, features = ["proc-macro-crate", "std"] }
+derivative = { version = "2", default-features = false }
+derive_more = { version = "0.99", features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "convert_case", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "iterator", "mul", "mul_assign", "not", "rustc_version", "sum", "try_into", "unwrap"] }
+dialoguer = { version = "0.10", features = ["editor", "password", "tempfile", "zeroize"] }
+digest = { version = "0.10", features = ["alloc", "block-buffer", "const-oid", "core-api", "mac", "oid", "std", "subtle"] }
+directories = { version = "5", default-features = false }
+dirs = { version = "4", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
+doc-comment = { version = "0.3", default-features = false }
+dotenvy = { version = "0.15", default-features = false }
+dtoa = { version = "1", default-features = false }
+dtoa-short = { version = "0.3", default-features = false }
+duct = { version = "0.13", default-features = false }
+dunce = { version = "1", default-features = false }
+edit-distance = { version = "2", default-features = false }
+either = { version = "1", features = ["use_std"] }
+embedded-dma = { version = "0.2", default-features = false }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
+embedded-graphics-simulator = { version = "0.3", features = ["sdl2", "with-sdl"] }
+embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
+embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+embedded-io = { version = "0.5", default-features = false }
+enable-ansi-support = { version = "0.2", default-features = false }
+env_logger = { version = "0.10", features = ["auto-color", "color", "humantime", "regex"] }
+envy = { version = "0.4", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-alloc = { version = "0.3", default-features = false }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp-println", "esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp-riscv-rt", "esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["interrupt"] }
+esp-idf-part = { version = "0.4", features = ["csv", "deku", "parse_int", "regex", "std", "thiserror"] }
+esp-println = { version = "0.5", features = ["colors", "critical-section", "esp32c3", "uart"] }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
+esp32c3 = { version = "0.16", features = ["critical-section"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", features = ["rt", "vectored"] }
+espflash = { version = "2", features = ["cli"] }
+event-listener = { version = "2", default-features = false }
+eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
+failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
+failure_derive = { version = "0.1", default-features = false }
+fallible-iterator = { version = "0.2", default-features = false, features = ["std"] }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
+fatfs = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+file-id = { version = "0.2", default-features = false }
+filetime = { version = "0.2", default-features = false }
+fixedbitset = { version = "0.4", default-features = false }
+flate2 = { version = "1", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9", features = ["num-traits", "ratio"] }
+fnv = { version = "1", features = ["std"] }
+form_urlencoded = { version = "1", features = ["alloc", "std"] }
+fs_at = { version = "0.1" }
+fs_extra = { version = "1", default-features = false }
+fugit = { version = "0.3", default-features = false }
+funty = { version = "2", default-features = false }
+futf = { version = "0.1", default-features = false }
+future-queue = { version = "0.3", default-features = false }
+futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-concurrency = { version = "7", default-features = false }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3", features = ["std"] }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+futures-macro = { version = "0.3", default-features = false }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+fxhash = { version = "0.2", default-features = false }
+gcd = { version = "2", default-features = false }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "std", "wasm-bindgen"] }
+gif = { version = "0.11", features = ["raii_no_panic", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "fallible-iterator", "read", "read-core", "stable_deref_trait", "std"] }
+gloo = { version = "0.9", features = ["console", "dialogs", "events", "file", "futures", "gloo-console", "gloo-dialogs", "gloo-events", "gloo-file", "gloo-history", "gloo-net", "gloo-render", "gloo-storage", "gloo-timers", "gloo-utils", "gloo-worker", "history", "net", "render", "storage", "timers", "utils", "worker"] }
+gloo-console = { version = "0.2", default-features = false }
+gloo-dialogs = { version = "0.1", default-features = false }
+gloo-events = { version = "0.1", default-features = false }
+gloo-file = { version = "0.2", features = ["futures", "futures-channel"] }
+gloo-history = { version = "0.1", features = ["query", "serde_urlencoded", "thiserror"] }
+gloo-net = { version = "0.3", features = ["eventsource", "futures-channel", "futures-core", "futures-sink", "http", "json", "pin-project", "serde", "serde_json", "websocket"] }
+gloo-render = { version = "0.1", default-features = false }
+gloo-storage = { version = "0.2", default-features = false }
+gloo-timers = { version = "0.2", features = ["futures", "futures-channel", "futures-core"] }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1", features = ["serde"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2", features = ["serde"] }
+gloo-worker = { version = "0.3", features = ["futures"] }
+gloo-worker-macros = { version = "0.1", default-features = false }
+gpt = { version = "3", default-features = false }
+guppy = { version = "0.17", default-features = false }
+guppy-workspace-hack = { version = "0.1", default-features = false }
+h2 = { version = "0.3", default-features = false }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["base64", "flate2", "nom", "serialization"] }
+heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
+heck = { version = "0.4" }
+hex = { version = "0.4", features = ["alloc", "serde", "std"] }
+hmac = { version = "0.12", default-features = false, features = ["reset"] }
+home = { version = "0.5", default-features = false }
+html5ever = { version = "0.25", default-features = false }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+http-range-header = { version = "0.3", default-features = false }
+httparse = { version = "1", features = ["std"] }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
+humantime-serde = { version = "1", default-features = false }
+hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+hyper-timeout = { version = "0.4", default-features = false }
+ident_case = { version = "1", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
+image = { version = "0.23", features = ["bmp", "dds", "dxt", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "png", "pnm", "scoped_threadpool", "tga", "tiff", "webp"] }
+indent_write = { version = "2", features = ["std"] }
+indenter = { version = "0.3" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
+indicatif = { version = "0.17", features = ["unicode-width"] }
+inout = { version = "0.1", default-features = false }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", default-features = false, features = ["use_alloc"] }
+itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11", features = ["use_alloc", "use_std"] }
+itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4", features = ["std"] }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jobserver = { version = "0.1", default-features = false }
+jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
+js-sys = { version = "0.3", default-features = false }
+just = { version = "1" }
+kv-log-macro = { version = "1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+lexiclean = { version = "0.0.1", default-features = false }
+libc = { version = "0.2", features = ["extra_traits", "std"] }
+libm = { version = "0.2" }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+llvm-tools = { version = "0.1", default-features = false }
+local-ip-address = { version = "0.5", default-features = false }
+lock_api = { version = "0.4", features = ["atomic_usize"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std", "value-bag"] }
+mac = { version = "0.1", default-features = false }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc", "tracing-01"] }
+markup5ever = { version = "0.10", default-features = false }
+matchers = { version = "0.1", default-features = false }
+matches = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
+mbrman = { version = "0.5", default-features = false }
+md5 = { version = "0.7", default-features = false, features = ["std"] }
+memchr = { version = "2", features = ["std", "use_std"] }
+memmap2 = { version = "0.5", default-features = false }
+memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
+miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
+miette-derive = { version = "5", default-features = false }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", default-features = false }
+minicbor = { version = "0.13", default-features = false, features = ["alloc", "derive", "minicbor-derive", "std"] }
+minicbor-derive = { version = "0.8", default-features = false }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
+miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", features = ["log", "net", "os-ext", "os-poll"] }
+modality-ingest-client = { version = "0.1", default-features = false }
+mukti-metadata = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
+nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
+nested = { version = "0.1", default-features = false }
+new_debug_unreachable = { version = "1", default-features = false }
+nextest-filtering = { version = "0.5" }
+nextest-metadata = { version = "0.9", default-features = false }
+nextest-runner = { version = "0.45", default-features = false, features = ["mukti-metadata", "self-update", "self_update"] }
+nextest-workspace-hack = { version = "0.1", default-features = false }
+nipper = { version = "0.1", default-features = false }
+nodrop = { version = "0.1", features = ["std"] }
+nom = { version = "7", features = ["alloc", "std"] }
+nom-tracable = { version = "0.9" }
+nom-tracable-macros = { version = "0.9", default-features = false }
+nom_locate = { version = "4", features = ["alloc", "std"] }
+normpath = { version = "1", default-features = false }
+notify = { version = "6", features = ["crossbeam-channel", "fsevent-sys", "macos_fsevent"] }
+notify-debouncer-full = { version = "0.3", features = ["crossbeam", "crossbeam-channel"] }
+nu-ansi-term = { version = "0.46", default-features = false }
+num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1", features = ["i128", "std"] }
+num-iter = { version = "0.1", features = ["std"] }
+num-rational = { version = "0.3", default-features = false }
+num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
+num_cpus = { version = "1", default-features = false }
+number_prefix = { version = "0.4", features = ["std"] }
+object = { version = "0.31", default-features = false, features = ["archive", "coff", "compression", "elf", "flate2", "macho", "pe", "read", "read_core", "ruzstd", "std", "unaligned", "xcoff"] }
+once_cell = { version = "1", features = ["alloc", "race", "std", "unstable"] }
+open = { version = "5", default-features = false }
+option-ext = { version = "0.2", default-features = false }
+os_pipe = { version = "1", default-features = false }
+os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
+overload = { version = "0.1", default-features = false }
+ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
+owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
+parking = { version = "2", default-features = false }
+parking_lot = { version = "0.12" }
+parking_lot_core = { version = "0.9", default-features = false }
+parse_int = { version = "0.6" }
+password-hash = { version = "0.4", default-features = false, features = ["rand_core"] }
+paste = { version = "1", default-features = false }
+pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
+pbkdf2 = { version = "0.11", features = ["hmac", "password-hash", "sha2", "simple"] }
+percent-encoding = { version = "2", features = ["alloc", "std"] }
+petgraph = { version = "0.6", default-features = false }
+phf = { version = "0.8", features = ["macros", "phf_macros", "proc-macro-hack", "std"] }
+phf_codegen = { version = "0.8", default-features = false }
+phf_generator-93f6ce9d446188ac = { package = "phf_generator", version = "0.10", default-features = false }
+phf_generator-c38e5c1d305a1b54 = { package = "phf_generator", version = "0.8", default-features = false }
+phf_macros = { version = "0.8", default-features = false }
+phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10", features = ["std"] }
+phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8", features = ["std"] }
+pin-project = { version = "1", default-features = false }
+pin-project-internal = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pinned = { version = "0.1", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
+png = { version = "0.16", features = ["deflate", "png-encoding"] }
+portable-atomic = { version = "1", features = ["critical-section", "fallback", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["heapless", "heapless-cas", "use-std"] }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
+postcard-cobs = { version = "0.1.5-pre", default-features = false }
+postcard-derive = { version = "0.1", default-features = false }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+precomputed-hash = { version = "0.1", default-features = false }
+proc-macro-crate = { version = "1", default-features = false }
+proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
+proc-macro-error-attr = { version = "1", default-features = false }
+proc-macro-hack = { version = "0.5", default-features = false }
+proc-macro2 = { version = "1", features = ["proc-macro"] }
+profont = { version = "0.6", default-features = false }
+proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+proptest-derive = { version = "0.4", default-features = false }
+prost = { version = "0.11", features = ["prost-derive", "std"] }
+prost-derive = { version = "0.11", default-features = false }
+prost-types = { version = "0.11", features = ["std"] }
+quick-error = { version = "1", default-features = false }
+quick-junit = { version = "0.3", default-features = false }
+quick-xml-2b5c6dc72f624058 = { package = "quick-xml", version = "0.23" }
+quick-xml-b73a96c0a5f6a7d9 = { package = "quick-xml", version = "0.29" }
+quote = { version = "1", features = ["proc-macro"] }
+r0 = { version = "1", default-features = false }
+radium = { version = "0.7", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+recursion = { version = "0.4" }
+regex = { version = "1", features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"] }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+remove_dir_all = { version = "0.8" }
+reqwest = { version = "0.11", default-features = false, features = ["__rustls", "__tls", "blocking", "default-tls", "hyper-rustls", "hyper-tls", "json", "native-tls-crate", "rustls", "rustls-pemfile", "rustls-tls", "rustls-tls-webpki-roots", "serde_json", "stream", "tokio-native-tls", "tokio-rustls", "tokio-util", "trust-dns", "trust-dns-resolver", "wasm-streams", "webpki-roots"] }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.11", default-features = false }
+riscv-rt-macros = { version = "0.2", default-features = false }
+riscv-target = { version = "0.1", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-cfg = { version = "0.4", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rustc_version = { version = "0.4", default-features = false }
+rustls = { version = "0.21", features = ["dangerous_configuration", "log", "logging", "tls12"] }
+rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100", features = ["alloc", "std"] }
+rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
+rustversion = { version = "1", default-features = false }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
+ruzstd = { version = "0.3", default-features = false }
+ryu = { version = "1", default-features = false }
+same-file = { version = "1", default-features = false }
+scoped_threadpool = { version = "0.1", default-features = false }
+scopeguard = { version = "1", features = ["use_std"] }
+sct = { version = "0.7", default-features = false }
+sdl2 = { version = "0.32" }
+sdl2-sys = { version = "0.32" }
+seahash = { version = "4" }
+selectors = { version = "0.22", default-features = false }
+self_update = { version = "0.37", features = ["archive-tar", "compression-flate2", "either", "flate2", "rustls", "tar"] }
+semver = { version = "1", features = ["serde", "std"] }
+serde = { version = "1", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+serde-big-array = { version = "0.4", default-features = false }
+serde-wasm-bindgen = { version = "0.5", default-features = false }
+serde_derive = { version = "1" }
+serde_ignored = { version = "0.1", default-features = false }
+serde_json = { version = "1", features = ["raw_value", "std", "unbounded_depth"] }
+serde_path_to_error = { version = "0.1", default-features = false }
+serde_plain = { version = "1", default-features = false }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f", features = ["libudev"] }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
+servo_arc = { version = "0.1", default-features = false }
+sha1 = { version = "0.10", features = ["std"] }
+sha2 = { version = "0.10", features = ["std"] }
+sharded-slab = { version = "0.1", default-features = false }
+shared_child = { version = "1", default-features = false }
+shell-words = { version = "1", features = ["std"] }
+similar = { version = "2", features = ["bstr", "text", "unicode", "unicode-segmentation"] }
+siphasher = { version = "0.3", features = ["std"] }
+slab = { version = "0.4", features = ["std"] }
+slip-codec = { version = "0.3" }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+smawk = { version = "0.3", default-features = false }
+smol_str = { version = "0.2", features = ["serde", "std"] }
+snafu = { version = "0.7", features = ["rust_1_39", "rust_1_46", "std"] }
+snafu-derive = { version = "0.7", default-features = false, features = ["rust_1_39", "rust_1_46"] }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
+stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+static_assertions = { version = "1", default-features = false }
+string_cache = { version = "0.8", features = ["serde", "serde_support"] }
+string_cache_codegen = { version = "0.5", default-features = false }
+strip-ansi-escapes = { version = "0.1", default-features = false }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
+strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive", "std", "strum_macros"] }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive", "std", "strum_macros"] }
+strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
+strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+sync_wrapper = { version = "0.1", default-features = false }
+synstructure = { version = "0.12", features = ["proc-macro"] }
+tap = { version = "1", default-features = false }
+tar = { version = "0.4", features = ["xattr"] }
+target = { version = "2", default-features = false }
+target-lexicon = { version = "0.12", features = ["std"] }
+target-spec = { version = "3", default-features = false, features = ["custom", "summaries"] }
+target-spec-miette = { version = "0.3", default-features = false }
+tempfile = { version = "3", default-features = false }
+tendril = { version = "0.4", default-features = false }
+term_size = { version = "0.3" }
+termcolor = { version = "1", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
+textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
+textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+thin-slice = { version = "0.1", default-features = false }
+thiserror = { version = "1", default-features = false }
+thiserror-impl = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+tiff = { version = "0.6", default-features = false }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["alloc", "formatting", "local-offset", "macros", "parsing", "std"] }
+time-core = { version = "0.1", default-features = false }
+time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
+tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
+tinyvec_macros = { version = "0.1", default-features = false }
+tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "tracing", "windows-sys"] }
+tokio-io-timeout = { version = "1", default-features = false }
+tokio-macros = { version = "2", default-features = false }
+tokio-native-tls = { version = "0.3", default-features = false }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
+tokio-tungstenite = { version = "0.19", features = ["connect", "handshake", "stream"] }
+tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
+toml-d8f496e17d97b5cb = { package = "toml", version = "0.5" }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tonic = { version = "0.9", features = ["channel", "codegen", "prost", "transport"] }
+tower = { version = "0.4", default-features = false, features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
+tower-http = { version = "0.4", features = ["fs", "httpdate", "mime", "mime_guess", "percent-encoding", "set-status", "tokio", "tokio-util", "trace", "tracing"] }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
+tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
+tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std", "valuable"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", features = ["std"] }
+tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
+tracing-wasm = { version = "0.2", default-features = false }
+trunk = { version = "0.17", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+tungstenite = { version = "0.19", default-features = false, features = ["data-encoding", "handshake", "http", "httparse", "sha1", "url"] }
+twox-hash = { version = "1", default-features = false }
+typed-arena = { version = "2", features = ["std"] }
+typenum = { version = "1", default-features = false }
+unarray = { version = "0.1", default-features = false }
+unicase = { version = "2", default-features = false }
+unicode-bidi = { version = "0.3", features = ["hardcoded-data", "std"] }
+unicode-ident = { version = "1", default-features = false }
+unicode-linebreak = { version = "0.1", default-features = false }
+unicode-normalization = { version = "0.1", features = ["std"] }
+unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
+unicode-xid = { version = "0.2" }
+untrusted = { version = "0.7", default-features = false }
+update-informer = { version = "1", features = ["crates", "rustls-tls", "ureq"] }
+ureq = { version = "2", default-features = false, features = ["flate2", "gzip", "json", "rustls", "serde", "serde_json", "tls", "webpki", "webpki-roots"] }
+url = { version = "2" }
+urlencoding = { version = "2", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
+utf8parse = { version = "0.2" }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["getrandom", "std", "v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
+value-bag = { version = "1", default-features = false }
+vcell = { version = "0.1", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
+vec_map = { version = "0.8", default-features = false }
+vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc", "rustc_version", "time"] }
+version_check = { version = "0.9", default-features = false }
+void = { version = "1", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+vte = { version = "0.10", features = ["arrayvec", "no_std"] }
+vte_generate_state_changes = { version = "0.1", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
+waker-fn = { version = "1", default-features = false }
+walkdir = { version = "2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
+wasm-bindgen-backend = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-macro = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-macro-support = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-shared = { version = "0.2", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "Blob", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "Element", "ErrorEvent", "Event", "EventSource", "EventTarget", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "Node", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "UiEvent", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerGlobalScope", "WorkerOptions", "console"] }
+webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
+weezl = { version = "0.1", features = ["alloc", "std"] }
+which = { version = "4", default-features = false }
+winnow = { version = "0.5", features = ["alloc", "std"] }
+wyz = { version = "0.5", default-features = false }
+xmas-elf = { version = "0.9", default-features = false }
+zero = { version = "0.1", default-features = false }
+zeroize = { version = "1", features = ["alloc"] }
+zip = { version = "0.6", features = ["aes", "aes-crypto", "bzip2", "constant_time_eq", "deflate", "flate2", "hmac", "pbkdf2", "sha1", "time", "zstd"] }
+zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11", features = ["arrays", "legacy", "zdict_builder"] }
+zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["arrays", "legacy", "zdict_builder", "zstdmt"] }
+zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
+
+[target.mipsel-unknown-linux-musl.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-registry = { version = "1", default-features = false }
+static_assertions = { version = "1", default-features = false }
+waker-fn = { version = "1", default-features = false }
+
+[target.mipsel-unknown-linux-musl.build-dependencies]
+ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
+arc-swap = { version = "1", default-features = false }
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+bitmaps = { version = "2", features = ["std"] }
+blocking = { version = "1", default-features = false }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
+btoi = { version = "0.4", features = ["std"] }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
+curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
+ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4", features = ["log"] }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1", features = ["unified_diff"] }
+inotify = { version = "0.9", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2", features = ["std"] }
+is-docker = { version = "0.2", default-features = false }
+is-wsl = { version = "0.4", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
+kstring = { version = "2", features = ["std", "unsafe"] }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+linked-hash-map = { version = "0.5", default-features = false }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1", features = ["use_core"] }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+neli = { version = "0.6" }
+neli-proc-macros = { version = "0.1", default-features = false }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "2", features = ["std"] }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3", features = ["serde"] }
+p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
+pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
+polling = { version = "2", features = ["std"] }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["std", "termios", "use-libc-auxv"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["mio-0_8", "support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6", features = ["std"] }
+spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+unicode-bom = { version = "2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1", features = ["unsupported"] }
+
+[target.thumbv4t-none-eabi.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+waker-fn = { version = "1", default-features = false }
+
+[target.thumbv4t-none-eabi.build-dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+encoding_rs = { version = "0.8", features = ["alloc"] }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+hostname = { version = "0.3" }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ipnet = { version = "2", features = ["std"] }
+linked-hash-map = { version = "0.5", default-features = false }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1", features = ["use_core"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+polling = { version = "2", features = ["std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustls-pemfile = { version = "1", default-features = false }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+
+[target.i686-unknown-linux-gnu.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-registry = { version = "1", default-features = false }
+static_assertions = { version = "1", default-features = false }
+waker-fn = { version = "1", default-features = false }
+
+[target.i686-unknown-linux-gnu.build-dependencies]
+ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
+arc-swap = { version = "1", default-features = false }
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+bitmaps = { version = "2", features = ["std"] }
+blocking = { version = "1", default-features = false }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
+btoi = { version = "0.4", features = ["std"] }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+cpufeatures = { version = "0.2", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
+curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
+ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
+enum-as-inner = { version = "0.5", default-features = false }
+faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4", features = ["log"] }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1", features = ["unified_diff"] }
+inotify = { version = "0.9", default-features = false }
+inotify-sys = { version = "0.1", default-features = false }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2", features = ["std"] }
+is-docker = { version = "0.2", default-features = false }
+is-wsl = { version = "0.4", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
+kstring = { version = "2", features = ["std", "unsafe"] }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
+linked-hash-map = { version = "0.5", default-features = false }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1", features = ["use_core"] }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+neli = { version = "0.6" }
+neli-proc-macros = { version = "0.1", default-features = false }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "2", features = ["std"] }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3", features = ["serde"] }
+p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
+pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
+polling = { version = "2", features = ["std"] }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["std", "termios", "use-libc-auxv"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["mio-0_8", "support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6", features = ["std"] }
+spin = { version = "0.5", default-features = false }
+spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+unicode-bom = { version = "2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1", features = ["unsupported"] }
+
+### END HAKARI SECTION
+
+# This part of the file should be preserved at the end.

--- a/fixtures/large/hakari/mnemos_b3b4da9-3.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-3.toml
@@ -1,0 +1,218 @@
+# This file is @generated. To regenerate, run:
+#    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
+
+### BEGIN HAKARI SECTION
+# resolver = 'install'
+# unify-target-host = 'none'
+# output-single-feature = false
+# dep-format-version = '3'
+# workspace-hack-line-style = 'full'
+# platforms = ['s390x-unknown-linux-gnu']
+# [[traversal-excludes.ids]]
+# name = 'bootloader_api'
+# version = '0.11.4'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'constant_time_eq'
+# version = '0.1.5'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'embedded-dma'
+# version = '0.2.0'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'mnemos-x86_64-bootloader'
+# version = '0.1.0'
+# workspace-path = 'platforms/x86_64/bootloader'
+#
+# [[traversal-excludes.ids]]
+# name = 'phf_generator'
+# version = '0.10.0'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'tinyvec'
+# version = '1.6.0'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'anstream'
+# version = '0.5.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'anstyle-query'
+# version = '1.0.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'mnemos-bitslab'
+# version = '0.1.0'
+# workspace-path = 'source/bitslab'
+#
+# [[final-excludes.ids]]
+# name = 'quick-error'
+# version = '1.2.3'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'unicode-width'
+# version = '0.1.10'
+# crates-io = true
+
+[dependencies]
+backtrace = { version = "0.3" }
+byteorder = { version = "1" }
+clap = { version = "4", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+cobs = { version = "0.2" }
+cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+embedded-hal = { version = "0.2", default-features = false, features = ["unproven"] }
+flate2 = { version = "1" }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-io = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+getrandom = { version = "0.2", default-features = false, features = ["std"] }
+gimli = { version = "0.27", default-features = false, features = ["read"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4" }
+hyper = { version = "0.14", features = ["full"] }
+libc = { version = "0.2", features = ["extra_traits"] }
+linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+memchr = { version = "2" }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
+nb = { version = "0.1", default-features = false, features = ["unstable"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
+object = { version = "0.31", default-features = false, features = ["archive", "elf", "macho", "pe", "read_core", "unaligned"] }
+once_cell = { version = "1" }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard = { version = "1", features = ["experimental-derive", "use-std"] }
+rand = { version = "0.8", features = ["small_rng"] }
+regex = { version = "1", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
+regex-automata = { version = "0.3", default-features = false, features = ["meta", "std", "unicode-case", "unicode-perl", "unicode-word-boundary"] }
+regex-syntax = { version = "0.7", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+scopeguard = { version = "1" }
+serde = { version = "1", features = ["alloc", "derive"] }
+serde_json = { version = "1" }
+strum = { version = "0.25", default-features = false, features = ["derive"] }
+tokio = { version = "1", features = ["io-std", "io-util", "macros", "net", "rt", "sync", "time", "tracing"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "timeout", "util"] }
+tracing = { version = "0.1" }
+tracing-core = { version = "0.1" }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
+unicode-normalization = { version = "0.1", default-features = false, features = ["std"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+
+[build-dependencies]
+addr2line = { version = "0.20" }
+axum = { version = "0.6", features = ["ws"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+bitflags = { version = "2", default-features = false, features = ["std"] }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+byteorder = { version = "1" }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+digest = { version = "0.10", features = ["mac", "oid", "std"] }
+either = { version = "1" }
+flate2 = { version = "1", features = ["zlib"] }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-io = { version = "0.3", default-features = false, features = ["std"] }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom = { version = "0.2", default-features = false, features = ["js", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["serde"] }
+hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
+libc = { version = "0.2", features = ["extra_traits"] }
+libz-sys = { version = "1", default-features = false, features = ["libc"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+memchr = { version = "2", features = ["use_std"] }
+miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+mio = { version = "0.8", features = ["net", "os-ext"] }
+num-traits = { version = "0.2", features = ["i128"] }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1", features = ["unstable"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
+portable-atomic = { version = "1", features = ["require-cas"] }
+postcard = { version = "1", features = ["experimental-derive", "use-std"] }
+rand = { version = "0.8" }
+regex = { version = "1" }
+regex-automata = { version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-syntax = { version = "0.7" }
+scopeguard = { version = "1" }
+semver = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+smallvec = { version = "1", default-features = false, features = ["write"] }
+stable_deref_trait = { version = "1" }
+strum = { version = "0.25", features = ["derive"] }
+subtle = { version = "2", default-features = false, features = ["i128"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
+toml_edit = { version = "0.19", features = ["serde"] }
+tower = { version = "0.4", default-features = false, features = ["log", "make", "util"] }
+tracing = { version = "0.1", features = ["log"] }
+tracing-core = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1" }
+uuid = { version = "1", features = ["serde", "v4"] }
+zeroize = { version = "1" }
+
+[target.s390x-unknown-linux-gnu.dependencies]
+io-lifetimes = { version = "1" }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
+openssl = { version = "0.10" }
+rustix = { version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }
+
+[target.s390x-unknown-linux-gnu.build-dependencies]
+io-lifetimes = { version = "1" }
+itertools = { version = "0.10" }
+nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+
+### END HAKARI SECTION
+
+# This part of the file should be preserved at the end.

--- a/fixtures/large/summaries/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-0.toml
@@ -1,0 +1,1065 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = 'install'
+include-dev = false
+initials-platform = 'host'
+
+[metadata.host-platform]
+spec = 'always'
+
+[metadata.target-platform]
+triple = 'powerpc-wrs-vxworks-spe'
+target-features = 'unknown'
+[[metadata.omitted-packages.ids]]
+name = 'rand'
+version = '0.8.5'
+crates-io = true
+
+[[metadata.features-only]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+features = []
+
+[[metadata.features-only]]
+name = 'mnemos-x86_64-bootloader'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/bootloader'
+features = []
+
+[[host-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'initial'
+features = ['async', 'default']
+
+[[host-package]]
+name = 'manganese'
+version = '0.1.0'
+workspace-path = 'tools/manganese'
+status = 'initial'
+features = []
+
+[[host-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'initial'
+features = ['default']
+
+[[host-package]]
+name = 'mnemos-x86_64-bootloader'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/bootloader'
+status = 'initial'
+features = []
+
+[[host-package]]
+name = 'mnemos-x86_64-core'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/core'
+status = 'initial'
+features = ['bootloader_api']
+optional-deps = ['bootloader_api']
+
+[[host-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = ['mnemos-trace-proto', 'serial-trace', 'tracing-core', 'tracing-serde-structured']
+optional-deps = ['mnemos-trace-proto', 'tracing-core', 'tracing-serde-structured']
+
+[[host-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'acpi'
+version = '4.1.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bootloader'
+version = '0.11.4'
+crates-io = true
+status = 'direct'
+features = ['bios', 'default', 'uefi']
+optional-deps = ['gpt', 'mbrman']
+
+[[host-package]]
+name = 'bootloader_api'
+version = '0.11.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'clap'
+version = '4.4.0'
+crates-io = true
+status = 'direct'
+features = ['color', 'default', 'derive', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['clap_derive', 'once_cell']
+
+[[host-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[host-package]]
+name = 'hal-core'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['embedded-graphics-core']
+optional-deps = ['embedded-graphics-core']
+
+[[host-package]]
+name = 'hal-x86_64'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[host-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[host-package]]
+name = 'mycelium-alloc'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['buddy', 'bump', 'hal-core', 'mycelium-util', 'tracing']
+optional-deps = ['hal-core', 'mycelium-util', 'tracing']
+
+[[host-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'ovmf-prebuilt'
+version = '0.1.0-alpha.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[host-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[host-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[host-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'getrandom', 'rng', 'serde', 'std', 'v4']
+optional-deps = ['getrandom', 'serde']
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anstream'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = ['auto', 'default', 'wincon']
+optional-deps = ['anstyle-query', 'anstyle-wincon', 'colorchoice']
+
+[[host-package]]
+name = 'anstyle'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'anstyle-parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'utf8']
+optional-deps = ['utf8parse']
+
+[[host-package]]
+name = 'anstyle-query'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'async-lock'
+version = '2.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'async-process'
+version = '1.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bincode'
+version = '1.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'bitflags'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bitvec'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'atomic', 'default', 'std']
+
+[[host-package]]
+name = 'bootloader-boot-config'
+version = '0.11.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'clap_builder'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['color', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['anstream', 'strsim']
+
+[[host-package]]
+name = 'clap_derive'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'clap_lex'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'colorchoice'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc'
+version = '3.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc-catalog'
+version = '2.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'event-listener'
+version = '2.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'fastrand'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'fatfs'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[host-package]]
+name = 'funty'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[host-package]]
+name = 'futures-concurrency'
+version = '7.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-executor'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'futures-lite'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'fastrand', 'futures-io', 'memchr', 'parking', 'std', 'waker-fn']
+optional-deps = ['fastrand', 'futures-io', 'memchr', 'parking', 'waker-fn']
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'slab']
+
+[[host-package]]
+name = 'getrandom'
+version = '0.2.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'gpt'
+version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'heck'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'llvm-tools'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'mbrman'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'mycelium-trace'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = ['default', 'embedded-graphics']
+optional-deps = ['embedded-graphics']
+
+[[host-package]]
+name = 'mycotest'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'parking'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'radium'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'raw-cpuid'
+version = '10.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rsdp'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde-big-array'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.105'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strsim'
+version = '0.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'tap'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tempfile'
+version = '3.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'utf8parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'volatile'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'waker-fn'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wyz'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-1.toml
@@ -1,0 +1,652 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = 'install'
+include-dev = false
+initials-platform = 'host'
+
+[metadata.host-platform]
+triple = 'aarch64-pc-windows-gnullvm'
+target-features = ['bmi1', 'bmi2', 'sse2', 'sse4.2', 'xsaveopt', 'xsaves']
+
+[metadata.target-platform]
+triple = 'aarch64-unknown-linux-gnu'
+target-features = ['bmi2', 'ssse3']
+flags = ['flag-test']
+[[metadata.omitted-packages.ids]]
+name = 'gcd'
+version = '2.3.0'
+crates-io = true
+
+[[host-package]]
+name = 'f3repl'
+version = '0.1.0'
+workspace-path = 'tools/f3repl'
+status = 'initial'
+features = []
+
+[[host-package]]
+name = 'mnemos-beepy'
+version = '0.1.0'
+workspace-path = 'platforms/beepy'
+status = 'initial'
+features = []
+
+[[host-package]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+status = 'initial'
+features = ['default']
+
+[[host-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default', 'use-std']
+
+[[host-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'bbq10kbd'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/bbq10kbd?branch=eliza/async#d2365be8726e9320b0e4ab626043c1a8a41246f8'
+status = 'direct'
+features = ['embedded-hal-async']
+optional-deps = ['embedded-hal-async']
+
+[[host-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[host-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[host-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[host-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[host-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[host-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['derive', 'serde_derive']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[host-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[host-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[host-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nb'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-2.toml
@@ -1,0 +1,1054 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = '1'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
+
+[metadata.host-platform]
+triple = 'riscv64gc-unknown-fuchsia'
+target-features = 'unknown'
+flags = ['foo']
+
+[metadata.target-platform]
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'mnemos-d1-core'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-core'
+
+[[metadata.features-only]]
+name = 'pomelo'
+version = '0.1.0'
+workspace-path = 'platforms/pomelo'
+features = []
+
+[[target-package]]
+name = 'dumbloader'
+version = '0.1.0'
+workspace-path = 'tools/dumbloader'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'initial'
+features = ['default', 'stats', 'use-std']
+
+[[target-package]]
+name = 'mnemos-bitslab'
+version = '0.1.0'
+workspace-path = 'source/bitslab'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-x86_64-core'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/core'
+status = 'initial'
+features = ['bootloader_api']
+optional-deps = ['bootloader_api']
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = ['mnemos-trace-proto', 'serial-trace', 'tracing-core', 'tracing-serde-structured']
+optional-deps = ['mnemos-trace-proto', 'tracing-core', 'tracing-serde-structured']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'acpi'
+version = '4.1.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bootloader_api'
+version = '0.11.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'std']
+
+[[target-package]]
+name = 'hal-core'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['embedded-graphics-core']
+optional-deps = ['embedded-graphics-core']
+
+[[target-package]]
+name = 'hal-x86_64'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default', 'tracing-01']
+optional-deps = ['tracing-01']
+
+[[target-package]]
+name = 'mycelium-alloc'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['buddy', 'bump', 'hal-core', 'mycelium-util', 'tracing']
+optional-deps = ['hal-core', 'mycelium-util', 'tracing']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '0.7.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'heapless', 'heapless-cas', 'use-std']
+optional-deps = ['heapless']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'atomic-polyfill'
+version = '0.1.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'default', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'slab']
+
+[[target-package]]
+name = 'generator'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[target-package]]
+name = 'libm'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'lock_api'
+version = '0.4.10'
+crates-io = true
+status = 'transitive'
+features = ['atomic_usize', 'default']
+
+[[target-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = ['kv_unstable', 'std', 'value-bag']
+optional-deps = ['value-bag']
+
+[[target-package]]
+name = 'loom'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'matchers'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mycelium-trace'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = ['default', 'embedded-graphics']
+optional-deps = ['embedded-graphics']
+
+[[target-package]]
+name = 'mycotest'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nu-ansi-term'
+version = '0.46.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = ['libm', 'std']
+optional-deps = ['libm']
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'overload'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'postcard-cobs'
+version = '0.1.5-pre'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'raw-cpuid'
+version = '10.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'regex-syntax', 'std']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'meta', 'nfa-pikevm', 'nfa-thompson', 'std', 'syntax', 'unicode-case', 'unicode-perl', 'unicode-word-boundary']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.29'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'rsdp'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scoped-tls'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sharded-slab'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'smallvec'
+version = '1.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'spin'
+version = '0.9.8'
+crates-io = true
+status = 'transitive'
+features = ['barrier', 'default', 'lazy', 'lock_api', 'lock_api_crate', 'mutex', 'once', 'rwlock', 'spin_mutex']
+optional-deps = ['lock_api_crate']
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.1.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing-log'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = ['log-tracer', 'std']
+
+[[target-package]]
+name = 'tracing-subscriber'
+version = '0.3.17'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'ansi', 'default', 'env-filter', 'fmt', 'matchers', 'nu-ansi-term', 'once_cell', 'regex', 'registry', 'sharded-slab', 'smallvec', 'std', 'thread_local', 'tracing', 'tracing-log']
+optional-deps = ['matchers', 'nu-ansi-term', 'once_cell', 'regex', 'sharded-slab', 'smallvec', 'thread_local', 'tracing', 'tracing-log']
+
+[[target-package]]
+name = 'valuable'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'value-bag'
+version = '1.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'volatile'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'minwinbase', 'minwindef', 'ntdef', 'processenv', 'profileapi', 'std', 'sysinfoapi', 'timezoneapi', 'ws2ipdef', 'ws2tcpip']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Globalization', 'Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_Memory', 'Win32_System_SystemInformation', 'default']
+
+[[target-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cc'
+version = '1.0.79'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-3.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-3.toml
@@ -1,0 +1,1092 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = '2'
+include-dev = true
+initials-platform = 'standard'
+
+[metadata.host-platform]
+spec = 'always'
+
+[metadata.target-platform]
+spec = 'always'
+[[metadata.omitted-packages.ids]]
+name = 'num-iter'
+version = '0.1.43'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'scoped-tls'
+version = '1.0.1'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'spin'
+version = '0.9.8'
+crates-io = true
+
+[[target-package]]
+name = 'crowtty'
+version = '0.1.0'
+workspace-path = 'tools/crowtty'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-esp32c3-buddy'
+version = '0.1.0'
+workspace-path = 'platforms/esp32c3-buddy'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-std'
+version = '0.1.0'
+workspace-path = 'source/mstd'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = ['mnemos-trace-proto', 'serial-trace', 'tracing-core', 'tracing-serde-structured']
+optional-deps = ['mnemos-trace-proto', 'tracing-core', 'tracing-serde-structured']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'workspace'
+features = ['std']
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = ['use-std']
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '4.4.0'
+crates-io = true
+status = 'direct'
+features = ['color', 'default', 'derive', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['clap_derive', 'once_cell']
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'esp-alloc'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'esp-backtrace'
+version = '0.7.0'
+crates-io = true
+status = 'direct'
+features = ['esp-println', 'esp32c3', 'exception-handler', 'panic-handler', 'print-uart']
+optional-deps = ['esp-println']
+
+[[target-package]]
+name = 'esp-println'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['colors', 'critical-section', 'default', 'esp32c3', 'uart']
+optional-deps = ['critical-section']
+
+[[target-package]]
+name = 'esp32c3-hal'
+version = '0.11.0'
+source = 'git+https://github.com/esp-rs/esp-hal?rev=5a8be302b4049a6ebc17bd712d97c85a9fd83f76#5a8be302b4049a6ebc17bd712d97c85a9fd83f76'
+status = 'direct'
+features = ['default', 'rt', 'vectored']
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = ['const_mut_refs']
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'owo-colors'
+version = '3.5.0'
+crates-io = true
+status = 'direct'
+features = ['supports-color', 'supports-colors']
+optional-deps = ['supports-color']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['critical-section', 'default', 'fallback', 'require-cas']
+optional-deps = ['critical-section']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'riscv'
+version = '0.10.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'serialport'
+version = '4.0.1'
+source = 'git+https://github.com/metta-systems/serialport-rs?rev=7fec572529ec35b82bd4e3636d897fe2f1c2233f#7fec572529ec35b82bd4e3636d897fe2f1c2233f'
+status = 'direct'
+features = ['default', 'libudev']
+
+[[target-package]]
+name = 'serialport'
+version = '4.2.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'libudev']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = ['once_cell', 'std']
+optional-deps = ['once_cell']
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'tracing-subscriber'
+version = '0.3.17'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'anstream'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = ['auto', 'default', 'wincon']
+optional-deps = ['anstyle-query', 'colorchoice']
+
+[[target-package]]
+name = 'anstyle'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'anstyle-parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'utf8']
+optional-deps = ['utf8parse']
+
+[[target-package]]
+name = 'anstyle-query'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitfield'
+version = '0.14.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'bitflags'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap_builder'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['color', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['anstream', 'strsim']
+
+[[target-package]]
+name = 'clap_lex'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'colorchoice'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-dma'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = ['unproven']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-io'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'esp-hal-common'
+version = '0.11.0'
+source = 'git+https://github.com/esp-rs/esp-hal?rev=5a8be302b4049a6ebc17bd712d97c85a9fd83f76#5a8be302b4049a6ebc17bd712d97c85a9fd83f76'
+status = 'transitive'
+features = ['esp-riscv-rt', 'esp32c3', 'rv-zero-rtc-bss', 'vectored']
+optional-deps = ['esp-riscv-rt', 'esp32c3']
+
+[[target-package]]
+name = 'esp-riscv-rt'
+version = '0.5.0'
+source = 'git+https://github.com/esp-rs/esp-hal?rev=5a8be302b4049a6ebc17bd712d97c85a9fd83f76#5a8be302b4049a6ebc17bd712d97c85a9fd83f76'
+status = 'transitive'
+features = ['zero-rtc-fast-bss']
+
+[[target-package]]
+name = 'esp32c3'
+version = '0.16.0'
+crates-io = true
+status = 'transitive'
+features = ['critical-section', 'default']
+optional-deps = ['critical-section']
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'fugit'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gcd'
+version = '2.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'is_ci'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[target-package]]
+name = 'nb'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strum'
+version = '0.25.0'
+crates-io = true
+status = 'transitive'
+features = ['derive', 'strum_macros']
+optional-deps = ['strum_macros']
+
+[[target-package]]
+name = 'supports-color'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'utf8parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'vcell'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'basic-toml'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'clap_derive'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'darling'
+version = '0.20.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'suggestions']
+
+[[host-package]]
+name = 'darling_core'
+version = '0.20.3'
+crates-io = true
+status = 'transitive'
+features = ['strsim', 'suggestions']
+optional-deps = ['strsim']
+
+[[host-package]]
+name = 'darling_macro'
+version = '0.20.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'equivalent'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'esp-hal-procmacros'
+version = '0.6.0'
+source = 'git+https://github.com/esp-rs/esp-hal?rev=5a8be302b4049a6ebc17bd712d97c85a9fd83f76#5a8be302b4049a6ebc17bd712d97c85a9fd83f76'
+status = 'transitive'
+features = ['interrupt']
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.14.0'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
+name = 'heck'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'ident_case'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'indexmap'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'paste'
+version = '1.0.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-crate'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'riscv-rt-macros'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'strsim'
+version = '0.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strum_macros'
+version = '0.25.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'toml_datetime'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'toml_edit'
+version = '0.19.14'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winnow'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']

--- a/fixtures/large/summaries/mnemos_b3b4da9-4.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-4.toml
@@ -1,0 +1,701 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = 'install'
+include-dev = false
+initials-platform = 'standard'
+
+[metadata.host-platform]
+spec = 'any'
+
+[metadata.target-platform]
+triple = 'i386-apple-ios'
+target-features = ['xsave']
+flags = ['foo']
+[[metadata.omitted-packages.ids]]
+name = 'mnemos-x86_64-bootloader'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/bootloader'
+
+[[metadata.omitted-packages.ids]]
+name = 'windows_i686_gnu'
+version = '0.42.2'
+crates-io = true
+
+[[metadata.features-only]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+features = []
+
+[[metadata.features-only]]
+name = 'mnemos-std'
+version = '0.1.0'
+workspace-path = 'source/mstd'
+features = []
+
+[[metadata.features-only]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+features = []
+
+[[target-package]]
+name = 'mnemos-d1-core'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-core'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-bitslab'
+version = '0.1.0'
+workspace-path = 'source/bitslab'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'd1-pac'
+version = '0.0.31'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['derive', 'serde_derive']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bare-metal'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'riscv'
+version = '0.10.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vcell'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-5.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-5.toml
@@ -1,0 +1,1421 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = '2'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
+
+[metadata.host-platform]
+triple = 'thumbv7em-none-eabihf'
+target-features = []
+flags = ['flag-test', 'foo']
+
+[metadata.target-platform]
+triple = 'powerpc-wrs-vxworks'
+target-features = 'unknown'
+flags = ['cargo_web', 'test-flag']
+
+[[metadata.features-only]]
+name = 'dumbloader'
+version = '0.1.0'
+workspace-path = 'tools/dumbloader'
+features = []
+
+[[metadata.features-only]]
+name = 'mnemos-bitslab'
+version = '0.1.0'
+workspace-path = 'source/bitslab'
+features = []
+
+[[metadata.features-only]]
+name = 'mnemos-d1'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1'
+features = []
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'initial'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-d1'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'd1-config'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-config'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-bitslab'
+version = '0.1.0'
+workspace-path = 'source/bitslab'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-d1-core'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-core'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'direct'
+features = ['restore-state-bool']
+
+[[target-package]]
+name = 'd1-pac'
+version = '0.0.31'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'riscv'
+version = '0.10.1'
+crates-io = true
+status = 'direct'
+features = ['critical-section-single-hart']
+
+[[target-package]]
+name = 'riscv-rt'
+version = '0.11.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bare-metal'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'r0'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vcell'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'initial'
+features = ['async', 'default']
+
+[[host-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'initial'
+features = ['default']
+
+[[host-package]]
+name = 'd1-config'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-config'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+status = 'workspace'
+features = ['default', 'use-std']
+optional-deps = ['miette', 'toml']
+
+[[host-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[host-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['defmt', 'serde']
+
+[[host-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[host-package]]
+name = 'miette'
+version = '5.10.0'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'backtrace-ext', 'default', 'fancy', 'fancy-no-backtrace', 'is-terminal', 'owo-colors', 'supports-color', 'supports-hyperlinks', 'supports-unicode', 'terminal_size', 'textwrap']
+optional-deps = ['backtrace', 'backtrace-ext', 'is-terminal', 'owo-colors', 'supports-color', 'supports-hyperlinks', 'supports-unicode', 'terminal_size', 'textwrap']
+
+[[host-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[host-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive', 'use-std']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[host-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'toml'
+version = '0.7.6'
+crates-io = true
+status = 'direct'
+features = ['default', 'display', 'parse']
+optional-deps = ['toml_edit']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'addr2line'
+version = '0.20.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'adler'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'aho-corasick'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'perf-literal', 'std']
+optional-deps = ['memchr']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'backtrace'
+version = '0.3.68'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'backtrace-ext'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cc'
+version = '1.0.79'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'equivalent'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[host-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[host-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[host-package]]
+name = 'gimli'
+version = '0.27.3'
+crates-io = true
+status = 'transitive'
+features = ['read', 'read-core']
+
+[[host-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.14.0'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
+name = 'indexmap'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'io-lifetimes'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = ['close', 'default', 'hermit-abi', 'libc', 'windows-sys']
+optional-deps = ['libc']
+
+[[host-package]]
+name = 'is-terminal'
+version = '0.4.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'is_ci'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[host-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'miette-derive'
+version = '5.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'miniz_oxide'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'object'
+version = '0.31.1'
+crates-io = true
+status = 'transitive'
+features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned']
+
+[[host-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'owo-colors'
+version = '3.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr']
+
+[[host-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment', 'unicode-word-boundary']
+optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'riscv-rt-macros'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'riscv-target'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc-demangle'
+version = '0.1.23'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustix'
+version = '0.37.20'
+crates-io = true
+status = 'transitive'
+features = ['default', 'io-lifetimes', 'libc', 'std', 'termios', 'use-libc-auxv']
+optional-deps = ['io-lifetimes', 'libc']
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'serde_spanned'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'smawk'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-color'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-hyperlinks'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-unicode'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'terminal_size'
+version = '0.1.17'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.15.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'smawk', 'unicode-linebreak', 'unicode-width']
+optional-deps = ['smawk', 'unicode-linebreak', 'unicode-width']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'toml_datetime'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'toml_edit'
+version = '0.19.14'
+crates-io = true
+status = 'transitive'
+features = ['default', 'serde']
+optional-deps = ['serde', 'serde_spanned']
+
+[[host-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-linebreak'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winnow'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']

--- a/fixtures/large/summaries/mnemos_b3b4da9-6.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-6.toml
@@ -1,0 +1,3187 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = '2'
+include-dev = true
+initials-platform = 'proc-macros-on-target'
+
+[metadata.host-platform]
+triple = 'i586-pc-windows-msvc'
+target-features = 'all'
+flags = ['cargo_web', 'foo']
+
+[metadata.target-platform]
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'anstyle-parse'
+version = '0.2.1'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'mach'
+version = '0.2.3'
+crates-io = true
+
+[[target-package]]
+name = 'melpomene'
+version = '0.1.0'
+workspace-path = 'platforms/melpomene'
+status = 'initial'
+features = ['atty', 'console-subscriber', 'default', 'humantime', 'trace-console', 'trace-fmt', 'trace-modality', 'tracing-modality']
+optional-deps = ['atty', 'console-subscriber', 'humantime', 'tracing-modality']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'initial'
+features = ['default', 'defmt', 'use-defmt']
+optional-deps = ['defmt']
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'initial'
+features = ['default', 'stats', 'use-std']
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'initial'
+features = ['std']
+
+[[target-package]]
+name = 'pomelo'
+version = '0.1.0'
+workspace-path = 'platforms/pomelo'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'melpo-config'
+version = '0.1.0'
+workspace-path = 'platforms/melpomene/melpo-config'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-std'
+version = '0.1.0'
+workspace-path = 'source/mstd'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'async-std'
+version = '1.12.0'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-channel', 'async-global-executor', 'async-io', 'async-lock', 'async-process', 'crossbeam-utils', 'default', 'futures-channel', 'futures-core', 'futures-io', 'futures-lite', 'gloo-timers', 'kv-log-macro', 'log', 'memchr', 'once_cell', 'pin-project-lite', 'pin-utils', 'slab', 'std', 'unstable', 'wasm-bindgen-futures']
+optional-deps = ['async-channel', 'async-global-executor', 'async-io', 'async-lock', 'async-process', 'crossbeam-utils', 'futures-channel', 'futures-core', 'futures-io', 'futures-lite', 'gloo-timers', 'kv-log-macro', 'log', 'memchr', 'once_cell', 'pin-project-lite', 'pin-utils', 'slab', 'wasm-bindgen-futures']
+
+[[target-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'chrono'
+version = '0.4.26'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'iana-time-zone', 'js-sys', 'oldtime', 'std', 'time', 'wasm-bindgen', 'wasmbind', 'winapi']
+optional-deps = ['iana-time-zone', 'js-sys', 'time', 'wasm-bindgen', 'winapi']
+
+[[target-package]]
+name = 'clap'
+version = '3.2.25'
+crates-io = true
+status = 'direct'
+features = ['atty', 'clap_derive', 'color', 'default', 'derive', 'env', 'once_cell', 'std', 'strsim', 'suggestions', 'termcolor']
+optional-deps = ['atty', 'clap_derive', 'once_cell', 'strsim', 'termcolor']
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'console-subscriber'
+version = '0.1.10'
+crates-io = true
+status = 'direct'
+features = ['default', 'env-filter']
+
+[[target-package]]
+name = 'console_error_panic_hook'
+version = '0.1.7'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-graphics-simulator'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'sdl2', 'with-sdl']
+optional-deps = ['sdl2']
+
+[[target-package]]
+name = 'embedded-graphics-web-simulator'
+version = '0.3.0'
+source = 'git+https://github.com/spookyvision/embedded-graphics-web-simulator#0f07b1efb8181860c16b3edf8293aff9515cc480'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'default', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'slab']
+
+[[target-package]]
+name = 'gloo'
+version = '0.9.0'
+crates-io = true
+status = 'direct'
+features = ['console', 'default', 'dialogs', 'events', 'file', 'futures', 'gloo-console', 'gloo-dialogs', 'gloo-events', 'gloo-file', 'gloo-history', 'gloo-net', 'gloo-render', 'gloo-storage', 'gloo-timers', 'gloo-utils', 'gloo-worker', 'history', 'net', 'render', 'storage', 'timers', 'utils', 'worker']
+optional-deps = ['gloo-console', 'gloo-dialogs', 'gloo-events', 'gloo-file', 'gloo-history', 'gloo-net', 'gloo-render', 'gloo-storage', 'gloo-timers', 'gloo-utils', 'gloo-worker']
+
+[[target-package]]
+name = 'gloo-utils'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde']
+optional-deps = ['serde', 'serde_json']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[target-package]]
+name = 'humantime'
+version = '2.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default', 'tracing-01']
+optional-deps = ['tracing-01']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tokio'
+version = '1.29.1'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'default', 'io-std', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'socket2', 'sync', 'time', 'tokio-macros', 'tracing', 'windows-sys']
+optional-deps = ['bytes', 'libc', 'mio', 'socket2', 'tokio-macros', 'tracing', 'windows-sys']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[target-package]]
+name = 'tracing-modality'
+version = '0.1.0'
+source = 'git+https://github.com/auxoncorp/modality-tracing-rs?rev=9c23c188466357e7ad0c618b4edfe9514e9bf764#9c23c188466357e7ad0c618b4edfe9514e9bf764'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = ['std']
+
+[[target-package]]
+name = 'tracing-subscriber'
+version = '0.3.17'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'ansi', 'default', 'env-filter', 'fmt', 'matchers', 'nu-ansi-term', 'once_cell', 'regex', 'registry', 'sharded-slab', 'smallvec', 'std', 'thread_local', 'tracing', 'tracing-log']
+optional-deps = ['matchers', 'nu-ansi-term', 'once_cell', 'regex', 'sharded-slab', 'smallvec', 'thread_local', 'tracing', 'tracing-log']
+
+[[target-package]]
+name = 'tracing-wasm'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'getrandom', 'rng', 'serde', 'std', 'v4']
+optional-deps = ['getrandom', 'serde']
+
+[[target-package]]
+name = 'wasm-bindgen'
+version = '0.2.87'
+crates-io = true
+status = 'direct'
+features = ['default', 'spans', 'std']
+
+[[target-package]]
+name = 'wasm-bindgen-futures'
+version = '0.4.37'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'web-sys'
+version = '0.3.64'
+crates-io = true
+status = 'direct'
+features = ['AbortSignal', 'AddEventListenerOptions', 'BinaryType', 'Blob', 'BlobPropertyBag', 'CanvasRenderingContext2d', 'CloseEvent', 'CloseEventInit', 'DedicatedWorkerGlobalScope', 'Document', 'DomException', 'Element', 'ErrorEvent', 'Event', 'EventSource', 'EventTarget', 'File', 'FileList', 'FilePropertyBag', 'FileReader', 'FormData', 'Headers', 'History', 'HtmlCanvasElement', 'HtmlElement', 'HtmlHeadElement', 'HtmlInputElement', 'ImageData', 'KeyboardEvent', 'Location', 'MessageEvent', 'Node', 'ObserverCallback', 'ProgressEvent', 'ReadableStream', 'ReferrerPolicy', 'Request', 'RequestCache', 'RequestCredentials', 'RequestInit', 'RequestMode', 'RequestRedirect', 'Response', 'ResponseInit', 'ResponseType', 'Storage', 'UiEvent', 'Url', 'UrlSearchParams', 'WebSocket', 'Window', 'Worker', 'WorkerGlobalScope', 'WorkerOptions', 'console']
+
+[[target-package]]
+name = 'addr2line'
+version = '0.20.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'adler'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'adler32'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'android-tzdata'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'android_system_properties'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'async-channel'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-executor'
+version = '1.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-global-executor'
+version = '2.3.1'
+crates-io = true
+status = 'transitive'
+features = ['async-io', 'default']
+optional-deps = ['async-io']
+
+[[target-package]]
+name = 'async-io'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-lock'
+version = '2.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-process'
+version = '1.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-task'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'atomic-polyfill'
+version = '0.1.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atomic-waker'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'axum'
+version = '0.6.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'axum-core'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'backtrace'
+version = '0.3.68'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'base64'
+version = '0.13.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'base64'
+version = '0.21.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bincode'
+version = '1.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'blocking'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bytemuck'
+version = '1.13.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bytes'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'clap_lex'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cloudabi'
+version = '0.0.3'
+crates-io = true
+status = 'transitive'
+features = ['bitflags', 'default']
+optional-deps = ['bitflags']
+
+[[target-package]]
+name = 'color_quant'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'concurrent-queue'
+version = '2.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'console-api'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = ['transport']
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'core-foundation'
+version = '0.9.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'core-foundation-sys'
+version = '0.8.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crc32fast'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-channel'
+version = '0.5.8'
+crates-io = true
+status = 'transitive'
+features = ['crossbeam-utils', 'default', 'std']
+optional-deps = ['crossbeam-utils']
+
+[[target-package]]
+name = 'crossbeam-deque'
+version = '0.8.3'
+crates-io = true
+status = 'transitive'
+features = ['crossbeam-epoch', 'crossbeam-utils', 'default', 'std']
+optional-deps = ['crossbeam-epoch', 'crossbeam-utils']
+
+[[target-package]]
+name = 'crossbeam-epoch'
+version = '0.9.15'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'crossbeam-utils'
+version = '0.8.16'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'deflate'
+version = '0.8.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dirs'
+version = '4.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dirs-sys'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'either'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno-dragonfly'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'event-listener'
+version = '2.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fastrand'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'flate2'
+version = '1.0.26'
+crates-io = true
+status = 'transitive'
+features = ['default', 'miniz_oxide', 'rust_backend']
+optional-deps = ['miniz_oxide']
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'foreign-types'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'foreign-types-shared'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'form_urlencoded'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'fuchsia-cprng'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'futures-lite'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'fastrand', 'futures-io', 'memchr', 'parking', 'std', 'waker-fn']
+optional-deps = ['fastrand', 'futures-io', 'memchr', 'parking', 'waker-fn']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'generator'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.2.10'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'gif'
+version = '0.11.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'raii_no_panic', 'std']
+
+[[target-package]]
+name = 'gimli'
+version = '0.27.3'
+crates-io = true
+status = 'transitive'
+features = ['read', 'read-core']
+
+[[target-package]]
+name = 'gloo-console'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gloo-dialogs'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gloo-events'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gloo-file'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'futures', 'futures-channel']
+optional-deps = ['futures-channel']
+
+[[target-package]]
+name = 'gloo-history'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'query', 'serde_urlencoded', 'thiserror']
+optional-deps = ['serde_urlencoded', 'thiserror']
+
+[[target-package]]
+name = 'gloo-net'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'eventsource', 'futures-channel', 'futures-core', 'futures-sink', 'http', 'json', 'pin-project', 'serde', 'serde_json', 'websocket']
+optional-deps = ['futures-channel', 'futures-core', 'futures-sink', 'pin-project', 'serde', 'serde_json']
+
+[[target-package]]
+name = 'gloo-render'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gloo-storage'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'gloo-timers'
+version = '0.2.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'futures', 'futures-channel', 'futures-core']
+optional-deps = ['futures-channel', 'futures-core']
+
+[[target-package]]
+name = 'gloo-utils'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'serde']
+optional-deps = ['serde', 'serde_json']
+
+[[target-package]]
+name = 'gloo-worker'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'futures']
+
+[[target-package]]
+name = 'h2'
+version = '0.3.20'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hashbrown'
+version = '0.12.3'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[target-package]]
+name = 'hdrhistogram'
+version = '7.5.2'
+crates-io = true
+status = 'transitive'
+features = ['base64', 'flate2', 'nom', 'serialization']
+optional-deps = ['base64', 'flate2', 'nom']
+
+[[target-package]]
+name = 'hermit-abi'
+version = '0.1.19'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'hermit-abi'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'hex'
+version = '0.4.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'http'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http-body'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'httparse'
+version = '1.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'httpdate'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hyper'
+version = '0.14.27'
+crates-io = true
+status = 'transitive'
+features = ['client', 'default', 'full', 'h2', 'http1', 'http2', 'runtime', 'server', 'socket2', 'stream', 'tcp']
+optional-deps = ['h2', 'socket2']
+
+[[target-package]]
+name = 'hyper-timeout'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'iana-time-zone'
+version = '0.1.57'
+crates-io = true
+status = 'transitive'
+features = ['fallback']
+
+[[target-package]]
+name = 'iana-time-zone-haiku'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'idna'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'image'
+version = '0.23.14'
+crates-io = true
+status = 'transitive'
+features = ['bmp', 'dds', 'default', 'dxt', 'farbfeld', 'gif', 'hdr', 'ico', 'jpeg', 'jpeg_rayon', 'png', 'pnm', 'scoped_threadpool', 'tga', 'tiff', 'webp']
+optional-deps = ['gif', 'jpeg', 'png', 'scoped_threadpool', 'tiff']
+
+[[target-package]]
+name = 'indexmap'
+version = '1.9.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'instant'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'io-lifetimes'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = ['close', 'hermit-abi', 'libc', 'windows-sys']
+optional-deps = ['hermit-abi', 'libc', 'windows-sys']
+
+[[target-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'jpeg-decoder'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['rayon']
+optional-deps = ['rayon']
+
+[[target-package]]
+name = 'js-sys'
+version = '0.3.64'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'kv-log-macro'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[target-package]]
+name = 'linux-raw-sys'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['errno', 'general', 'ioctl', 'no_std']
+
+[[target-package]]
+name = 'lock_api'
+version = '0.4.10'
+crates-io = true
+status = 'transitive'
+features = ['atomic_usize', 'default']
+
+[[target-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = ['kv_unstable', 'std', 'value-bag']
+optional-deps = ['value-bag']
+
+[[target-package]]
+name = 'loom'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'matchers'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'matchit'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'memoffset'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'micromath'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mime'
+version = '0.3.17'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'minicbor'
+version = '0.13.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'derive', 'minicbor-derive', 'std']
+optional-deps = ['minicbor-derive']
+
+[[target-package]]
+name = 'minimal-lexical'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'miniz_oxide'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'miniz_oxide'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = ['no_extern_crate_alloc']
+
+[[target-package]]
+name = 'miniz_oxide'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['with-alloc']
+
+[[target-package]]
+name = 'mio'
+version = '0.8.8'
+crates-io = true
+status = 'transitive'
+features = ['net', 'os-ext', 'os-poll']
+
+[[target-package]]
+name = 'modality-ingest-client'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'native-tls'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nom'
+version = '7.1.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'nu-ansi-term'
+version = '0.46.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-integer'
+version = '0.1.45'
+crates-io = true
+status = 'transitive'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'num-iter'
+version = '0.1.43'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'num-rational'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'num_cpus'
+version = '1.16.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'object'
+version = '0.31.1'
+crates-io = true
+status = 'transitive'
+features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned']
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'openssl'
+version = '0.10.55'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'openssl-probe'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'openssl-sys'
+version = '0.9.90'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'os_str_bytes'
+version = '6.5.1'
+crates-io = true
+status = 'transitive'
+features = ['raw_os_str']
+
+[[target-package]]
+name = 'overload'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parking'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '2.3.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pinned'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'png'
+version = '0.16.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'deflate', 'png-encoding']
+optional-deps = ['deflate']
+
+[[target-package]]
+name = 'polling'
+version = '2.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.17'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'prost'
+version = '0.11.9'
+crates-io = true
+status = 'transitive'
+features = ['default', 'prost-derive', 'std']
+optional-deps = ['prost-derive']
+
+[[target-package]]
+name = 'prost-types'
+version = '0.11.9'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[target-package]]
+name = 'rand'
+version = '0.8.5'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'rand_chacha', 'small_rng', 'std', 'std_rng']
+optional-deps = ['libc', 'rand_chacha']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_core'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.6.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rayon'
+version = '1.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rayon-core'
+version = '1.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rdrand'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.2.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_users'
+version = '0.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'regex-syntax', 'std']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'meta', 'nfa-pikevm', 'nfa-thompson', 'std', 'syntax', 'unicode-case', 'unicode-perl', 'unicode-word-boundary']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.29'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'rustc-demangle'
+version = '0.1.23'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustix'
+version = '0.37.20'
+crates-io = true
+status = 'transitive'
+features = ['default', 'fs', 'io-lifetimes', 'libc', 'std', 'use-libc-auxv']
+optional-deps = ['io-lifetimes', 'libc']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'schannel'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scoped-tls'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scoped_threadpool'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sdl2'
+version = '0.32.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'sdl2-sys'
+version = '0.32.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'security-framework'
+version = '2.9.2'
+crates-io = true
+status = 'transitive'
+features = ['OSX_10_9', 'default']
+
+[[target-package]]
+name = 'security-framework-sys'
+version = '2.9.1'
+crates-io = true
+status = 'transitive'
+features = ['OSX_10_9', 'default']
+
+[[target-package]]
+name = 'serde-wasm-bindgen'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde_json'
+version = '1.0.105'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'serde_urlencoded'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sharded-slab'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'signal-hook'
+version = '0.3.17'
+crates-io = true
+status = 'transitive'
+features = ['channel', 'iterator']
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'smallvec'
+version = '1.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'socket2'
+version = '0.4.9'
+crates-io = true
+status = 'transitive'
+features = ['all']
+
+[[target-package]]
+name = 'spin'
+version = '0.9.8'
+crates-io = true
+status = 'transitive'
+features = ['barrier', 'default', 'lazy', 'lock_api', 'lock_api_crate', 'mutex', 'once', 'rwlock', 'spin_mutex']
+optional-deps = ['lock_api_crate']
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sync_wrapper'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'termcolor'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'textwrap'
+version = '0.16.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.1.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tiff'
+version = '0.6.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'time'
+version = '0.1.45'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tinyvec'
+version = '1.6.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'tinyvec_macros']
+optional-deps = ['tinyvec_macros']
+
+[[target-package]]
+name = 'tinyvec_macros'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-io-timeout'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-native-tls'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-stream'
+version = '0.1.14'
+crates-io = true
+status = 'transitive'
+features = ['default', 'net', 'time']
+
+[[target-package]]
+name = 'tokio-util'
+version = '0.7.8'
+crates-io = true
+status = 'transitive'
+features = ['codec', 'default', 'tracing']
+optional-deps = ['tracing']
+
+[[target-package]]
+name = 'tonic'
+version = '0.9.2'
+crates-io = true
+status = 'transitive'
+features = ['channel', 'codegen', 'default', 'prost', 'transport']
+optional-deps = ['async-trait', 'axum', 'h2', 'hyper', 'hyper-timeout', 'prost', 'tokio', 'tower']
+
+[[target-package]]
+name = 'tower'
+version = '0.4.13'
+crates-io = true
+status = 'transitive'
+features = ['__common', 'balance', 'buffer', 'discover', 'futures-core', 'futures-util', 'indexmap', 'limit', 'load', 'make', 'pin-project', 'pin-project-lite', 'rand', 'ready-cache', 'slab', 'timeout', 'tokio', 'tokio-util', 'tracing', 'util']
+optional-deps = ['futures-core', 'futures-util', 'indexmap', 'pin-project', 'pin-project-lite', 'rand', 'slab', 'tokio', 'tokio-util', 'tracing']
+
+[[target-package]]
+name = 'tower-layer'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-service'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing-log'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = ['log-tracer', 'std']
+
+[[target-package]]
+name = 'try-lock'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-bidi'
+version = '0.3.13'
+crates-io = true
+status = 'transitive'
+features = ['hardcoded-data', 'std']
+
+[[target-package]]
+name = 'unicode-normalization'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'url'
+version = '2.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'uuid'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'getrandom', 'std', 'v4']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'valuable'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'value-bag'
+version = '1.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'waker-fn'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'want'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wasi'
+version = '0.10.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'wasi'
+version = '0.11.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'weezl'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'knownfolders', 'minwinbase', 'minwindef', 'ntdef', 'ntsecapi', 'objbase', 'processenv', 'profileapi', 'shlobj', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'ws2ipdef', 'ws2tcpip']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Globalization', 'Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_Memory', 'Win32_System_SystemInformation', 'default']
+
+[[target-package]]
+name = 'windows-sys'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_NetworkManagement', 'Win32_NetworkManagement_IpHelper', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Security_Authentication', 'Win32_Security_Authentication_Identity', 'Win32_Security_Credentials', 'Win32_Security_Cryptography', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_IO', 'Win32_System_LibraryLoader', 'Win32_System_Memory', 'Win32_System_Pipes', 'Win32_System_SystemServices', 'Win32_System_Threading', 'Win32_System_WindowsProgramming', 'default']
+
+[[target-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'initial'
+features = ['default']
+
+[[host-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'initial'
+features = ['default']
+
+[[host-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[host-package]]
+name = 'melpo-config'
+version = '0.1.0'
+workspace-path = 'platforms/melpomene/melpo-config'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'mnemos-config'
+version = '0.1.0'
+workspace-path = 'source/config'
+status = 'workspace'
+features = ['default', 'use-std']
+optional-deps = ['miette', 'toml']
+
+[[host-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['async-await']
+
+[[host-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['defmt', 'serde']
+
+[[host-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[host-package]]
+name = 'miette'
+version = '5.10.0'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'backtrace-ext', 'default', 'fancy', 'fancy-no-backtrace', 'is-terminal', 'owo-colors', 'supports-color', 'supports-hyperlinks', 'supports-unicode', 'terminal_size', 'textwrap']
+optional-deps = ['backtrace', 'backtrace-ext', 'is-terminal', 'owo-colors', 'supports-color', 'supports-hyperlinks', 'supports-unicode', 'terminal_size', 'textwrap']
+
+[[host-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[host-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive', 'use-std']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[host-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'toml'
+version = '0.7.6'
+crates-io = true
+status = 'direct'
+features = ['default', 'display', 'parse']
+optional-deps = ['toml_edit']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'addr2line'
+version = '0.20.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'adler'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'async-trait'
+version = '0.1.72'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'backtrace'
+version = '0.3.68'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'backtrace-ext'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'bumpalo'
+version = '3.13.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cc'
+version = '1.0.79'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'clap_derive'
+version = '3.2.25'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[host-package]]
+name = 'either'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'equivalent'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[host-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[host-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[host-package]]
+name = 'gimli'
+version = '0.27.3'
+crates-io = true
+status = 'transitive'
+features = ['read', 'read-core']
+
+[[host-package]]
+name = 'gloo-worker-macros'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.14.0'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
+name = 'heck'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'indexmap'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'io-lifetimes'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = ['close', 'default', 'hermit-abi', 'libc', 'windows-sys']
+optional-deps = ['windows-sys']
+
+[[host-package]]
+name = 'is-terminal'
+version = '0.4.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'is_ci'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itertools'
+version = '0.10.5'
+crates-io = true
+status = 'transitive'
+features = ['use_alloc']
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'miette-derive'
+version = '5.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'minicbor-derive'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'miniz_oxide'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'object'
+version = '0.31.1'
+crates-io = true
+status = 'transitive'
+features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned']
+
+[[host-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'openssl-macros'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'owo-colors'
+version = '3.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pkg-config'
+version = '0.3.27'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-crate'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'prost-derive'
+version = '0.11.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rustc-demangle'
+version = '0.1.23'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'serde_spanned'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'smawk'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-color'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-hyperlinks'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'supports-unicode'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'terminal_size'
+version = '0.1.17'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.15.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'smawk', 'unicode-linebreak', 'unicode-width']
+optional-deps = ['smawk', 'unicode-linebreak', 'unicode-width']
+
+[[host-package]]
+name = 'thiserror'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thiserror-impl'
+version = '1.0.47'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-macros'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'toml_datetime'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = ['serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'toml_edit'
+version = '0.19.14'
+crates-io = true
+status = 'transitive'
+features = ['default', 'serde']
+optional-deps = ['serde', 'serde_spanned']
+
+[[host-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-linebreak'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'vcpkg'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wasm-bindgen-backend'
+version = '0.2.87'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-macro'
+version = '0.2.87'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-macro-support'
+version = '0.2.87'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-shared'
+version = '0.2.87'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['handleapi', 'processenv', 'winbase', 'wincon', 'winnt']
+
+[[host-package]]
+name = 'windows-sys'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Threading', 'default']
+
+[[host-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winnow'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']

--- a/fixtures/large/summaries/mnemos_b3b4da9-7.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-7.toml
@@ -1,0 +1,633 @@
+# This summary was @generated. To regenerate, run:
+#   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
+
+[metadata]
+resolver = '1'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
+
+[metadata.host-platform]
+spec = 'any'
+
+[metadata.target-platform]
+spec = 'always'
+[[metadata.omitted-packages.ids]]
+name = 'defmt-parser'
+version = '0.3.3'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'event-listener'
+version = '2.5.3'
+crates-io = true
+
+[[metadata.features-only]]
+name = 'mnemos-x86_64-bootloader'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/bootloader'
+features = []
+
+[[target-package]]
+name = 'melpo-config'
+version = '0.1.0'
+workspace-path = 'platforms/melpomene/melpo-config'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'initial'
+features = ['mnemos-trace-proto', 'serial-trace', 'tracing-core', 'tracing-serde-structured']
+optional-deps = ['mnemos-trace-proto', 'tracing-core', 'tracing-serde-structured']
+
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'workspace'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'workspace'
+features = ['default', 'use-std']
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive', 'use-std']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'default', 'std', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'getrandom', 'rng', 'serde', 'std', 'v4']
+optional-deps = ['getrandom', 'serde']
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-executor'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'slab']
+
+[[target-package]]
+name = 'getrandom'
+version = '0.2.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vergen'
+version = '8.2.1'
+crates-io = true
+status = 'direct'
+features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
+optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'autocfg'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'const_format_proc_macros'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'defmt-macros'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-project-internal'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'postcard-derive'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-error'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'syn', 'syn-error']
+optional-deps = ['syn']
+
+[[host-package]]
+name = 'proc-macro-error-attr'
+version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.66'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.32'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rustc_version'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustversion'
+version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.188'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'syn'
+version = '1.0.109'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.29'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'time'
+version = '0.3.22'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'formatting', 'parsing', 'std']
+optional-deps = ['itoa']
+
+[[host-package]]
+name = 'time-core'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tracing-attributes'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []

--- a/fixtures/src/json.rs
+++ b/fixtures/src/json.rs
@@ -158,6 +158,8 @@ pub static METADATA_LIBRA_F0091A4_PATH: &str = "../large/metadata_libra_f0091a4.
 
 pub static METADATA_LIBRA_9FFD93B_PATH: &str = "../large/metadata_libra_9ffd93b.json";
 
+pub static MNEMOS_B3B4DA9_PATH: &str = "../large/mnemos_b3b4da9.json";
+
 pub static METADATA_GUPPY_78CB7E8_PATH: &str = "../guppy/metadata_guppy_78cb7e8.json";
 
 pub static METADATA_GUPPY_869476C_PATH: &str = "../guppy/metadata_guppy_869476c.json";
@@ -214,6 +216,7 @@ define_fixtures! {
     metadata_libra => METADATA_LIBRA_PATH,
     metadata_libra_f0091a4 => METADATA_LIBRA_F0091A4_PATH,
     metadata_libra_9ffd93b => METADATA_LIBRA_9FFD93B_PATH,
+    mnemos_b3b4da9 => MNEMOS_B3B4DA9_PATH,
     metadata_guppy_78cb7e8 => METADATA_GUPPY_78CB7E8_PATH,
     metadata_guppy_869476c => METADATA_GUPPY_869476C_PATH,
     metadata_guppy_c9b4f76 => METADATA_GUPPY_C9B4F76_PATH,
@@ -1324,6 +1327,12 @@ impl FixtureDetails {
                 METADATA_LIBRA_MOVE_LANG,
             ],
         ])
+    }
+
+    pub(crate) fn mnemos_b3b4da9() -> Self {
+        let details = AHashMap::new();
+
+        Self::new(details)
     }
 
     pub(crate) fn metadata_guppy_78cb7e8() -> Self {

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -463,8 +463,10 @@ impl PackageDataValue {
                 }
             }
             None => {
-                // XXX warn here?
-                ResolvedName::LibNameNotSpecified(package.name.replace('-', "_"))
+                // This means that it's a weird case like a binary-only dependency (not part of
+                // stable Rust as of 2023-11). This will typically be reflected as an empty resolved
+                // name.
+                ResolvedName::NoLibTarget
             }
         };
 
@@ -485,6 +487,7 @@ enum ResolvedName {
     LibNameSpecified(String),
     /// This variant has its - replaced with _.
     LibNameNotSpecified(String),
+    NoLibTarget,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -492,6 +495,7 @@ enum ReqResolvedName<'g> {
     Renamed(String),
     LibNameSpecified(&'g str),
     LibNameNotSpecified(&'g str),
+    NoLibTarget,
 }
 
 impl<'g> ReqResolvedName<'g> {
@@ -503,6 +507,7 @@ impl<'g> ReqResolvedName<'g> {
         match resolved_name {
             ResolvedName::LibNameSpecified(name) => Self::LibNameSpecified(name),
             ResolvedName::LibNameNotSpecified(name) => Self::LibNameNotSpecified(name),
+            ResolvedName::NoLibTarget => Self::NoLibTarget,
         }
     }
 
@@ -511,6 +516,7 @@ impl<'g> ReqResolvedName<'g> {
             Self::Renamed(rename) => rename == name,
             Self::LibNameSpecified(resolved_name) => *resolved_name == name,
             Self::LibNameNotSpecified(resolved_name) => *resolved_name == name,
+            Self::NoLibTarget => name.is_empty(),
         }
     }
 }

--- a/guppy/tests/graph-tests/graph_tests.rs
+++ b/guppy/tests/graph-tests/graph_tests.rs
@@ -444,6 +444,14 @@ mod large {
     }
 
     proptest_suite!(metadata_libra_9ffd93b);
+
+    #[test]
+    fn mnemos_b3b4da9() {
+        let metadata = JsonFixture::mnemos_b3b4da9();
+        metadata.verify();
+    }
+
+    proptest_suite!(mnemos_b3b4da9);
 }
 
 mod guppy_tests {


### PR DESCRIPTION
Some dependencies don't have lib targets. While they can't be depended on in stable Rust, there's a nightly Rust feature that enables use of binary-only dependencies. In those cases, the `resolved_name` is an empty string.

Also added mnemos to our corpus.