### PR TITLE
[guppy] fix a hakari bug

### DIFF
--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
@@ -94,6 +94,13 @@ status = 'direct'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'assert_matches'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'cargo'
 version = '0.46.0'
 source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
@@ -121,6 +128,13 @@ crates-io = true
 status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
 optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+
+[[host-package]]
+name = 'criterion'
+version = '0.3.3'
+crates-io = true
+status = 'direct'
+features = ['default']
 
 [[host-package]]
 name = 'dialoguer'
@@ -365,6 +379,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'cast'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'cc'
 version = '1.0.61'
 crates-io = true
@@ -417,6 +438,35 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'criterion-plot'
+version = '0.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-channel'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-deque'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-epoch'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
 name = 'crossbeam-utils'
 version = '0.7.2'
 crates-io = true
@@ -430,6 +480,20 @@ version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'csv'
+version = '1.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'csv-core'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'curl'
@@ -516,6 +580,13 @@ features = []
 [[host-package]]
 name = 'globset'
 version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'half'
+version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -684,11 +755,25 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'maybe-uninit'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'memchr'
 version = '2.3.3'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std', 'use_std']
+
+[[host-package]]
+name = 'memoffset'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'num-integer'
@@ -707,6 +792,13 @@ features = ['default', 'std']
 [[host-package]]
 name = 'num_cpus'
 version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'oorandom'
+version = '11.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -731,6 +823,13 @@ version = '0.3.18'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'plotters'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = ['area_series', 'line_series', 'svg']
 
 [[host-package]]
 name = 'ppv-lite86'
@@ -827,6 +926,20 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'rayon'
+version = '1.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rayon-core'
+version = '1.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'regex'
 version = '1.3.9'
 crates-io = true
@@ -863,6 +976,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'rustc_version'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'rustfix'
 version = '0.5.1'
 crates-io = true
@@ -892,11 +1012,32 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
 name = 'semver-parser'
 version = '0.7.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'serde_cbor'
+version = '0.11.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'serde_derive'
@@ -1015,6 +1156,13 @@ features = []
 [[host-package]]
 name = 'time'
 version = '0.1.44'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tinytemplate'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-5.toml
@@ -156,6 +156,13 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'pretty_assertions'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
@@ -300,6 +307,20 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'ctor'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
 name = 'either'
 version = '1.6.1'
 crates-io = true
@@ -396,6 +417,13 @@ version = '0.2.12'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[host-package]]
+name = 'output_vt100'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'ppv-lite86'

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
@@ -97,6 +97,13 @@ status = 'direct'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'assert_matches'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true

--- a/fixtures/large/summaries/metadata_libra-0.toml
+++ b/fixtures/large/summaries/metadata_libra-0.toml
@@ -1662,6 +1662,28 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'libra-failure-ext'
+version = '0.1.0'
+workspace-path = 'common/failure-ext'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-failure-macros'
+version = '0.1.0'
+workspace-path = 'common/failure-ext/failure-macros'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'failure'
+version = '0.1.5'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[host-package]]
 name = 'grpcio-compiler'
 version = '0.5.0-alpha.2'
 crates-io = true
@@ -1856,14 +1878,6 @@ version = '1.5.2'
 crates-io = true
 status = 'transitive'
 features = ['default', 'use_std']
-
-[[host-package]]
-name = 'failure'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
-optional-deps = ['backtrace', 'failure_derive']
 
 [[host-package]]
 name = 'failure_derive'

--- a/fixtures/large/summaries/metadata_libra-1.toml
+++ b/fixtures/large/summaries/metadata_libra-1.toml
@@ -1801,6 +1801,14 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'failure'
+version = '0.1.5'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'std']
+optional-deps = ['backtrace']
+
+[[host-package]]
 name = 'grpcio-compiler'
 version = '0.5.0-alpha.2'
 crates-io = true
@@ -1979,14 +1987,6 @@ version = '1.5.2'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'failure'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['backtrace', 'std']
-optional-deps = ['backtrace']
 
 [[host-package]]
 name = 'failure_derive'

--- a/fixtures/large/summaries/metadata_libra-7.toml
+++ b/fixtures/large/summaries/metadata_libra-7.toml
@@ -1664,6 +1664,28 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'libra-failure-ext'
+version = '0.1.0'
+workspace-path = 'common/failure-ext'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-failure-macros'
+version = '0.1.0'
+workspace-path = 'common/failure-ext/failure-macros'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'failure'
+version = '0.1.5'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[host-package]]
 name = 'grpcio-compiler'
 version = '0.5.0-alpha.2'
 crates-io = true
@@ -1843,14 +1865,6 @@ version = '1.5.2'
 crates-io = true
 status = 'transitive'
 features = ['default', 'use_std']
-
-[[host-package]]
-name = 'failure'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
-optional-deps = ['backtrace', 'failure_derive']
 
 [[host-package]]
 name = 'failure_derive'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-0.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-0.toml
@@ -122,6 +122,13 @@ status = 'direct'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'assert_approx_eq'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'byteorder'
 version = '1.3.4'
 crates-io = true
@@ -309,6 +316,14 @@ version = '1.0.0'
 crates-io = true
 status = 'direct'
 features = []
+
+[[host-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
 
 [[host-package]]
 name = 'serde'
@@ -1014,6 +1029,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'rand'
 version = '0.4.6'
 crates-io = true
@@ -1473,6 +1495,13 @@ features = []
 [[host-package]]
 name = 'url'
 version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
@@ -49,6 +49,14 @@ status = 'initial'
 features = []
 
 [[host-package]]
+name = 'futures'
+version = '0.3.4'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[host-package]]
 name = 'tokio'
 version = '0.2.13'
 crates-io = true
@@ -86,11 +94,62 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'futures-channel'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[host-package]]
 name = 'futures-core'
 version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-executor'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'futures-io'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'futures-macro'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'futures-util'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
 
 [[host-package]]
 name = 'iovec'
@@ -159,6 +218,27 @@ features = []
 [[host-package]]
 name = 'pin-project-lite'
 version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-hack'
+version = '0.5.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-5.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-5.toml
@@ -3416,6 +3416,13 @@ status = 'initial'
 features = []
 
 [[host-package]]
+name = 'anyhow'
+version = '1.0.26'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'async-trait'
 version = '0.1.24'
 crates-io = true
@@ -3490,13 +3497,6 @@ features = ['default', 'rustfmt', 'transport']
 [[host-package]]
 name = 'aho-corasick'
 version = '0.7.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'anyhow'
-version = '1.0.26'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']

--- a/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
@@ -72,9 +72,23 @@ status = 'workspace'
 features = ['default']
 
 [[host-package]]
+name = 'compiler'
+version = '0.1.0'
+workspace-path = 'language/compiler'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
 name = 'datatest-stable'
 version = '0.1.0'
 workspace-path = 'common/datatest-stable'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'functional-tests'
+version = '0.1.0'
+workspace-path = 'language/functional-tests'
 status = 'workspace'
 features = []
 
@@ -91,6 +105,13 @@ version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'workspace'
 features = ['default']
+
+[[host-package]]
+name = 'language-e2e-tests'
+version = '0.1.0'
+workspace-path = 'language/e2e-tests'
+status = 'workspace'
+features = []
 
 [[host-package]]
 name = 'libra-canonical-serialization'
@@ -252,6 +273,13 @@ features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
 [[host-package]]
+name = 'aho-corasick'
+version = '0.7.8'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'anyhow'
 version = '1.0.26'
 crates-io = true
@@ -367,6 +395,13 @@ source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ad
 status = 'direct'
 features = ['serde', 'std', 'u64_backend']
 optional-deps = ['serde']
+
+[[host-package]]
+name = 'filecheck'
+version = '0.4.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'futures'
@@ -699,13 +734,6 @@ version = '0.5.2'
 source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
 status = 'direct'
 features = ['std', 'u64_backend']
-
-[[host-package]]
-name = 'aho-corasick'
-version = '0.7.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'ansi_term'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
@@ -1166,6 +1166,13 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'anyhow'
+version = '1.0.26'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'proc-macro2'
 version = '1.0.8'
 crates-io = true
@@ -1207,13 +1214,6 @@ version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'rustfmt', 'transport']
-
-[[host-package]]
-name = 'anyhow'
-version = '1.0.26'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'async-stream-impl'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
@@ -696,6 +696,20 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'assert_approx_eq'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'assert_matches'
+version = '1.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'async-trait'
 version = '0.1.24'
 crates-io = true
@@ -740,6 +754,13 @@ status = 'direct'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'bitvec'
+version = '0.10.2'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
 name = 'byteorder'
 version = '1.3.4'
 crates-io = true
@@ -752,6 +773,13 @@ version = '0.5.4'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
+
+[[host-package]]
+name = 'cached'
+version = '0.11.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'chashmap'
@@ -923,6 +951,13 @@ status = 'direct'
 features = ['std']
 
 [[host-package]]
+name = 'goldenfile'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'hex'
 version = '0.4.2'
 crates-io = true
@@ -1080,6 +1115,13 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'prettydiff'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'proc-macro2'
 version = '1.0.8'
 crates-io = true
@@ -1188,6 +1230,13 @@ crates-io = true
 status = 'direct'
 features = ['__tls', 'blocking', 'hyper-rustls', 'json', 'rustls', 'rustls-tls', 'serde_json', 'tokio-rustls', 'webpki-roots']
 optional-deps = ['hyper-rustls', 'rustls', 'serde_json', 'tokio-rustls', 'webpki-roots']
+
+[[host-package]]
+name = 'ripemd160'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'rocksdb'
@@ -1352,6 +1401,20 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'statistical'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'stats_alloc'
+version = '0.1.8'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
 name = 'structopt'
 version = '0.3.9'
 crates-io = true
@@ -1379,6 +1442,13 @@ crates-io = true
 status = 'direct'
 features = ['clone-impls', 'default', 'derive', 'extra-traits', 'fold', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
 optional-deps = ['quote']
+
+[[host-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'termcolor'
@@ -1512,6 +1582,13 @@ features = []
 [[host-package]]
 name = 'adler32'
 version = '1.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ansi_term'
+version = '0.9.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1943,6 +2020,13 @@ version = '1.5.3'
 crates-io = true
 status = 'transitive'
 features = ['default', 'use_std']
+
+[[host-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'encoding_rs'
@@ -2607,6 +2691,14 @@ status = 'transitive'
 features = ['simd', 'std']
 
 [[host-package]]
+name = 'prettytable-rs'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['csv', 'default', 'win_crlf']
+optional-deps = ['csv']
+
+[[host-package]]
 name = 'proc-macro-crate'
 version = '0.1.4'
 crates-io = true
@@ -3062,6 +3154,20 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'structopt'
+version = '0.2.18'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'structopt-derive'
+version = '0.2.18'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'structopt-derive'
 version = '0.4.2'
 crates-io = true
@@ -3112,11 +3218,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'tempfile'
-version = '3.1.0'
+name = 'term'
+version = '0.5.2'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default']
 
 [[host-package]]
 name = 'term'

--- a/fixtures/small/summaries/metadata_alternate_registries-0.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-0.toml
@@ -31,8 +31,36 @@ status = 'initial'
 features = []
 
 [[host-package]]
+name = 'serde_json'
+version = '1.0.68'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'unicode-xid'
 version = '0.2.2'
 crates-io = true
 status = 'direct'
 features = ['default']
+
+[[host-package]]
+name = 'itoa'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'serde'
+version = '1.0.130'
+crates-io = true
+status = 'transitive'
+features = ['std']

--- a/fixtures/small/summaries/metadata_alternate_registries-6.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-6.toml
@@ -31,8 +31,36 @@ features = ['serde']
 optional-deps = ['serde']
 
 [[host-package]]
+name = 'serde_json'
+version = '1.0.68'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'unicode-xid'
 version = '0.2.2'
 crates-io = true
 status = 'direct'
 features = ['default']
+
+[[host-package]]
+name = 'itoa'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'serde'
+version = '1.0.130'
+crates-io = true
+status = 'transitive'
+features = ['std']

--- a/fixtures/small/summaries/metadata_dups-4.toml
+++ b/fixtures/small/summaries/metadata_dups-4.toml
@@ -34,7 +34,21 @@ features = []
 
 [[host-package]]
 name = 'bytes'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'bytes'
 version = '0.5.4'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
+
+[[host-package]]
+name = 'lazy_static'
+version = '0.2.11'
+crates-io = true
+status = 'direct'
+features = []

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -63,7 +63,7 @@ impl<'a> CargoOptions<'a> {
     /// This does not affect transitive dependencies -- for example, a build or dev-dependency's
     /// further dev-dependencies are never followed.
     ///
-    /// The default is true, which matches what a plain `cargo build` does.
+    /// The default is false, which matches what a plain `cargo build` does.
     pub fn set_include_dev(&mut self, include_dev: bool) -> &mut Self {
         self.include_dev = include_dev;
         self

--- a/guppy/src/graph/feature/feature_list.rs
+++ b/guppy/src/graph/feature/feature_list.rs
@@ -18,7 +18,7 @@ use std::{fmt, slice, vec};
 /// This provides a convenient way to query and print out lists of features.
 ///
 /// Returned by methods on `FeatureSet`.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct FeatureList<'g> {
     package: PackageMetadata<'g>,
     labels: SortedSet<FeatureLabel<'g>>,
@@ -113,6 +113,15 @@ impl<'g> FeatureList<'g> {
     }
 }
 
+impl<'g> fmt::Debug for FeatureList<'g> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FeatureList")
+            .field("package", self.package.id())
+            .field("labels", &self.display_features())
+            .finish()
+    }
+}
+
 impl<'g> IntoIterator for FeatureList<'g> {
     type Item = FeatureId<'g>;
     type IntoIter = IntoIter<'g>;
@@ -186,7 +195,7 @@ impl<'g, 'a> Iterator for Iter<'g, 'a> {
 /// A pretty-printer for a list of features.
 ///
 /// Returned by `FeatureList::display_filters`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct DisplayFeatures<'g, 'a>(&'a [FeatureLabel<'g>]);
 
 impl<'g, 'a> fmt::Display for DisplayFeatures<'g, 'a> {
@@ -199,5 +208,12 @@ impl<'g, 'a> fmt::Display for DisplayFeatures<'g, 'a> {
             }
         }
         Ok(())
+    }
+}
+
+impl<'g, 'a> fmt::Debug for DisplayFeatures<'g, 'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Use the Display impl as the debug one because it's easier to read.
+        write!(f, "{}", self)
     }
 }

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use std::fmt;
+
 use crate::{
     debug_ignore::DebugIgnore,
     graph::{
@@ -62,10 +64,18 @@ impl<'g> FeatureGraph<'g> {
 ///
 /// Created by `FeatureQuery::resolve`, the `FeatureGraph::resolve_` methods, or from
 /// `PackageSet::to_feature_set`.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct FeatureSet<'g> {
     graph: DebugIgnore<FeatureGraph<'g>>,
     core: ResolveCore<FeatureGraphSpec>,
+}
+
+impl<'g> fmt::Debug for FeatureSet<'g> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set()
+            .entries(self.packages_with_features(DependencyDirection::Forward))
+            .finish()
+    }
 }
 
 assert_covariant!(FeatureSet);


### PR DESCRIPTION
Proc-macros are host initials for computations, and they can have dev-dependencies. We saw hakari missing out on prettyplease in https://github.com/oxidecomputer/omicron/pull/4965.