### PR TITLE
[guppy] fix out of bounds panic in hakari generate

### DIFF
--- a/guppy/src/petgraph_support/topo.rs
+++ b/guppy/src/petgraph_support/topo.rs
@@ -44,7 +44,7 @@ impl<Ix: IndexType> TopoWithCycles<Ix> {
 
         // Because the graph is NodeCompactIndexable, the indexes are in the range (0..topo.len()).
         // Use this property to build a reverse map.
-        let mut reverse_index = vec![0; topo.len()];
+        let mut reverse_index = vec![0; graph.node_count()];
         topo.iter().enumerate().for_each(|(topo_ix, node_ix)| {
             reverse_index[node_ix.index()] = topo_ix;
         });

--- a/guppy/src/petgraph_support/topo.rs
+++ b/guppy/src/petgraph_support/topo.rs
@@ -42,7 +42,8 @@ impl<Ix: IndexType> TopoWithCycles<Ix> {
         // order.
         topo.reverse();
 
-        // Because the graph is NodeCompactIndexable, the indexes are in the range (0..topo.len()).
+        // Because the graph is NodeCompactIndexable, the indexes are in the range
+        // (0..graph.node_count()).
         // Use this property to build a reverse map.
         let mut reverse_index = vec![0; graph.node_count()];
         topo.iter().enumerate().for_each(|(topo_ix, node_ix)| {


### PR DESCRIPTION
Solves the out of bounds panic in hakari of #255. I believe the graph indices should indeed have range `(0..graph.node_count())`,  but `topo` is filtered, so `topo.len()` might be smaller than `graph.node_count()`.

This change in any case solves it for me.