### PR TITLE
update builtin targets to Rust 1.80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
       # This matches the cfg-expr version.
-      - uses: dtolnay/rust-toolchain@1.75.0
+      - uses: dtolnay/rust-toolchain@1.80.0
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2
       - name: Build and test
         run: cargo test --package cargo-compare --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,10 +40,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e35ed54e5ea7997c14ed4c70ba043478db1112e98263b3b035907aa197d991"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
 
 [[package]]
 name = "ansi_term"
@@ -56,15 +72,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -171,9 +188,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -210,9 +227,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitmaps"
@@ -244,15 +261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "btoi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,10 +289,11 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.76.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cb275625d5f6445b70d6c544230c3db747dd8b23ae65faa7d5d095e4f6d293"
+checksum = "f24c9dcadcdad2f6fa2553b63d5e9c9700fa6932b75d53f3b11b8aea35ebab99"
 dependencies = [
+ "annotate-snippets",
  "anstream",
  "anstyle",
  "anyhow",
@@ -296,7 +305,8 @@ dependencies = [
  "cargo-credential-wincred",
  "cargo-platform",
  "cargo-util",
- "clap 4.4.18",
+ "cargo-util-schemas",
+ "clap 4.5.11",
  "color-print",
  "crates-io",
  "curl",
@@ -306,7 +316,6 @@ dependencies = [
  "git2",
  "git2-curl",
  "gix",
- "gix-features 0.35.0",
  "glob",
  "hex",
  "hmac",
@@ -316,7 +325,7 @@ dependencies = [
  "ignore",
  "im-rc",
  "indexmap 2.2.6",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "jobserver",
  "lazycell",
  "libc",
@@ -326,32 +335,33 @@ dependencies = [
  "os_info",
  "pasetors",
  "pathdiff",
- "pulldown-cmark",
  "rand",
+ "regex",
+ "rusqlite",
  "rustfix",
+ "same-file",
  "semver",
  "serde",
  "serde-untagged",
- "serde-value",
  "serde_ignored",
  "serde_json",
  "sha1",
  "shell-escape",
  "supports-hyperlinks",
- "syn 2.0.48",
+ "supports-unicode",
  "tar",
  "tempfile",
  "time",
- "toml 0.8.9",
- "toml_edit 0.20.7",
+ "toml 0.8.16",
+ "toml_edit 0.22.17",
  "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
  "unicase",
  "unicode-width",
- "unicode-xid",
  "url",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -376,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb63e2bf69272d1d7236a7d3083a75a8437c9ce69465a1665caa7c3a213d757"
+checksum = "3a3e7c625670eacbefd48f552588c491eccc79a85a96898af13af7b312d1c4cd"
 dependencies = [
  "anyhow",
  "libc",
@@ -386,14 +396,14 @@ dependencies = [
  "serde_json",
  "thiserror",
  "time",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e66f527855fced262c773931afd15340dcb0b5094f009fcb97e51dde994bc09"
+checksum = "7133c8156697989e0d3547f886083bdcb4d7463be67699c37c206152e46925b0"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -402,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07c6d49412548e3bbe9824c9259253bf0355e9f4bd22aa859ea22db154ac0b5"
+checksum = "5e238786dd6bc99a94a99a108a0fedcc7e786a86c81b8e9857da88ca3caac3d0"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -412,12 +422,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2353aca6dcb405fab527445d65bf35b64b56f47509bba516bb0be2800f70b4"
+checksum = "cc0e24a553bb387e22fd5a18f49b72f15db22426b5a0cd37c5fc804978f5ce13"
 dependencies = [
  "cargo-credential",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -445,7 +455,7 @@ version = "0.9.29"
 dependencies = [
  "camino",
  "cfg-if",
- "clap 4.4.18",
+ "clap 4.5.11",
  "color-eyre",
  "dialoguer",
  "duct",
@@ -471,14 +481,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.8"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2bdd1d8ab2353ddd763881eaba60cb53f1deee0ff9d271b9f0e4cdbcd063fb"
+checksum = "14104698cb1694d43c2ff73492468ccf2bb0b047071a9838d999eeba9e984ffa"
 dependencies = [
  "anyhow",
  "core-foundation",
  "filetime",
  "hex",
+ "ignore",
  "jobserver",
  "libc",
  "miow",
@@ -488,7 +499,23 @@ dependencies = [
  "tempfile",
  "tracing",
  "walkdir",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddc7fc157e3dbbd88f05ef8be7c3ed3ecb05925a3f51f716d6103a607fb7c4"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror",
+ "toml 0.8.16",
+ "unicode-xid",
+ "url",
 ]
 
 [[package]]
@@ -523,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.6"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6100bc57b6209840798d95cb2775684849d332f7bd788db2a8c8caf7ef82a41a"
+checksum = "345c78335be0624ed29012dc10c49102196c6882c12dde65d9f35b02da2aada8"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -598,24 +625,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
- "clap_derive 4.4.7",
+ "clap_derive 4.5.11",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
- "strsim 0.10.0",
+ "clap_lex 0.7.2",
+ "strsim 0.11.1",
  "terminal_size",
 ]
 
@@ -634,11 +661,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -655,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "clru"
@@ -680,23 +707,23 @@ dependencies = [
 
 [[package]]
 name = "color-print"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a858372ff14bab9b1b30ea504f2a4bc534582aee3e42ba2d41d2a7baba63d5d"
+checksum = "1ee543c60ff3888934877a5671f45494dd27ed4ba25c6670b9a7576b7ed7a8c0"
 dependencies = [
  "color-print-proc-macro",
 ]
 
 [[package]]
 name = "color-print-proc-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e37866456a721d0a404439a1adae37a31be4e0055590d053dfe6981e05003f"
+checksum = "77ff1a80c5f3cb1ca7c06ffdd71b6a6dd6d8f896c42141fbd43f50ed28dcdb93"
 dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -751,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.39.1"
+version = "0.40.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4530c82103cc1a9c776970623b07b0f5ad097c477b1b0c69d114eb1132db1a8"
+checksum = "3b7837d3d2ea5d21a399489029609840d95608bfdf1dc5fd8604392df4b219b3"
 dependencies = [
  "curl",
  "percent-encoding",
@@ -781,7 +808,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.18",
+ "clap 4.5.11",
  "criterion-plot",
  "is-terminal",
  "itertools 0.10.5",
@@ -878,9 +905,9 @@ checksum = "f3b7eb4404b8195a9abb6356f4ac07d8ba267045c8d6d220ac4dc992e6cc75df"
 
 [[package]]
 name = "curl"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
@@ -888,14 +915,14 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.71+curl-8.6.0"
+version = "0.4.73+curl-8.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b12a7ab780395666cb576203dc3ed6e01513754939a600b85196ccf5356bc5"
+checksum = "450ab250ecf17227c39afb9a2dd9261dc0035cb80f2612472fc0c4aac2dcb84d"
 dependencies = [
  "cc",
  "libc",
@@ -904,7 +931,18 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1152,28 +1190,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "faster-hex"
-version = "0.8.1"
+name = "fallible-iterator"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a"
-dependencies = [
- "serde",
-]
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "faster-hex"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "ff"
@@ -1242,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -1304,11 +1342,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -1331,19 +1369,21 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.55.2"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002667cd1ebb789313d0d0afe3d23b2821cf3b0e91605095f0e6d8751f0ceeea"
+checksum = "984c5018adfa7a4536ade67990b3ebc6e11ab57b3d6cd9968de0947ca99b4b06"
 dependencies = [
  "gix-actor",
  "gix-attributes",
+ "gix-command",
  "gix-commitgraph",
  "gix-config",
  "gix-credentials",
  "gix-date",
  "gix-diff",
+ "gix-dir",
  "gix-discover",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-filter",
  "gix-fs",
  "gix-glob",
@@ -1380,18 +1420,17 @@ dependencies = [
  "prodash",
  "smallvec",
  "thiserror",
- "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-actor"
-version = "0.28.1"
+version = "0.31.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadca029ef716b4378f7afb19f7ee101fde9e58ba1f1445971315ac866db417"
+checksum = "a0e454357e34b833cc3a00b6efbbd3dd4d18b24b9fb0c023876ec2645e8aa3f2"
 dependencies = [
  "bstr",
- "btoi",
  "gix-date",
+ "gix-utils",
  "itoa",
  "thiserror",
  "winnow",
@@ -1399,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.20.1"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f395469d38c76ec47cd1a6c5a53fbc3f13f737b96eaf7535f4e6b367e643381"
+checksum = "e37ce99c7e81288c28b703641b6d5d119aacc45c1a6b247156e6249afa486257"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1416,54 +1455,57 @@ dependencies = [
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b6cd0f246180034ddafac9b00a112f19178135b21eb031b3f79355891f7325"
+checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "003ec6deacf68076a0c157271a127e0bb2c031c1a41f7168cbe5d248d9b85c78"
+checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.2.10"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c576cfbf577f72c097b5f88aedea502cd62952bdc1fb3adcab4531d5525a4c7"
+checksum = "0d76867867da891cbe32021ad454e8cae90242f6afb06762e4dd0d357afd1d7b"
 dependencies = [
  "bstr",
+ "gix-path",
+ "gix-trace",
+ "shell-words",
 ]
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.22.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a7007ba021f059803afaf6f8a48872422abc20550ac12ede6ddea2936cec36"
+checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
 dependencies = [
  "bstr",
  "gix-chunk",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-hash",
- "memmap2 0.9.4",
+ "memmap2",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.31.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cae98c6b4c66c09379bc35274b172587d6b0ac369a416c39128ad8c6454f9bb"
+checksum = "53fafe42957e11d98e354a66b6bd70aeea00faf2f62dd11164188224a507c840"
 dependencies = [
  "bstr",
  "gix-config-value",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-glob",
  "gix-path",
  "gix-ref",
@@ -1478,11 +1520,11 @@ dependencies = [
 
 [[package]]
 name = "gix-config-value"
-version = "0.14.4"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e7bfb37a46ed0b8468db37a6d8a0a61d56bdbe4603ae492cb322e5f3958"
+checksum = "b328997d74dd15dc71b2773b162cb4af9a25c424105e4876e6d0686ab41c383e"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bstr",
  "gix-path",
  "libc",
@@ -1491,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "gix-credentials"
-version = "0.21.0"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5c5d74069b842a1861e581027ac6b7ad9ff66f5911c89b9f45484d7ebda6a4"
+checksum = "198588f532e4d1202e04e6c3f50e4d7c060dffc66801c6f53cc246f1d234739e"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1501,15 +1543,16 @@ dependencies = [
  "gix-path",
  "gix-prompt",
  "gix-sec",
+ "gix-trace",
  "gix-url",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-date"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7f3dfb72bebe3449b5e642be64e3c6ccbe9821c8b8f19f487cf5bfbbf4067e"
+checksum = "9eed6931f21491ee0aeb922751bd7ec97b4b2fe8fbfedcb678e2a2dce5f3b8c0"
 dependencies = [
  "bstr",
  "itoa",
@@ -1519,23 +1562,45 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.37.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931394f69fb8c9ed6afc0aae3487bd869e936339bcc13ed8884472af072e0554"
+checksum = "1996d5c8a305b59709467d80617c9fde48d9d75fd1f4179ea970912630886c9d"
 dependencies = [
+ "bstr",
  "gix-hash",
  "gix-object",
  "thiserror",
 ]
 
 [[package]]
-name = "gix-discover"
-version = "0.26.0"
+name = "gix-dir"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45d5cf0321178883e38705ab2b098f625d609a7d4c391b33ac952eff2c490f2"
+checksum = "60c99f8c545abd63abe541d20ab6cda347de406c0a3f1c80aadc12d9b0e94974"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc27c699b63da66b50d50c00668bc0b7e90c3a382ef302865e891559935f3dbf"
 dependencies = [
  "bstr",
  "dunce",
+ "gix-fs",
  "gix-hash",
  "gix-path",
  "gix-ref",
@@ -1545,30 +1610,20 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.35.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9ff423ae4983f762659040d13dd7a5defbd54b6a04ac3cc7347741cec828cd"
-dependencies = [
- "crossbeam-channel",
- "gix-hash",
- "gix-trace",
- "libc",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d46a4a5c6bb5bebec9c0d18b65ada20e6517dbd7cf855b87dd4bbdce3a771b2"
+checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "flate2",
  "gix-hash",
  "gix-trace",
+ "gix-utils",
  "libc",
  "once_cell",
+ "parking_lot",
  "prodash",
  "sha1_smol",
  "thiserror",
@@ -1577,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.6.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f674d3fdb6b1987b04521ec9a5b7be8650671f2c4bbd17c3c81e2a364242ff"
+checksum = "e6547738da28275f4dff4e9f3a0f28509f53f94dd6bd822733c91cb306bca61a"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1591,46 +1646,49 @@ dependencies = [
  "gix-path",
  "gix-quote",
  "gix-trace",
+ "gix-utils",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.8.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20e86eb040f5776a5ade092282e51cdcad398adb77d948b88d17583c2ae4e107"
+checksum = "6adf99c27cdf17b1c4d77680c917e0d94d8783d4e1c73d3be0d1d63107163d7a"
 dependencies = [
- "gix-features 0.36.1",
+ "fastrand",
+ "gix-features",
+ "gix-utils",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.14.1"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db19298c5eeea2961e5b3bf190767a2d1f09b8802aeb5f258e42276350aff19"
+checksum = "fa7df15afa265cc8abe92813cd354d522f1ac06b29ec6dfa163ad320575cb447"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bstr",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-path",
 ]
 
 [[package]]
 name = "gix-hash"
-version = "0.13.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8cf8c2266f63e582b7eb206799b63aa5fa68ee510ad349f637dfe2d0653de0"
+checksum = "f93d7df7366121b5018f947a04d37f034717e113dcf9ccd85c34b58e57a74d5e"
 dependencies = [
- "faster-hex 0.9.0",
+ "faster-hex",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-hashtable"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb61880816d7ec4f0b20606b498147d480860ddd9133ba542628df2f548d3ca"
+checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
 dependencies = [
  "gix-hash",
  "hashbrown 0.14.3",
@@ -1639,44 +1697,50 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.9.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a215cc8cf21645bca131fcf6329d3ebd46299c47dbbe27df71bb1ca9e328b879"
+checksum = "5e6afb8f98e314d4e1adc822449389ada863c174b5707cedd327d67b84dba527"
 dependencies = [
  "bstr",
  "gix-glob",
  "gix-path",
+ "gix-trace",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-index"
-version = "0.26.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83a4fcc121b2f2e109088f677f89f85e7a8ebf39e8e6659c0ae54d4283b1650"
+checksum = "9a9a44eb55bd84bb48f8a44980e951968ced21e171b22d115d1cdcef82a7d73f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bstr",
- "btoi",
  "filetime",
+ "fnv",
  "gix-bitmap",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.14.3",
  "itoa",
- "memmap2 0.7.1",
+ "libc",
+ "memmap2",
+ "rustix",
  "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "11.0.1"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5c65e6a29830a435664891ced3f3c1af010f14900226019590ee0971a22f37"
+checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -1685,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "gix-macros"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75e7ab728059f595f6ddc1ad8771b8d6a231971ae493d9d5948ecad366ee8bb"
+checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1696,11 +1760,11 @@ dependencies = [
 
 [[package]]
 name = "gix-negotiate"
-version = "0.9.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a5cdcf491ecc9ce39dcc227216c540355fe0024ae7c38e94557752ca5ebb67f"
+checksum = "9ec879fb6307bb63519ba89be0024c6f61b4b9d61f1a91fd2ce572d89fe9c224"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1712,16 +1776,16 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.38.0"
+version = "0.42.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740f2a44267f58770a1cb3a3d01d14e67b089c7136c48d4bddbb3cfd2bf86a51"
+checksum = "25da2f46b4e7c2fa7b413ce4dffb87f69eaf89c2057e386491f4c55cadbfe386"
 dependencies = [
  "bstr",
- "btoi",
  "gix-actor",
  "gix-date",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-hash",
+ "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
@@ -1731,13 +1795,14 @@ dependencies = [
 
 [[package]]
 name = "gix-odb"
-version = "0.54.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8630b56cb80d8fa684d383dad006a66401ee8314e12fbf0e566ddad8c115143b"
+checksum = "20d384fe541d93d8a3bb7d5d5ef210780d6df4f50c4e684ccba32665a5e3bc9b"
 dependencies = [
  "arc-swap",
  "gix-date",
- "gix-features 0.36.1",
+ "gix-features",
+ "gix-fs",
  "gix-hash",
  "gix-object",
  "gix-pack",
@@ -1750,19 +1815,19 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.44.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1431ba2e30deff1405920693d54ab231c88d7c240dd6ccc936ee223d8f8697c3"
+checksum = "3e0594491fffe55df94ba1c111a6566b7f56b3f8d2e1efc750e77d572f5f5229"
 dependencies = [
  "clru",
  "gix-chunk",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "gix-path",
  "gix-tempfile",
- "memmap2 0.7.1",
+ "memmap2",
  "parking_lot",
  "smallvec",
  "thiserror",
@@ -1770,31 +1835,33 @@ dependencies = [
 
 [[package]]
 name = "gix-packetline"
-version = "0.16.7"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8384b1e964151aff0d5632dd9b191059d07dff358b96bd940f1b452600d7ab"
+checksum = "b70486beda0903b6d5b65dfa6e40585098cdf4e6365ca2dff4f74c387354a515"
 dependencies = [
  "bstr",
- "faster-hex 0.8.1",
+ "faster-hex",
+ "gix-trace",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-packetline-blocking"
-version = "0.16.6"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8395f7501c84d6a1fe902035fdfd8cd86d89e2dd6be0200ec1a72fd3c92d39"
+checksum = "c31d42378a3d284732e4d589979930d0d253360eccf7ec7a80332e5ccb77e14a"
 dependencies = [
  "bstr",
- "faster-hex 0.8.1",
+ "faster-hex",
+ "gix-trace",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.5"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e9ad649bf5e109562d6acba657ca428661ec08e77eaf3a755d8fa55485be9c"
+checksum = "8d23d5bbda31344d8abc8de7c075b3cf26e5873feba7c4a15d916bce67382bd9"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -1805,11 +1872,11 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.4.1"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbbb92f75a38ef043c8bb830b339b38d0698d7f3746968b5fcbade7a880494d"
+checksum = "d307d1b8f84dc8386c4aa20ce0cf09242033840e15469a3ecba92f10cfb5c046"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1820,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "gix-prompt"
-version = "0.7.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9a913769516f5e9d937afac206fb76428e3d7238e538845842887fda584678"
+checksum = "7e0595d2be4b6d6a71a099e989bdd610882b882da35fb8503d91d6f81aa0936f"
 dependencies = [
  "gix-command",
  "gix-config-value",
@@ -1833,17 +1900,17 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.41.1"
+version = "0.45.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391e3feabdfa5f90dad6673ce59e3291ac28901b2ff248d86c5a7fbde0391e0e"
+checksum = "bad8da8e89f24177bd77947092199bb13dcc318bbd73530ba8a05e6d6adaaa9d"
 dependencies = [
  "bstr",
- "btoi",
  "gix-credentials",
  "gix-date",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-hash",
  "gix-transport",
+ "gix-utils",
  "maybe-async",
  "thiserror",
  "winnow",
@@ -1851,41 +1918,42 @@ dependencies = [
 
 [[package]]
 name = "gix-quote"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7dc10303d73a960d10fb82f81188b036ac3e6b11b5795b20b1a60b51d1321f"
+checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
 dependencies = [
  "bstr",
- "btoi",
+ "gix-utils",
  "thiserror",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.38.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec2f6d07ac88d2fb8007ee3fa3e801856fb9d82e7366ec0ca332eb2c9d74a52"
+checksum = "3394a2997e5bc6b22ebc1e1a87b41eeefbcfcff3dbfa7c4bd73cb0ac8f1f3e2e"
 dependencies = [
  "gix-actor",
  "gix-date",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-fs",
  "gix-hash",
  "gix-lock",
  "gix-object",
  "gix-path",
  "gix-tempfile",
+ "gix-utils",
  "gix-validate",
- "memmap2 0.7.1",
+ "memmap2",
  "thiserror",
  "winnow",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.19.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb0974cc41dbdb43a180c7f67aa481e1c1e160fcfa8f4a55291fd1126c1a6e7"
+checksum = "6868f8cd2e62555d1f7c78b784bece43ace40dd2a462daf3b588d5416e603f37"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -1897,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.23.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca97ac73459a7f3766aa4a5638a6e37d56d4c7962bc1986fbaf4883d0772588"
+checksum = "01b13e43c2118c4b0537ddac7d0821ae0dfa90b7b8dbf20c711e153fb749adce"
 dependencies = [
  "bstr",
  "gix-date",
@@ -1913,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.9.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16d8c892e4cd676d86f0265bf9d40cefd73d8d94f86b213b8b77d50e77efae0"
+checksum = "1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -1928,11 +1996,11 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.10.4"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8d9bf462feaf05f2121cba7399dbc6c34d88a9cad58fc1e95027791d6a3c6d2"
+checksum = "1547d26fa5693a7f34f05b4a3b59a90890972922172653bcb891ab3f09f436df"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gix-path",
  "libc",
  "windows-sys 0.52.0",
@@ -1940,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.5.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba78c8d12aa24370178453ec3a472ff08dfaa657d116229f57f2c9cd469a1c2"
+checksum = "921cd49924ac14b6611b22e5fb7bbba74d8780dc7ad26153304b64d1272460ac"
 dependencies = [
  "bstr",
  "gix-config",
@@ -1955,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "11.0.1"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388dd29114a86ec69b28d1e26d6d63a662300ecf61ab3f4cc578f7d7dc9e7e23"
+checksum = "006acf5a613e0b5cf095d8e4b3f48c12a60d9062aa2b2dd105afaf8344a5600c"
 dependencies = [
  "gix-fs",
  "libc",
@@ -1968,22 +2036,22 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b202d766a7fefc596e2cc6a89cda8ad8ad733aed82da635ac120691112a9b1"
+checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
 
 [[package]]
 name = "gix-transport"
-version = "0.38.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f209a93364e24f20319751bc11092272e2f3fe82bb72592b2822679cf5be752"
+checksum = "27c02b83763ffe95bcc27ce5821b2b7f843315a009c06f1cd59c9b66c508c058"
 dependencies = [
  "base64",
  "bstr",
  "curl",
  "gix-command",
  "gix-credentials",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-packetline",
  "gix-quote",
  "gix-sec",
@@ -1993,10 +2061,11 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.34.0"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d050ec7d4e1bb76abf0636cf4104fb915b70e54e3ced9a4427c999100ff38a"
+checksum = "e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840"
 dependencies = [
+ "bitflags 2.6.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2009,12 +2078,12 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.25.2"
+version = "0.27.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c427a1a11ccfa53a4a2da47d9442c2241deee63a154bc15cc14b8312fbc4005"
+checksum = "e2eb9b35bba92ea8f0b5ab406fad3cf6b87f7929aa677ff10aa042c6da621156"
 dependencies = [
  "bstr",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-path",
  "home",
  "thiserror",
@@ -2023,19 +2092,20 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e839f3d0798b296411263da6bee780a176ef8008a5dfc31287f7eda9266ab8"
+checksum = "35192df7fd0fa112263bad8021e2df7167df4cc2a6e6d15892e1e55621d3d4dc"
 dependencies = [
+ "bstr",
  "fastrand",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac7cc36f496bd5d96cdca0f9289bb684480725d40db60f48194aa7723b883854"
+checksum = "82c27dd34a49b1addf193c92070bcbf3beaf6e10f16a78544de6372e146a0acf"
 dependencies = [
  "bstr",
  "thiserror",
@@ -2043,13 +2113,13 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.27.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddaf79e721dba64fe726a42f297a3c8ed42e55cdc0d81ca68452f2def3c2d7fd"
+checksum = "26f7326ebe0b9172220694ea69d344c536009a9b98fb0f9de092c440f3efe7a6"
 dependencies = [
  "bstr",
  "gix-attributes",
- "gix-features 0.36.1",
+ "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -2057,6 +2127,7 @@ dependencies = [
  "gix-index",
  "gix-object",
  "gix-path",
+ "gix-validate",
 ]
 
 [[package]]
@@ -2165,7 +2236,7 @@ name = "guppy-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
- "clap 4.4.18",
+ "clap 4.5.11",
  "clap_builder",
  "getrandom",
  "indexmap 1.9.3",
@@ -2243,6 +2314,19 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "heck"
@@ -2258,6 +2342,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2432,19 +2522,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2466,9 +2553,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.27"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -2505,15 +2592,25 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -2525,12 +2622,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.1"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2547,6 +2644,17 @@ checksum = "b57e858af2798e167e709b9d969325b6d8e9d50232fcbc494d7d54f976854a64"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2619,18 +2727,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memmap2"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
-dependencies = [
- "libc",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -2780,13 +2879,14 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opener"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+checksum = "f8df34be653210fbe9ffaff41d3b92721c56ce82dfee58ee684f9afb5e3a90c0"
 dependencies = [
  "bstr",
+ "dbus",
  "normpath",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2829,13 +2929,12 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
- "serde",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3075,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "26.2.2"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf"
+checksum = "744a264d26b88a6a7e37cbad97953fa233b94d585236310bcbc88474b4092d79"
 dependencies = [
  "parking_lot",
 ]
@@ -3090,7 +3189,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -3120,17 +3219,6 @@ dependencies = [
  "guppy-workspace-hack",
  "proptest",
  "twox-hash",
-]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.4.2",
- "memchr",
- "unicase",
 ]
 
 [[package]]
@@ -3227,9 +3315,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3280,6 +3368,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.6.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,14 +3398,14 @@ dependencies = [
 
 [[package]]
 name = "rustfix"
-version = "0.6.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd2853d9e26988467753bd9912c3a126f642d05d229a4b53f5752ee36c56481"
+checksum = "4cef0c817217c330b3ef879e06455d726c1cffc800eaf7734d3b4ac63213636b"
 dependencies = [
- "anyhow",
- "log",
  "serde",
  "serde_json",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -3312,7 +3414,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3377,11 +3479,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3390,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3469,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -3563,12 +3665,12 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3607,6 +3709,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structopt"
@@ -3650,12 +3758,15 @@ dependencies = [
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -3701,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "target-spec"
@@ -3811,18 +3922,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3909,14 +4020,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.5",
- "toml_edit 0.21.1",
+ "toml_datetime 0.6.7",
+ "toml_edit 0.22.17",
 ]
 
 [[package]]
@@ -3927,9 +4038,9 @@ checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
 dependencies = [
  "serde",
 ]
@@ -3948,27 +4059,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.22.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
  "serde_spanned",
- "toml_datetime 0.6.5",
- "winnow",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
-dependencies = [
- "indexmap 2.2.6",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.5",
+ "toml_datetime 0.6.7",
  "winnow",
 ]
 
@@ -3992,6 +4090,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4099,9 +4208,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "unicode-xid"
@@ -4111,9 +4220,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4182,9 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4482,9 +4591,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "b480ae9340fc261e6be3e95a1ba86d54ae3f9171132a73ce8d4bbaf68339507c"
 dependencies = [
  "memchr",
 ]

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['powerpc-wrs-vxworks', 'thumbv7em-none-eabi']
+# platforms = ['powerpc-wrs-vxworks', 'thumbv7a-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-unknown-fuchsia', 'armv7-sony-vita-newlibeabihf']
+# platforms = ['aarch64-unknown-freebsd', 'armv6-unknown-netbsd-eabihf']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['powerpc-wrs-vxworks-spe', 'riscv64gc-unknown-freebsd', 'mipsel-unknown-linux-uclibc']
+# platforms = ['powerpc-wrs-vxworks-spe', 'riscv32imc-unknown-none-elf', 'mipsel-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'pathdiff'
 # version = '0.2.0'
@@ -66,16 +66,10 @@ libc = { version = "0.2", features = ["std"] }
 [target.powerpc-wrs-vxworks-spe.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.riscv64gc-unknown-freebsd.dependencies]
+[target.mipsel-unknown-linux-musl.dependencies]
 libc = { version = "0.2", features = ["std"] }
 
-[target.riscv64gc-unknown-freebsd.build-dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.mipsel-unknown-linux-uclibc.dependencies]
-libc = { version = "0.2", features = ["std"] }
-
-[target.mipsel-unknown-linux-uclibc.build-dependencies]
+[target.mipsel-unknown-linux-musl.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-apple-watchos-sim']
+# platforms = ['aarch64-apple-visionos-sim']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -333,7 +333,7 @@ void = { version = "1", default-features = false }
 vte = { version = "0.3", default-features = false }
 walkdir = { version = "2", default-features = false }
 
-[target.aarch64-apple-watchos-sim.dependencies]
+[target.aarch64-apple-visionos-sim.dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }
@@ -343,7 +343,7 @@ ppv-lite86 = { version = "0.2", default-features = false, features = ["std"] }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
 termios = { version = "0.3", default-features = false }
 
-[target.aarch64-apple-watchos-sim.build-dependencies]
+[target.aarch64-apple-visionos-sim.build-dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['nvptx64-nvidia-cuda', 'x86_64-unknown-redox', 'aarch64-uwp-windows-msvc']
+# platforms = ['msp430-none-elf', 'x86_64-unknown-redox', 'aarch64-unknown-teeos']
 # [[traversal-excludes.ids]]
 # name = 'fixtures'
 # version = '0.1.0'
@@ -80,9 +80,6 @@ libc = { version = "0.2" }
 
 [target.x86_64-unknown-redox.build-dependencies]
 libc = { version = "0.2" }
-
-[target.aarch64-uwp-windows-msvc.dependencies]
-winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64h-apple-darwin', 'aarch64-wrs-vxworks']
+# platforms = ['x86_64h-apple-darwin', 'aarch64-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
 # name = 'bit-set'
 # version = '0.5.2'
@@ -66,8 +66,8 @@ syn = { version = "1", features = ["full", "visit"] }
 [target.x86_64h-apple-darwin.dependencies]
 libc = { version = "0.2" }
 
-[target.aarch64-wrs-vxworks.dependencies]
-libc = { version = "0.2" }
+[target.aarch64-uwp-windows-msvc.dependencies]
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['wasm32-unknown-unknown']
+# platforms = ['wasm32-wasi']
 # [[traversal-excludes.ids]]
 # name = 'byteorder'
 # version = '1.3.4'
@@ -198,7 +198,7 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.wasm32-unknown-unknown.dependencies]
+[target.wasm32-wasi.dependencies]
 adler = { version = "0.2", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
@@ -206,10 +206,12 @@ js-sys = { version = "0.3", default-features = false }
 miniz_oxide = { version = "0.4", default-features = false }
 openssl = { version = "0.10", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
+wasi-93f6ce9d446188ac = { package = "wasi", version = "0.10" }
+wasi-274715c4dabd11b0 = { package = "wasi", version = "0.9" }
 wasm-bindgen = { version = "0.2" }
 web-sys = { version = "0.3", default-features = false, features = ["CanvasRenderingContext2d", "Document", "DomRect", "HtmlCanvasElement", "Window"] }
 
-[target.wasm32-unknown-unknown.build-dependencies]
+[target.wasm32-wasi.build-dependencies]
 bumpalo = { version = "3" }
 cfg-if = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64-wrs-vxworks']
+# platforms = ['aarch64-unknown-uefi']
 # [[traversal-excludes.ids]]
 # name = 'openssl'
 # version = '0.10.30'
@@ -356,16 +356,6 @@ version_check = { version = "0.9", default-features = false }
 void = { version = "1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-
-[target.aarch64-wrs-vxworks.dependencies]
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
-
-[target.aarch64-wrs-vxworks.build-dependencies]
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-unknown-uefi']
+# platforms = ['x86_64-uwp-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'git2-curl'
 # version = '0.14.1'
@@ -216,11 +216,16 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.x86_64-unknown-uefi.dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
+[target.x86_64-uwp-windows-gnu.dependencies]
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+output_vt100 = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.x86_64-uwp-windows-gnu.build-dependencies]
+ctor = { version = "0.1", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-pc-windows-gnullvm', 'i686-unknown-haiku', 'x86_64-unknown-hermit']
+# platforms = ['aarch64-linux-android', 'i686-unknown-freebsd', 'x86_64-unknown-illumos']
 # [[traversal-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'
@@ -142,26 +142,20 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.aarch64-pc-windows-gnullvm.dependencies]
-encode_unicode = { version = "0.3" }
-output_vt100 = { version = "0.1", default-features = false }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
-rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
-winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "minwinbase", "minwindef", "ntdef", "processenv", "profileapi", "std", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winuser"] }
-winapi-util = { version = "0.1", default-features = false }
-
-[target.aarch64-pc-windows-gnullvm.build-dependencies]
-ctor = { version = "0.1", default-features = false }
-
-[target.i686-unknown-haiku.dependencies]
+[target.aarch64-linux-android.dependencies]
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
 termios = { version = "0.3", default-features = false }
 
-[target.x86_64-unknown-hermit.dependencies]
-hermit-abi = { version = "0.1" }
+[target.i686-unknown-freebsd.dependencies]
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
+termios = { version = "0.3", default-features = false }
+
+[target.x86_64-unknown-illumos.dependencies]
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
+termios = { version = "0.3", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'aarch64_be-unknown-linux-gnu_ilp32'
+triple = 'aarch64_be-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'm68k-unknown-linux-gnu'
+triple = 'loongarch64-unknown-none'
 target-features = ['bmi1', 'xsaveopt']
 [[metadata.omitted-packages.ids]]
 name = 'guppy-summaries'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-netbsd'
+triple = 'mipsel-unknown-linux-uclibc'
 target-features = ['sse2', 'sse3']
 flags = ['abc', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'x86_64-apple-ios-macabi'
+triple = 'x86_64-apple-darwin'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
@@ -12,7 +12,7 @@ target-features = ['avx2', 'bmi2', 'fma', 'sse', 'sse3', 'xsaveopt']
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'riscv32imac-unknown-xous-elf'
+triple = 'riscv32imac-unknown-none-elf'
 target-features = 'unknown'
 flags = ['abc', 'foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'arm-unknown-linux-musleabihf'
+triple = 'arm-unknown-linux-musleabi'
 target-features = 'unknown'
 flags = ['bar', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'mipsisa64r6el-unknown-linux-gnuabi64'
+triple = 'mipsisa64r6-unknown-linux-gnuabi64'
 target-features = []
 flags = ['flag-test']
 

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'avr-unknown-gnu-atmega328'
+triple = 'armv8r-none-eabihf'
 target-features = ['bmi1', 'sse3', 'sse4.2']
 
 [[host-package]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['bar', 'foo']
 
 [metadata.target-platform]
-triple = 'mipsel-sony-psx'
+triple = 'mipsel-sony-psp'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-gnueabi'
+triple = 'armv7-linux-androideabi'
 target-features = 'unknown'
 flags = ['bar', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-openbsd'
+triple = 'sparc64-unknown-netbsd'
 target-features = ['aes', 'bmi1', 'xsaves']
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mips64-unknown-linux-muslabi64'
 target-features = 'unknown'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-uefi'
+triple = 'x86_64-uwp-windows-gnu'
 target-features = 'all'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-redox'
+triple = 'x86_64-unknown-uefi'
 target-features = 'unknown'
 flags = ['flag-test', 'test-flag']
 [[metadata.omitted-packages.ids]]
@@ -95,7 +95,7 @@ version = '2.33.3'
 crates-io = true
 status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
 
 [[host-package]]
 name = 'dialoguer'
@@ -227,13 +227,6 @@ status = 'direct'
 features = []
 
 [[host-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ascii'
 version = '0.9.3'
 crates-io = true
@@ -295,7 +288,7 @@ version = '0.4.19'
 crates-io = true
 status = 'transitive'
 features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
-optional-deps = ['libc', 'time']
+optional-deps = ['libc', 'time', 'winapi']
 
 [[host-package]]
 name = 'combine'
@@ -310,7 +303,7 @@ version = '0.11.3'
 crates-io = true
 status = 'transitive'
 features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
-optional-deps = ['regex', 'unicode-width']
+optional-deps = ['regex', 'unicode-width', 'winapi-util']
 
 [[host-package]]
 name = 'either'
@@ -318,6 +311,13 @@ version = '1.6.1'
 crates-io = true
 status = 'transitive'
 features = ['use_std']
+
+[[host-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'fnv'
@@ -657,6 +657,20 @@ features = []
 [[host-package]]
 name = 'wait-timeout'
 version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'minwinbase', 'minwindef', 'ntdef', 'processenv', 'profileapi', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winuser']
+
+[[host-package]]
+name = 'winapi-util'
+version = '0.1.5'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-linux-musl'
+triple = 'riscv64gc-unknown-hermit'
 target-features = ['avx', 'bmi2', 'rdrand', 'sse', 'sse2']
 flags = ['abc', 'test-flag']
 
@@ -1114,13 +1114,6 @@ version = '0.1.21'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'pkg-config'

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32imac-unknown-xous-elf'
+triple = 'riscv32imac-unknown-none-elf'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-freebsd'
+triple = 'aarch64-pc-windows-gnullvm'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'guppy-cmdlib'
@@ -316,18 +316,18 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'num-traits'
 version = '0.2.12'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[target-package]]
+name = 'output_vt100'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'ppv-lite86'
@@ -451,6 +451,13 @@ crates-io = true
 status = 'transitive'
 features = []
 
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'minwinbase', 'minwindef', 'processenv', 'std', 'winbase', 'winerror', 'winuser']
+
 [[host-package]]
 name = 'proptest-derive'
 version = '0.2.0'
@@ -461,6 +468,13 @@ features = []
 [[host-package]]
 name = 'autocfg'
 version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ctor'
+version = '0.1.16'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-l4re-uclibc'
+triple = 'x86_64-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['test-flag']
 

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-fuchsia'
+triple = 'aarch64-pc-windows-msvc'
 target-features = ['avx2', 'sha', 'sse2', 'sse3']
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]
@@ -151,7 +151,7 @@ version = '2.33.3'
 crates-io = true
 status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
 
 [[target-package]]
 name = 'criterion'
@@ -408,7 +408,7 @@ version = '0.4.19'
 crates-io = true
 status = 'transitive'
 features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
-optional-deps = ['libc', 'time']
+optional-deps = ['libc', 'time', 'winapi']
 
 [[target-package]]
 name = 'combine'
@@ -423,7 +423,7 @@ version = '0.11.3'
 crates-io = true
 status = 'transitive'
 features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
-optional-deps = ['regex', 'unicode-width']
+optional-deps = ['regex', 'unicode-width', 'winapi-util']
 
 [[target-package]]
 name = 'crates-io'
@@ -503,7 +503,6 @@ version = '0.4.33'
 crates-io = true
 status = 'transitive'
 features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
-optional-deps = ['openssl-probe', 'openssl-sys']
 
 [[target-package]]
 name = 'curl-sys'
@@ -511,7 +510,7 @@ version = '0.4.36+curl-7.71.1'
 crates-io = true
 status = 'transitive'
 features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
-optional-deps = ['libnghttp2-sys', 'openssl-sys']
+optional-deps = ['libnghttp2-sys']
 
 [[target-package]]
 name = 'difference'
@@ -519,6 +518,13 @@ version = '2.0.0'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[target-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'env_logger'
@@ -551,15 +557,8 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'foreign-types'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'foreign-types-shared'
-version = '0.1.1'
+name = 'fwdansi'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -577,7 +576,6 @@ version = '0.13.11'
 crates-io = true
 status = 'transitive'
 features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['openssl-probe', 'openssl-sys']
 
 [[target-package]]
 name = 'git2-curl'
@@ -718,7 +716,7 @@ version = '0.12.13+1.0.1'
 crates-io = true
 status = 'transitive'
 features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['libssh2-sys', 'openssl-sys']
+optional-deps = ['libssh2-sys']
 
 [[target-package]]
 name = 'libnghttp2-sys'
@@ -785,6 +783,13 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
+name = 'miow'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'num-integer'
 version = '0.1.43'
 crates-io = true
@@ -820,22 +825,8 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'openssl'
-version = '0.10.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-probe'
+name = 'output_vt100'
 version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-sys'
-version = '0.9.58'
 crates-io = true
 status = 'transitive'
 features = []
@@ -874,7 +865,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
+optional-deps = ['getrandom_package']
 
 [[target-package]]
 name = 'rand_chacha'
@@ -985,6 +976,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'schannel'
+version = '0.1.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'scopeguard'
 version = '1.1.0'
 crates-io = true
@@ -1071,13 +1069,6 @@ features = []
 [[target-package]]
 name = 'terminal_size'
 version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'termios'
-version = '0.3.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1208,6 +1199,20 @@ crates-io = true
 status = 'transitive'
 features = []
 
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['basetsd', 'consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'jobapi', 'jobapi2', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntstatus', 'processenv', 'processthreadsapi', 'profileapi', 'psapi', 'schannel', 'securitybaseapi', 'shellapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip']
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
 [[host-package]]
 name = 'proptest-derive'
 version = '0.2.0'
@@ -1229,6 +1234,13 @@ crates-io = true
 status = 'transitive'
 features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
+
+[[host-package]]
+name = 'ctor'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'heck'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-nintendo-switch-freestanding'
+triple = 'aarch64-kmc-solid_asp3'
 target-features = 'unknown'
 flags = ['abc']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-fuchsia'
+triple = 'x86_64-fortanix-unknown-sgx'
 target-features = 'all'
 flags = ['bar']
 

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-6.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i586-unknown-linux-musl'
+triple = 'i586-pc-windows-msvc'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64-apple-tvos']
+# platforms = ['x86_64-apple-ios']
 # [[traversal-excludes.ids]]
 # name = 'aho-corasick'
 # version = '1.1.3'
@@ -114,7 +114,7 @@ quote = { version = "1" }
 syn = { version = "2", features = ["full"] }
 tokio-macros = { version = "2", default-features = false }
 
-[target.x86_64-apple-tvos.dependencies]
+[target.x86_64-apple-ios.dependencies]
 libc = { version = "0.2" }
 signal-hook-registry = { version = "1", default-features = false }
 

--- a/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['i686-pc-windows-gnullvm', 'armv7-unknown-linux-ohos']
+# platforms = ['i686-linux-android', 'armv7-unknown-linux-gnueabihf']
 # [[traversal-excludes.ids]]
 # name = 'async-stream-impl'
 # version = '0.3.5'
@@ -64,12 +64,6 @@ tokio = { version = "1", features = ["macros", "net", "signal", "test-util"] }
 [build-dependencies]
 futures-core = { version = "0.3" }
 tokio = { version = "1", features = ["macros", "net", "signal", "test-util"] }
-
-[target.i686-pc-windows-gnullvm.dependencies]
-windows-sys = { version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
-
-[target.i686-pc-windows-gnullvm.build-dependencies]
-windows-sys = { version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_WindowsProgramming"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/hyper_util_7afb1ed-3.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armv7r-none-eabihf', 'sparc-unknown-none-elf', 'x86_64-apple-darwin']
+# platforms = ['armv7k-apple-watchos', 'sparc-unknown-linux-gnu', 'wasm64-unknown-unknown']
 # [[traversal-excludes.ids]]
 # name = 'futures-core'
 # version = '0.3.30'
@@ -91,7 +91,11 @@ syn = { version = "2", features = ["clone-impls", "derive", "full", "parsing", "
 tokio-macros = { version = "2", default-features = false }
 unicode-ident = { version = "1", default-features = false }
 
-[target.x86_64-apple-darwin.dependencies]
+[target.armv7k-apple-watchos.dependencies]
+libc = { version = "0.2", features = ["std"] }
+signal-hook-registry = { version = "1", default-features = false }
+
+[target.sparc-unknown-linux-gnu.dependencies]
 ipnetwork = { version = "0.20", features = ["serde"] }
 libc = { version = "0.2", features = ["std"] }
 no-std-net = { version = "0.6", default-features = false, features = ["std"] }

--- a/fixtures/large/hakari/metadata_libra-0.toml
+++ b/fixtures/large/hakari/metadata_libra-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['x86_64-pc-windows-msvc', 'arm-unknown-linux-musleabi', 'armv7-unknown-freebsd']
+# platforms = ['x86_64-pc-windows-gnullvm', 'arm-unknown-linux-gnueabihf', 'armv7-linux-androideabi']
 # [[traversal-excludes.ids]]
 # name = 'netcore'
 # version = '0.1.0'
@@ -730,7 +730,7 @@ x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://githu
 x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.x86_64-pc-windows-msvc.dependencies]
+[target.x86_64-pc-windows-gnullvm.dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 kernel32-sys = { version = "0.2", default-features = false }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -747,7 +747,7 @@ wincolor = { version = "1", default-features = false }
 winreg = { version = "0.6", default-features = false }
 ws2_32-sys = { version = "0.2", default-features = false }
 
-[target.x86_64-pc-windows-msvc.build-dependencies]
+[target.x86_64-pc-windows-gnullvm.build-dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 kernel32-sys = { version = "0.2", default-features = false }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -757,7 +757,6 @@ miow-468e82937335b1c9 = { package = "miow", version = "0.3", default-features = 
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
 socket2 = { version = "0.3", default-features = false }
-vcpkg = { version = "0.2", default-features = false }
 winapi-6f8ce4dd05d13bba = { package = "winapi", version = "0.2", default-features = false }
 winapi-468e82937335b1c9 = { package = "winapi", version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "memoryapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-build = { version = "0.1", default-features = false }
@@ -766,7 +765,7 @@ wincolor = { version = "1", default-features = false }
 winreg = { version = "0.6", default-features = false }
 ws2_32-sys = { version = "0.2", default-features = false }
 
-[target.arm-unknown-linux-musleabi.dependencies]
+[target.arm-unknown-linux-gnueabihf.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -779,7 +778,7 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.arm-unknown-linux-musleabi.build-dependencies]
+[target.arm-unknown-linux-gnueabihf.build-dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -792,9 +791,10 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.armv7-unknown-freebsd.dependencies]
+[target.armv7-linux-androideabi.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
+get_if_addrs-sys = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 mio-uds = { version = "0.6", default-features = false }
 nix = { version = "0.14", default-features = false }
@@ -805,9 +805,10 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.armv7-unknown-freebsd.build-dependencies]
+[target.armv7-linux-androideabi.build-dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
+get_if_addrs-sys = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 mio-uds = { version = "0.6", default-features = false }
 nix = { version = "0.14", default-features = false }

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-nintendo-switch-freestanding', 'x86_64-apple-tvos']
+# platforms = ['aarch64-kmc-solid_asp3', 'x86_64-apple-ios-macabi']
 # [[traversal-excludes.ids]]
 # name = 'c_linked_list'
 # version = '1.1.1'
@@ -171,17 +171,17 @@ toml = { version = "0.5" }
 ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 
-[target.aarch64-nintendo-switch-freestanding.dependencies]
+[target.aarch64-kmc-solid_asp3.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.aarch64-nintendo-switch-freestanding.build-dependencies]
+[target.aarch64-kmc-solid_asp3.build-dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.x86_64-apple-tvos.dependencies]
+[target.x86_64-apple-ios-macabi.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 
-[target.x86_64-apple-tvos.build-dependencies]
+[target.x86_64-apple-ios-macabi.build-dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['riscv64-linux-android']
+# platforms = ['riscv32imafc-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'hmac'
 # version = '0.7.1'
@@ -114,8 +114,8 @@ crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
-crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-queue = { version = "0.2", features = ["std"] }
+crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
@@ -489,8 +489,8 @@ crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
-crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-queue = { version = "0.2", features = ["std"] }
+crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
@@ -852,60 +852,37 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.riscv64-linux-android.dependencies]
+[target.riscv32imafc-unknown-none-elf.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
-crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
-get_if_addrs-sys = { version = "0.1", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
-mio-uds = { version = "0.6", default-features = false }
 native-tls = { version = "0.2", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration", "log", "logging"] }
 rustls-native-certs = { version = "0.3", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
-[target.riscv64-linux-android.build-dependencies]
+[target.riscv32imafc-unknown-none-elf.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
-crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
-gcc = { version = "0.3", default-features = false }
-get_if_addrs-sys = { version = "0.1", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
-mio-uds = { version = "0.6", default-features = false }
 native-tls = { version = "0.2", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration", "log", "logging"] }
 rustls-native-certs = { version = "0.3", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['powerpc-unknown-linux-gnuspe', 'sparc64-unknown-netbsd']
+# platforms = ['powerpc-unknown-linux-gnuspe', 'sparc-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'crypto-mac'
 # version = '0.7.0'
@@ -136,7 +136,7 @@ toml = { version = "0.5" }
 [target.powerpc-unknown-linux-gnuspe.dependencies]
 hyper = { version = "0.13" }
 
-[target.sparc64-unknown-netbsd.dependencies]
+[target.sparc-unknown-none-elf.dependencies]
 hyper = { version = "0.13" }
 
 ### END HAKARI SECTION

--- a/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['avr-unknown-gnu-atmega328']
+# platforms = ['armv8r-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'derivative'
 # version = '1.0.3'
@@ -100,7 +100,7 @@ subtle = { version = "2", features = ["i128", "std"] }
 syn = { version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 toml = { version = "0.5" }
 
-[target.avr-unknown-gnu-atmega328.dependencies]
+[target.armv8r-none-eabihf.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
 ### END HAKARI SECTION

--- a/fixtures/large/hakari/metadata_libra_f0091a4-3.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64-sun-solaris']
+# platforms = ['x86_64-pc-windows-msvc']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -77,8 +77,12 @@ subtle = { version = "2", features = ["i128", "std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 
-[target.x86_64-sun-solaris.dependencies]
+[target.x86_64-pc-windows-msvc.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+
+[target.x86_64-pc-windows-msvc.build-dependencies]
+winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "ioapiset", "knownfolders", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "schannel", "securitybaseapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['armv7-linux-androideabi', 'sparc-unknown-linux-gnu']
+# platforms = ['armv6-unknown-freebsd', 's390x-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'string_cache_codegen'
 # version = '0.5.2'
@@ -826,9 +826,7 @@ zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-fea
 zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
-[target.armv7-linux-androideabi.dependencies]
-android-tzdata = { version = "0.1", default-features = false }
-android_system_properties = { version = "0.1", default-features = false }
+[target.armv6-unknown-freebsd.dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
@@ -847,7 +845,6 @@ hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["general", "ioctl", "no_std"] }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 mio = { version = "0.8" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -867,10 +864,8 @@ static_assertions = { version = "1", default-features = false }
 unicode-bidi = { version = "0.3" }
 waker-fn = { version = "1", default-features = false }
 
-[target.armv7-linux-androideabi.build-dependencies]
+[target.armv6-unknown-freebsd.build-dependencies]
 ahash = { version = "0.8" }
-android-tzdata = { version = "0.1", default-features = false }
-android_system_properties = { version = "0.1", default-features = false }
 arc-swap = { version = "1", default-features = false }
 async-io = { version = "1", default-features = false }
 base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
@@ -965,13 +960,13 @@ idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = 
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
 imara-diff = { version = "0.1" }
-inotify = { version = "0.9", default-features = false }
-inotify-sys = { version = "0.1", default-features = false }
 io-close = { version = "0.3", default-features = false }
 ipnet = { version = "2" }
 is-docker = { version = "0.2", default-features = false }
 is-wsl = { version = "0.4", default-features = false }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kqueue = { version = "1", default-features = false }
+kqueue-sys = { version = "1", default-features = false }
 kstring = { version = "2" }
 lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
@@ -980,8 +975,6 @@ libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked-hash-map = { version = "0.5", default-features = false }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["general", "ioctl", "no_std"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["general", "ioctl", "no_std"] }
 lru-cache = { version = "0.1", default-features = false }
 match_cfg = { version = "0.1" }
 maybe-async = { version = "0.2", features = ["is_sync"] }
@@ -1027,7 +1020,6 @@ signal-hook-registry = { version = "1", default-features = false }
 signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
 sized-chunks = { version = "0.6" }
 smallvec = { version = "1", default-features = false, features = ["write"] }
-spin = { version = "0.5", default-features = false }
 spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
 subtle = { version = "2", default-features = false, features = ["i128"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", default-features = false, features = ["visit-mut"] }
@@ -1042,7 +1034,7 @@ vcpkg = { version = "0.2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 xattr = { version = "1" }
 
-[target.sparc-unknown-linux-gnu.dependencies]
+[target.s390x-unknown-linux-gnu.dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
@@ -1084,7 +1076,7 @@ static_assertions = { version = "1", default-features = false }
 unicode-bidi = { version = "0.3" }
 waker-fn = { version = "1", default-features = false }
 
-[target.sparc-unknown-linux-gnu.build-dependencies]
+[target.s390x-unknown-linux-gnu.build-dependencies]
 ahash = { version = "0.8" }
 arc-swap = { version = "1", default-features = false }
 async-io = { version = "1", default-features = false }

--- a/fixtures/large/hakari/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['mipsel-unknown-linux-musl', 'thumbv4t-none-eabi', 'i686-unknown-hurd-gnu']
+# platforms = ['mipsel-unknown-linux-gnu', 'sparcv9-sun-solaris', 'i686-unknown-haiku']
 # [[traversal-excludes.ids]]
 # name = 'cargo_metadata'
 # version = '0.14.2'
@@ -950,7 +950,7 @@ zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-fea
 zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
-[target.mipsel-unknown-linux-musl.dependencies]
+[target.mipsel-unknown-linux-gnu.dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2", features = ["async-io"] }
 async-io = { version = "1", default-features = false }
@@ -963,6 +963,9 @@ foreign-types-shared = { version = "0.1", default-features = false }
 futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
 linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -978,7 +981,7 @@ signal-hook-registry = { version = "1", default-features = false }
 static_assertions = { version = "1", default-features = false }
 waker-fn = { version = "1", default-features = false }
 
-[target.mipsel-unknown-linux-musl.build-dependencies]
+[target.mipsel-unknown-linux-gnu.build-dependencies]
 ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
 arc-swap = { version = "1", default-features = false }
 async-executor = { version = "1", default-features = false }
@@ -1082,6 +1085,9 @@ libc = { version = "0.2", default-features = false, features = ["use_std"] }
 libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
 linked-hash-map = { version = "0.5", default-features = false }
 linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
@@ -1135,63 +1141,7 @@ unicode-bom = { version = "2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 xattr = { version = "1", features = ["unsupported"] }
 
-[target.thumbv4t-none-eabi.dependencies]
-async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
-async-io = { version = "1", default-features = false }
-async-process = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
-atomic-waker = { version = "1", default-features = false }
-blocking = { version = "1", default-features = false }
-errno = { version = "0.3", default-features = false }
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
-parking = { version = "2", default-features = false }
-polling = { version = "2", features = ["std"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
-waker-fn = { version = "1", default-features = false }
-
-[target.thumbv4t-none-eabi.build-dependencies]
-async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
-async-io = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
-atomic-waker = { version = "1", default-features = false }
-blocking = { version = "1", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
-enum-as-inner = { version = "0.5", default-features = false }
-errno = { version = "0.3", default-features = false }
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-hostname = { version = "0.3" }
-hyper-rustls = { version = "0.24", default-features = false }
-hyper-tls = { version = "0.5", default-features = false }
-idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-ipnet = { version = "2", features = ["std"] }
-linked-hash-map = { version = "0.5", default-features = false }
-lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1", features = ["use_core"] }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-macros = { version = "0.1", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
-polling = { version = "2", features = ["std"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
-rustls-pemfile = { version = "1", default-features = false }
-tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
-trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
-webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
-
-[target.i686-unknown-hurd-gnu.dependencies]
+[target.sparcv9-sun-solaris.dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2", features = ["async-io"] }
 async-io = { version = "1", default-features = false }
@@ -1219,7 +1169,187 @@ signal-hook-registry = { version = "1", default-features = false }
 static_assertions = { version = "1", default-features = false }
 waker-fn = { version = "1", default-features = false }
 
-[target.i686-unknown-hurd-gnu.build-dependencies]
+[target.sparcv9-sun-solaris.build-dependencies]
+ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
+arc-swap = { version = "1", default-features = false }
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+bitmaps = { version = "2", features = ["std"] }
+blocking = { version = "1", default-features = false }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
+btoi = { version = "0.4", features = ["std"] }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
+curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
+ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4", features = ["log"] }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1", features = ["unified_diff"] }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2", features = ["std"] }
+is-docker = { version = "0.2", default-features = false }
+is-wsl = { version = "0.4", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
+kstring = { version = "2", features = ["std", "unsafe"] }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+linked-hash-map = { version = "0.5", default-features = false }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1", features = ["use_core"] }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "2", features = ["std"] }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3", features = ["serde"] }
+p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
+pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
+polling = { version = "2", features = ["std"] }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["std", "termios", "use-libc-auxv"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["mio-0_8", "support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6", features = ["std"] }
+spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+unicode-bom = { version = "2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1", features = ["unsupported"] }
+
+[target.i686-unknown-haiku.dependencies]
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2", features = ["async-io"] }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4", features = ["std"] }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+iana-time-zone-haiku = { version = "0.1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-registry = { version = "1", default-features = false }
+static_assertions = { version = "1", default-features = false }
+waker-fn = { version = "1", default-features = false }
+
+[target.i686-unknown-haiku.build-dependencies]
 ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
 arc-swap = { version = "1", default-features = false }
 async-executor = { version = "1", default-features = false }
@@ -1307,6 +1437,7 @@ http-auth = { version = "0.1", default-features = false }
 hyper-rustls = { version = "0.24", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+iana-time-zone-haiku = { version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }

--- a/fixtures/large/hakari/mnemos_b3b4da9-3.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['s390x-unknown-linux-musl']
+# platforms = ['riscv64imac-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'bootloader_api'
 # version = '0.11.4'
@@ -196,22 +196,16 @@ unicode-normalization = { version = "0.1" }
 uuid = { version = "1", features = ["serde", "v4"] }
 zeroize = { version = "1" }
 
-[target.s390x-unknown-linux-musl.dependencies]
+[target.riscv64imac-unknown-none-elf.dependencies]
 io-lifetimes = { version = "1" }
-libc = { version = "0.2", default-features = false, features = ["use_std"] }
-nix = { version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "signal", "term"] }
 openssl = { version = "0.10" }
 rustix = { version = "0.37", features = ["fs", "termios"] }
-signal-hook = { version = "0.3", default-features = false, features = ["iterator"] }
 
-[target.s390x-unknown-linux-musl.build-dependencies]
+[target.riscv64imac-unknown-none-elf.build-dependencies]
 io-lifetimes = { version = "1" }
-itertools = { version = "0.10" }
-nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
 rustix = { version = "0.37", features = ["fs", "termios"] }
-signal-hook = { version = "0.3" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/summaries/hyper_util_7afb1ed-0.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'thumbv4t-none-eabi'
+triple = 'sparcv9-sun-solaris'
 target-features = ['sha', 'sse']
 flags = ['bar', 'foo']
 [[metadata.omitted-packages.ids]]
@@ -98,7 +98,7 @@ version = '1.39.2'
 crates-io = true
 status = 'direct'
 features = ['default', 'libc', 'macros', 'mio', 'net', 'rt', 'signal', 'signal-hook-registry', 'socket2', 'sync', 'test-util', 'time', 'tokio-macros']
-optional-deps = ['mio', 'tokio-macros']
+optional-deps = ['libc', 'mio', 'signal-hook-registry', 'tokio-macros']
 
 [[target-package]]
 name = 'tokio-test'
@@ -173,6 +173,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'libc'
+version = '0.2.155'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
 name = 'log'
 version = '0.4.22'
 crates-io = true
@@ -215,6 +222,13 @@ version = '0.8.4'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'termcolor'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-musleabi'
+triple = 'armv7-unknown-linux-gnueabi'
 target-features = 'all'
 
 [[metadata.features-only]]

--- a/fixtures/large/summaries/hyper_util_7afb1ed-3.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'asmjs-unknown-emscripten'
+triple = 'armv7r-none-eabihf'
 target-features = ['bmi2', 'sse', 'xsave']
 
 [metadata.target-platform]

--- a/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-openbsd'
+triple = 'sparc64-unknown-netbsd'
 target-features = 'unknown'
 flags = ['bar', 'flag-test']
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-netbsd'
+triple = 'aarch64-unknown-linux-musl'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'log'
@@ -86,6 +86,13 @@ version = '0.2.14'
 crates-io = true
 status = 'direct'
 features = []
+
+[[target-package]]
+name = 'pnet_datalink'
+version = '0.35.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'pretty_env_logger'
@@ -224,6 +231,14 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
+name = 'ipnetwork'
+version = '0.20.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[target-package]]
 name = 'is-terminal'
 version = '0.4.12'
 crates-io = true
@@ -259,6 +274,13 @@ status = 'transitive'
 features = ['net', 'os-ext', 'os-poll']
 
 [[target-package]]
+name = 'no-std-net'
+version = '0.6.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
 name = 'once_cell'
 version = '1.19.0'
 crates-io = true
@@ -268,6 +290,20 @@ features = ['alloc', 'default', 'race', 'std']
 [[target-package]]
 name = 'pin-utils'
 version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pnet_base'
+version = '0.35.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'pnet_sys'
+version = '0.35.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -294,6 +330,13 @@ version = '0.8.4'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.204'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'signal-hook-registry'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-pc-windows-gnullvm'
+triple = 'x86_64-pc-windows-gnu'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'httpdate'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-fuchsia'
+triple = 'aarch64-pc-windows-msvc'
 target-features = 'all'
 flags = ['flag-test', 'test-flag']
 
 [metadata.target-platform]
-triple = 'armv7-unknown-netbsd-eabihf'
+triple = 'armv7-unknown-linux-uclibceabi'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'libc'
@@ -324,13 +324,6 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
-name = 'signal-hook-registry'
-version = '1.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'slab'
 version = '0.4.9'
 crates-io = true
@@ -412,6 +405,34 @@ features = []
 [[host-package]]
 name = 'want'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi-util'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows-sys'
+version = '0.52.0'
+crates-io = true
+status = 'transitive'
+features = ['Wdk', 'Wdk_Foundation', 'Wdk_Storage', 'Wdk_Storage_FileSystem', 'Wdk_System', 'Wdk_System_IO', 'Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Pipes', 'Win32_System_SystemInformation', 'Win32_System_WindowsProgramming', 'default']
+
+[[host-package]]
+name = 'windows-targets'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_aarch64_msvc'
+version = '0.52.6'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra-0.toml
+++ b/fixtures/large/summaries/metadata_libra-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-l4re-uclibc'
+triple = 'x86_64-unknown-linux-gnu'
 target-features = ['xsaves']
 flags = ['foo']
 

--- a/fixtures/large/summaries/metadata_libra-1.toml
+++ b/fixtures/large/summaries/metadata_libra-1.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i686-unknown-haiku'
+triple = 'i686-unknown-freebsd'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'aarch64-pc-windows-msvc'
+triple = 'aarch64-nintendo-switch-freestanding'
 target-features = ['sha', 'ssse3', 'xsaves']
 flags = ['abc', 'bar']
 [[metadata.omitted-packages.ids]]
@@ -989,13 +989,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'libc'
 version = '0.2.62'
 crates-io = true
@@ -1052,7 +1045,7 @@ version = '0.5.6'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'winapi']
+optional-deps = ['getrandom']
 
 [[target-package]]
 name = 'mio'
@@ -1060,13 +1053,6 @@ version = '0.6.19'
 crates-io = true
 status = 'transitive'
 features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'net2'
@@ -1235,7 +1221,6 @@ version = '0.5.6'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
-optional-deps = ['winapi']
 
 [[target-package]]
 name = 'rand'
@@ -1754,34 +1739,6 @@ features = []
 [[target-package]]
 name = 'want'
 version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2437,13 +2394,6 @@ features = []
 [[host-package]]
 name = 'which'
 version = '2.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra-3.toml
+++ b/fixtures/large/summaries/metadata_libra-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-linux-uclibc'
+triple = 'mipsel-unknown-linux-musl'
 target-features = []
 flags = ['foo']
 

--- a/fixtures/large/summaries/metadata_libra-4.toml
+++ b/fixtures/large/summaries/metadata_libra-4.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv7-unknown-linux-uclibceabihf'
+triple = 'armv7-unknown-linux-musleabihf'
 target-features = 'unknown'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-linux-musl'
+triple = 'mipsel-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra-5.toml
+++ b/fixtures/large/summaries/metadata_libra-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-nto-qnx710'
+triple = 'aarch64-unknown-netbsd'
 target-features = ['rdrand', 'sha', 'sse4.2', 'xsave', 'xsaves']
 flags = ['flag-test']
 

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'thumbv7a-uwp-windows-msvc'
+triple = 'thumbv7a-pc-windows-msvc'
 target-features = ['bmi2', 'rdrand', 'sse4.1']
 flags = ['bar', 'test-flag']
 
 [metadata.target-platform]
-triple = 'sparc-unknown-linux-gnu'
+triple = 's390x-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['foo', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armeb-unknown-linux-gnueabi'
+triple = 'arm64_32-apple-watchos'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'x86_64-apple-darwin'
+triple = 'wasm32-wasip2'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'multipart'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-6.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabihf'
+triple = 'arm-unknown-linux-gnueabi'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'void'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'aarch64_be-unknown-linux-gnu_ilp32'
+triple = 'aarch64-wrs-vxworks'
 target-features = ['avx2', 'fma', 'rdrand', 'sha', 'sse2', 'ssse3', 'xsave']
 [[metadata.omitted-packages.ids]]
 name = 'libfuzzer-sys'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-pc-windows-gnu'
+triple = 'x86_64-pc-solaris'
 target-features = 'unknown'
 
 [metadata.target-platform]
@@ -1109,6 +1109,13 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'arrayref'
 version = '0.3.6'
 crates-io = true
@@ -1699,13 +1706,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'lazy_static'
 version = '1.4.0'
 crates-io = true
@@ -1819,22 +1819,8 @@ status = 'transitive'
 features = ['default', 'with-deprecated']
 
 [[host-package]]
-name = 'mio-named-pipes'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.3.3'
+name = 'mio-uds'
+version = '0.6.7'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1856,6 +1842,20 @@ features = ['default', 'duration']
 [[host-package]]
 name = 'nibble_vec'
 version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nix'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nix'
+version = '0.17.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2375,6 +2375,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'signal-hook-registry'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'slab'
 version = '0.4.2'
 crates-io = true
@@ -2406,13 +2413,6 @@ features = []
 name = 'snappy-sys'
 version = '0.1.0'
 source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'socket2'
-version = '0.3.11'
-crates-io = true
 status = 'transitive'
 features = []
 
@@ -2794,6 +2794,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'vec_map'
 version = '0.8.1'
 crates-io = true
@@ -2806,6 +2813,13 @@ version = '0.9.1'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'wait-timeout'
@@ -2838,55 +2852,6 @@ features = []
 [[host-package]]
 name = 'which'
 version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'impl-debug', 'impl-default', 'ioapiset', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winreg', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-util'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winreg'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-illumos'
+triple = 'x86_64-unknown-l4re-uclibc'
 target-features = ['avx', 'sse3']
 flags = ['abc', 'test-flag']
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-hermit'
+triple = 'riscv64gc-unknown-freebsd'
 target-features = 'unknown'
 flags = ['bar', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips64el-unknown-linux-muslabi64'
+triple = 'mips64el-unknown-linux-gnuabi64'
 target-features = 'unknown'
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-redox'
+triple = 'x86_64-unknown-uefi'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-pc-windows-gnu'
+triple = 'i686-apple-darwin'
 target-features = 'unknown'
 
 [metadata.target-platform]
@@ -2457,20 +2457,6 @@ features = ['default']
 [[host-package]]
 name = 'which'
 version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[host-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-linux-gnu'
+triple = 'x86_64-unknown-linux-gnux32'
 target-features = 'unknown'
 flags = ['abc', 'foo']
 

--- a/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv6k-nintendo-3ds'
+triple = 'armv5te-unknown-linux-uclibceabi'
 target-features = 'unknown'
 flags = ['cargo_web']
 
@@ -2573,6 +2573,13 @@ features = ['std']
 [[host-package]]
 name = 'opaque-debug'
 version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'openssl-probe'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-linux-musl'
+triple = 'riscv64gc-unknown-hermit'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-freebsd'
+triple = 'armv6k-nintendo-3ds'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'base64'

--- a/fixtures/large/summaries/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc-wrs-vxworks-spe'
+triple = 'powerpc64-ibm-aix'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'rand'

--- a/fixtures/large/summaries/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-1.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-pc-windows-gnullvm'
+triple = 'aarch64-linux-android'
 target-features = ['bmi1', 'bmi2', 'sse2', 'sse4.2', 'xsaveopt', 'xsaves']
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-linux-gnu'
+triple = 'aarch64-unknown-fuchsia'
 target-features = ['bmi2', 'ssse3']
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-hermit'
+triple = 'riscv64gc-unknown-freebsd'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/large/summaries/mnemos_b3b4da9-4.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'i586-pc-windows-msvc'
+triple = 'i386-apple-ios'
 target-features = ['xsave']
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/mnemos_b3b4da9-5.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'thumbv7m-none-eabi'
+triple = 'thumbv7em-none-eabihf'
 target-features = []
 flags = ['flag-test', 'foo']
 

--- a/fixtures/large/summaries/mnemos_b3b4da9-6.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i586-unknown-linux-musl'
+triple = 'i586-pc-windows-msvc'
 target-features = 'all'
 flags = ['cargo_web', 'foo']
 
@@ -2685,7 +2685,7 @@ version = '1.0.11'
 crates-io = true
 status = 'transitive'
 features = ['close', 'default', 'hermit-abi', 'libc', 'windows-sys']
-optional-deps = ['libc']
+optional-deps = ['windows-sys']
 
 [[host-package]]
 name = 'is-terminal'
@@ -2720,14 +2720,7 @@ name = 'libc'
 version = '0.2.147'
 crates-io = true
 status = 'transitive'
-features = ['default', 'extra_traits', 'std']
-
-[[host-package]]
-name = 'linux-raw-sys'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['errno', 'general', 'ioctl', 'no_std']
+features = []
 
 [[host-package]]
 name = 'log'
@@ -2904,14 +2897,6 @@ version = '0.4.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'rustix'
-version = '0.37.20'
-crates-io = true
-status = 'transitive'
-features = ['default', 'io-lifetimes', 'libc', 'std', 'termios', 'use-libc-auxv']
-optional-deps = ['io-lifetimes', 'libc']
 
 [[host-package]]
 name = 'rustversion'
@@ -3125,6 +3110,13 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'vcpkg'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.9.4'
 crates-io = true
@@ -3155,6 +3147,34 @@ features = ['spans']
 [[host-package]]
 name = 'wasm-bindgen-shared'
 version = '0.2.87'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['handleapi', 'processenv', 'winbase', 'wincon', 'winnt']
+
+[[host-package]]
+name = 'windows-sys'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Threading', 'default']
+
+[[host-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['riscv64gc-unknown-linux-gnu', 'armv7r-none-eabihf']
+# platforms = ['riscv64gc-unknown-fuchsia', 'armv7r-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'linked-hash-map'
 # version = '0.5.2'

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-wrs-vxworks', 'aarch64-linux-android']
+# platforms = ['x86_64-wrs-vxworks', 'aarch64-fuchsia']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata1-2.toml
+++ b/fixtures/small/hakari/metadata1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-unknown-uefi']
+# platforms = ['aarch64-unknown-redox']
 # [[traversal-excludes.ids]]
 # name = 'regex'
 # version = '1.3.1'

--- a/fixtures/small/hakari/metadata1-3.toml
+++ b/fixtures/small/hakari/metadata1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-pc-windows-msvc', 'i686-pc-windows-gnu', 'armv7a-none-eabi']
+# platforms = ['x86_64-pc-windows-gnullvm', 'i686-apple-darwin', 'armv7a-kmc-solid_asp3-eabi']
 # [[traversal-excludes.ids]]
 # name = 'bitflags'
 # version = '1.1.0'
@@ -52,6 +52,9 @@ quote = { path = "/fakepath/testcrate/../quote" }
 syn = { version = "1", features = ["fold", "full"] }
 unicode-xid = { version = "0.2" }
 version_check = { version = "0.9", default-features = false }
+
+[target.i686-apple-darwin.dependencies]
+mach = { version = "0.2" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata2-1.toml
+++ b/fixtures/small/hakari/metadata2-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['aarch64-apple-tvos', 'armv7-unknown-linux-uclibceabihf']
+# platforms = ['aarch64-apple-tvos-sim', 'armv7-unknown-linux-ohos']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata2-2.toml
+++ b/fixtures/small/hakari/metadata2-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['i686-apple-darwin', 'riscv64gc-unknown-hermit']
+# platforms = ['i586-unknown-netbsd', 'riscv64gc-unknown-freebsd']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata2-3.toml
+++ b/fixtures/small/hakari/metadata2-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64-unknown-uefi', 'mips64el-unknown-linux-muslabi64', 'riscv32gc-unknown-linux-gnu']
+# platforms = ['aarch64-unknown-redox', 'mips64el-unknown-linux-gnuabi64', 'riscv32gc-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'

--- a/fixtures/small/hakari/metadata_alternate_registries-0.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv7s-apple-ios', 'riscv32gc-unknown-linux-gnu', 'powerpc64-unknown-linux-musl']
+# platforms = ['armv7r-none-eabi', 'riscv32gc-unknown-linux-gnu', 'powerpc64-unknown-linux-musl']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_alternate_registries-1.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['i686-unknown-openbsd', 'arm-unknown-linux-musleabihf']
+# platforms = ['i686-unknown-netbsd', 'arm-unknown-linux-musleabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_builddep-0.toml
+++ b/fixtures/small/hakari/metadata_builddep-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['powerpc-unknown-netbsd', 'mipsisa32r6el-unknown-linux-gnu', 'i686-unknown-netbsd']
+# platforms = ['powerpc-unknown-netbsd', 'mipsisa32r6-unknown-linux-gnu', 'i686-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['wasm32-unknown-unknown', 'armv4t-unknown-linux-gnueabi', 'riscv64gc-unknown-linux-musl']
+# platforms = ['wasm32-unknown-unknown', 'armebv7r-none-eabi', 'riscv64gc-unknown-hermit']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-3.toml
+++ b/fixtures/small/hakari/metadata_builddep-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['i686-unknown-freebsd', 'riscv64gc-unknown-linux-musl']
+# platforms = ['i686-pc-windows-msvc', 'riscv64gc-unknown-hermit']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-0.toml
+++ b/fixtures/small/hakari/metadata_cycle1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['thumbv8m.main-none-eabihf', 'x86_64-apple-ios']
+# platforms = ['thumbv8m.main-none-eabihf', 'x86_64-apple-darwin']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-1.toml
+++ b/fixtures/small/hakari/metadata_cycle1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['riscv64gc-unknown-none-elf', 'x86_64-apple-darwin', 'mips64-unknown-linux-gnuabi64']
+# platforms = ['riscv64gc-unknown-linux-musl', 'wasm64-unknown-unknown', 'mips64-openwrt-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-apple-ios-macabi', 'x86_64-pc-windows-msvc']
+# platforms = ['aarch64-apple-ios-macabi', 'x86_64-pc-windows-gnullvm']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-1.toml
+++ b/fixtures/small/hakari/metadata_cycle2-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['armv7-unknown-freebsd']
+# platforms = ['armv7-linux-androideabi']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-2.toml
+++ b/fixtures/small/hakari/metadata_cycle2-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['mipsisa32r6el-unknown-linux-gnu', 'aarch64-apple-tvos-sim', 'thumbv8m.main-none-eabihf']
+# platforms = ['mipsisa32r6-unknown-linux-gnu', 'aarch64-apple-tvos-sim', 'thumbv8m.main-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-0.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armv7-sony-vita-newlibeabihf', 'riscv32gc-unknown-linux-musl', 'x86_64-apple-darwin']
+# platforms = ['armv6-unknown-netbsd-eabihf', 'riscv32i-unknown-none-elf', 'wasm64-unknown-unknown']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-helper'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-1.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['x86_64-apple-watchos-sim', 'mips-unknown-linux-gnu']
+# platforms = ['x86_64-apple-tvos', 'loongarch64-unknown-none-softfloat']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-3.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-unknown-linux-musl', 'armv5te-unknown-linux-uclibceabi']
+# platforms = ['x86_64-unknown-linux-none', 'armv5te-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_dups-0.toml
+++ b/fixtures/small/hakari/metadata_dups-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['mipsel-unknown-none', 'i686-unknown-uefi']
+# platforms = ['mipsel-unknown-netbsd', 'i686-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.3.0'

--- a/fixtures/small/hakari/metadata_dups-1.toml
+++ b/fixtures/small/hakari/metadata_dups-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['i586-pc-nto-qnx700', 'riscv32imac-unknown-xous-elf', 'armv4t-unknown-linux-gnueabi']
+# platforms = ['hexagon-unknown-none-elf', 'riscv32imac-unknown-xous-elf', 'armebv7r-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'lazy_static'
 # version = '0.2.11'

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv4t-unknown-linux-gnueabi']
+# platforms = ['armeb-unknown-linux-gnueabi']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.3.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-0.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-uwp-windows-msvc', 'x86_64h-apple-darwin', 'powerpc-wrs-vxworks-spe']
+# platforms = ['aarch64-unknown-teeos', 'x86_64h-apple-darwin', 'powerpc-wrs-vxworks-spe']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_proc_macro1-1.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-apple-tvos', 'armv7k-apple-watchos', 'armv7-unknown-netbsd-eabihf']
+# platforms = ['x86_64-apple-ios-macabi', 'armv7a-none-eabihf', 'armv7-unknown-linux-uclibceabi']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-2.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['mipsel-unknown-linux-musl', 'powerpc-unknown-linux-musl']
+# platforms = ['mipsel-unknown-linux-gnu', 'powerpc-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-3.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['arm-unknown-linux-musleabihf', 'armv7-wrs-vxworks-eabihf', 'aarch64-unknown-redox']
+# platforms = ['arm-unknown-linux-musleabi', 'armv7-unknown-linux-uclibceabihf', 'aarch64-unknown-nto-qnx710']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_targets1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['aarch64-apple-ios-macabi', 'armv7-unknown-linux-gnueabi']
+# platforms = ['aarch64-apple-ios-macabi', 'armv7-linux-androideabi']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_targets1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['armv7a-kmc-solid_asp3-eabihf', 'mips64el-unknown-linux-gnuabi64', 'i686-pc-windows-gnu']
+# platforms = ['armv7-wrs-vxworks-eabihf', 'mips64-unknown-linux-gnuabi64', 'i686-linux-android']
 # [[traversal-excludes.ids]]
 # name = 'serde'
 # version = '1.0.105'
@@ -20,14 +20,14 @@ bytes = { version = "0.5", features = ["serde"] }
 dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false, features = ["bar", "baz", "foo", "quux"] }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 
-[target.armv7a-kmc-solid_asp3-eabihf.dependencies]
+[target.armv7-wrs-vxworks-eabihf.dependencies]
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
-[target.mips64el-unknown-linux-gnuabi64.dependencies]
+[target.mips64-unknown-linux-gnuabi64.dependencies]
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
-[target.i686-pc-windows-gnu.dependencies]
-lazy_static-c65f7effa3be6d31 = { package = "lazy_static", version = "0.1", default-features = false }
+[target.i686-linux-android.dependencies]
+lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_targets1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['i686-pc-windows-msvc', 'armebv7r-none-eabihf', 'powerpc-wrs-vxworks-spe']
+# platforms = ['i686-pc-windows-gnu', 'arm64e-apple-ios', 'powerpc64-ibm-aix']
 # [[traversal-excludes.ids]]
 # name = 'dep-a'
 # version = '0.1.0'
@@ -26,7 +26,7 @@
 bytes = { version = "0.5", features = ["serde"] }
 serde = { version = "1" }
 
-[target.i686-pc-windows-msvc.dependencies]
+[target.i686-pc-windows-gnu.dependencies]
 lazy_static = { version = "0.1", default-features = false }
 
 ### END HAKARI SECTION

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['wasm64-unknown-unknown', 'mips64-unknown-linux-muslabi64']
+# platforms = ['wasm32-wasip1-threads', 'mips64-openwrt-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'
 # version = '0.7.2'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['sparc-unknown-linux-gnu', 'riscv32imc-esp-espidf', 'powerpc64le-unknown-linux-gnu']
+# platforms = ['s390x-unknown-linux-musl', 'riscv32imac-unknown-xous-elf', 'powerpc64le-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'
 # version = '0.7.2'

--- a/fixtures/small/summaries/metadata1-0.toml
+++ b/fixtures/small/summaries/metadata1-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armeb-unknown-linux-gnueabi'
+triple = 'arm64_32-apple-watchos'
 target-features = 'unknown'
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata1-2.toml
+++ b/fixtures/small/summaries/metadata1-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-netbsd'
+triple = 'riscv64gc-unknown-linux-gnu'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata1-3.toml
+++ b/fixtures/small/summaries/metadata1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'sparc64-unknown-linux-gnu'
+triple = 'sparc-unknown-none-elf'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'serde'

--- a/fixtures/small/summaries/metadata1-5.toml
+++ b/fixtures/small/summaries/metadata1-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'i686-unknown-linux-musl'
+triple = 'i686-unknown-linux-gnu'
 target-features = 'all'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata1-6.toml
+++ b/fixtures/small/summaries/metadata1-6.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i586-unknown-netbsd'
+triple = 'i586-unknown-linux-gnu'
 target-features = 'all'
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'x86_64-apple-ios'
+triple = 'wasm64-unknown-unknown'
 target-features = ['avx2', 'sse2', 'ssse3', 'xsave']
 flags = ['abc']
 
@@ -80,13 +80,6 @@ version = '0.5.2'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'mach'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'deprecated', 'use_std']
 
 [[target-package]]
 name = 'memchr'

--- a/fixtures/small/summaries/metadata1-7.toml
+++ b/fixtures/small/summaries/metadata1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'arm-unknown-linux-musleabi'
+triple = 'arm-unknown-linux-gnueabi'
 target-features = 'unknown'
 flags = ['flag-test', 'foo']
 
 [metadata.target-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'riscv64imac-unknown-none-elf'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata2-0.toml
+++ b/fixtures/small/summaries/metadata2-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-linux-gnu'
+triple = 'riscv64gc-unknown-fuchsia'
 target-features = 'unknown'
 flags = ['abc', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata2-1.toml
+++ b/fixtures/small/summaries/metadata2-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64_be-unknown-netbsd'
+triple = 'aarch64_be-unknown-linux-gnu_ilp32'
 target-features = 'all'
 flags = ['abc', 'cargo_web']
 

--- a/fixtures/small/summaries/metadata2-2.toml
+++ b/fixtures/small/summaries/metadata2-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-hermit'
+triple = 'riscv64gc-unknown-freebsd'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata2-3.toml
+++ b/fixtures/small/summaries/metadata2-3.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv32imc-unknown-none-elf'
+triple = 'riscv32imafc-unknown-none-elf'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-fuchsia'
+triple = 'riscv64-linux-android'
 target-features = ['sse4.2', 'xsaveopt', 'xsaves']
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-0.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32imc-unknown-none-elf'
+triple = 'riscv32imafc-esp-espidf'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_alternate_registries-1.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-1.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7a-kmc-solid_asp3-eabihf'
+triple = 'armv7-wrs-vxworks-eabihf'
 target-features = ['aes', 'fma', 'sha', 'sse2', 'xsavec']
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-uclibc'
+triple = 'mips-unknown-linux-gnu'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'quote'

--- a/fixtures/small/summaries/metadata_alternate_registries-2.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'loongarch64-unknown-linux-gnu'
+triple = 'i686-wrs-vxworks'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_alternate_registries-3.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32gc-unknown-linux-musl'
+triple = 'riscv32i-unknown-none-elf'
 target-features = 'all'
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-4.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-apple-watchos-sim'
+triple = 'x86_64-apple-ios-macabi'
 target-features = 'all'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_alternate_registries-6.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'hexagon-unknown-linux-musl'
+triple = 'csky-unknown-linux-gnuabiv2hf'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'proc-macro2'

--- a/fixtures/small/summaries/metadata_alternate_registries-7.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'loongarch64-unknown-none'
+triple = 'loongarch64-unknown-linux-gnu'
 target-features = 'all'
 flags = ['flag-test', 'foo']
 

--- a/fixtures/small/summaries/metadata_build_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'avr-unknown-gnu-atmega328'
+triple = 'armv7s-apple-ios'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-freebsd'
+triple = 'riscv32imc-esp-espidf'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'riscv64imac-unknown-none-elf'
 target-features = 'all'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'i686-uwp-windows-msvc'
+triple = 'i686-uwp-windows-gnu'
 target-features = ['bmi1', 'sse', 'sse3', 'sse4.1', 'ssse3', 'xsavec']
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_builddep-0.toml
+++ b/fixtures/small/summaries/metadata_builddep-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-wrs-vxworks'
+triple = 'i686-uwp-windows-msvc'
 target-features = 'all'
 flags = ['test-flag']
 
 [metadata.target-platform]
-triple = 'thumbv7neon-linux-androideabi'
+triple = 'thumbv7m-none-eabi'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_builddep-2.toml
+++ b/fixtures/small/summaries/metadata_builddep-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-linux-musl'
+triple = 'aarch64-unknown-illumos'
 target-features = 'unknown'
 flags = ['cargo_web', 'test-flag']
 

--- a/fixtures/small/summaries/metadata_builddep-3.toml
+++ b/fixtures/small/summaries/metadata_builddep-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv6-unknown-freebsd'
+triple = 'armv5te-none-eabi'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'builddep'

--- a/fixtures/small/summaries/metadata_builddep-6.toml
+++ b/fixtures/small/summaries/metadata_builddep-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'arm-linux-androideabi'
+triple = 'aarch64_be-unknown-netbsd'
 target-features = 'all'
 flags = ['cargo_web', 'foo']
 

--- a/fixtures/small/summaries/metadata_cycle1-0.toml
+++ b/fixtures/small/summaries/metadata_cycle1-0.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'wasm32-wasi-preview1-threads'
+triple = 'wasm32-wasip1-threads'
 target-features = 'unknown'
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_cycle1-1.toml
+++ b/fixtures/small/summaries/metadata_cycle1-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-sun-solaris'
+triple = 'x86_64-unikraft-linux-musl'
 target-features = 'unknown'
 flags = ['abc', 'bar']
 

--- a/fixtures/small/summaries/metadata_cycle1-2.toml
+++ b/fixtures/small/summaries/metadata_cycle1-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-none-softfloat'
+triple = 'aarch64-unknown-linux-ohos'
 target-features = []
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_cycle1-3.toml
+++ b/fixtures/small/summaries/metadata_cycle1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7s-apple-ios'
+triple = 'armv7r-none-eabi'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle1-5.toml
+++ b/fixtures/small/summaries/metadata_cycle1-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mips64-unknown-linux-gnuabi64'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle1-6.toml
+++ b/fixtures/small/summaries/metadata_cycle1-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv4t-none-eabi'
+triple = 'armeb-unknown-linux-gnueabi'
 target-features = 'all'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'aarch64-pc-windows-msvc'
+triple = 'aarch64-nintendo-switch-freestanding'
 target-features = 'all'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle1-7.toml
+++ b/fixtures/small/summaries/metadata_cycle1-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32gc-unknown-linux-gnu'
+triple = 'riscv32gc-unknown-linux-musl'
 target-features = ['bmi1', 'sha', 'sse4.2', 'xsaveopt']
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_cycle2-2.toml
+++ b/fixtures/small/summaries/metadata_cycle2-2.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32imac-unknown-xous-elf'
+triple = 'riscv32imac-unknown-none-elf'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-linux-ohos'
+triple = 'x86_64-unknown-netbsd'
 target-features = ['avx', 'bmi1']
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-4.toml
+++ b/fixtures/small/summaries/metadata_cycle2-4.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-linux-gnu'
+triple = 'x86_64-unknown-linux-gnux32'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle2-5.toml
+++ b/fixtures/small/summaries/metadata_cycle2-5.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7r-none-eabi'
+triple = 'armv7a-none-eabihf'
 target-features = 'unknown'
 flags = ['bar']
 

--- a/fixtures/small/summaries/metadata_cycle2-6.toml
+++ b/fixtures/small/summaries/metadata_cycle2-6.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'arm-linux-androideabi'
+triple = 'aarch64_be-unknown-netbsd'
 target-features = 'unknown'
 flags = ['bar', 'flag-test']
 
 [metadata.target-platform]
-triple = 'armv4t-none-eabi'
+triple = 'arm64ec-pc-windows-msvc'
 target-features = 'unknown'
 
 [[metadata.features-only]]

--- a/fixtures/small/summaries/metadata_cycle_features-1.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-gnu'
+triple = 'loongarch64-unknown-none-softfloat'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-2.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'armv4t-unknown-linux-gnueabi'
+triple = 'armeb-unknown-linux-gnueabi'
 target-features = ['fma', 'rdrand', 'sha']
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-3.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-3.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-linux-gnu'
+triple = 'riscv64gc-unknown-fuchsia'
 target-features = 'all'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'i586-pc-windows-msvc'
+triple = 'i386-apple-ios'
 target-features = ['bmi2', 'sse', 'sse4.1']
 flags = ['bar', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-4.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-freebsd'
+triple = 'x86_64-unknown-fuchsia'
 target-features = 'all'
 flags = ['foo', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-5.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-5.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-unknown-uefi'
+triple = 'i686-unknown-openbsd'
 target-features = 'all'
 flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-triple = 'i686-apple-darwin'
+triple = 'i586-unknown-netbsd'
 target-features = 'unknown'
 flags = ['cargo_web', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-6.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'loongarch64-unknown-none-softfloat'
+triple = 'loongarch64-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_cycle_features-7.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-7.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-uwp-windows-msvc'
+triple = 'x86_64-win7-windows-msvc'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'armv5te-unknown-linux-musleabi'
+triple = 'armv4t-unknown-linux-gnueabi'
 target-features = 'all'
 
 [[target-package]]

--- a/fixtures/small/summaries/metadata_dups-0.toml
+++ b/fixtures/small/summaries/metadata_dups-0.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-apple-ios-macabi'
+triple = 'x86_64-apple-darwin'
 target-features = 'all'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'riscv32imac-esp-espidf'
+triple = 'riscv32ima-unknown-none-elf'
 target-features = []
 flags = ['cargo_web', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_dups-1.toml
+++ b/fixtures/small/summaries/metadata_dups-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-linux-ohos'
+triple = 'aarch64-unknown-linux-gnu'
 target-features = []
 flags = ['test-flag']
 

--- a/fixtures/small/summaries/metadata_dups-3.toml
+++ b/fixtures/small/summaries/metadata_dups-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-pc-windows-gnullvm'
+triple = 'x86_64-pc-windows-gnu'
 target-features = 'all'
 flags = ['test-flag']
 

--- a/fixtures/small/summaries/metadata_dups-4.toml
+++ b/fixtures/small/summaries/metadata_dups-4.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'i686-wrs-vxworks'
+triple = 'i686-uwp-windows-msvc'
 target-features = 'unknown'
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'x86_64-pc-windows-msvc'
+triple = 'x86_64-pc-windows-gnullvm'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'lazy_static'

--- a/fixtures/small/summaries/metadata_dups-5.toml
+++ b/fixtures/small/summaries/metadata_dups-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'nvptx64-nvidia-cuda'
+triple = 'msp430-none-elf'
 target-features = 'all'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_proc_macro1-0.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32i-unknown-none-elf'
+triple = 'riscv32im-risc0-zkvm-elf'
 target-features = ['ssse3', 'xsaves']
 flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-hermit'
+triple = 'x86_64-unknown-illumos'
 target-features = 'unknown'
 flags = ['test-flag']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-2.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-netbsd'
+triple = 'riscv64gc-unknown-linux-gnu'
 target-features = ['fma', 'sse4.1']
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-3.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-linux-android'
+triple = 'x86_64-fuchsia'
 target-features = []
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-6.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-6.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-wrs-vxworks'
+triple = 'x86_64-win7-windows-msvc'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_proc_macro1-7.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-none-softfloat'
+triple = 'aarch64-unknown-netbsd'
 target-features = 'all'
 flags = ['abc', 'cargo_web']
 

--- a/fixtures/small/summaries/metadata_targets1-0.toml
+++ b/fixtures/small/summaries/metadata_targets1-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-fuchsia'
+triple = 'aarch64-apple-watchos'
 target-features = ['fma', 'sse', 'sse3', 'sse4.2', 'xsavec', 'xsaveopt']
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_targets1-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7a-none-eabi'
+triple = 'armv7a-kmc-solid_asp3-eabi'
 target-features = 'unknown'
 flags = ['abc', 'bar']
 

--- a/fixtures/small/summaries/metadata_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_targets1-2.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mips64-unknown-linux-gnuabi64'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'armv5te-unknown-linux-uclibceabi'
+triple = 'armv5te-none-eabi'
 target-features = 'unknown'
 flags = ['abc', 'bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_targets1-4.toml
+++ b/fixtures/small/summaries/metadata_targets1-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-sun-solaris'
+triple = 'x86_64-pc-windows-msvc'
 target-features = []
 flags = ['foo']
 

--- a/fixtures/small/summaries/metadata_targets1-5.toml
+++ b/fixtures/small/summaries/metadata_targets1-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'armv7r-none-eabihf'
+triple = 'armv7k-apple-watchos'
 target-features = []
 [[metadata.omitted-packages.ids]]
 name = 'bytes'

--- a/fixtures/small/summaries/metadata_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_targets1-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32imc-unknown-none-elf'
+triple = 'riscv32imafc-unknown-none-elf'
 target-features = ['rdrand']
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'mips64-unknown-linux-muslabi64'
+triple = 'mips64-openwrt-linux-musl'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'dep-a'

--- a/fixtures/small/summaries/metadata_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_targets1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-none'
+triple = 'mipsel-unknown-netbsd'
 target-features = ['avx2', 'sse3']
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-gnu'
+triple = 'loongarch64-unknown-none-softfloat'
 target-features = 'unknown'
 
 [[metadata.features-only]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-sony-vita-newlibeabihf'
+triple = 'armv6-unknown-netbsd-eabihf'
 target-features = 'unknown'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'm68k-unknown-linux-gnu'
+triple = 'loongarch64-unknown-none'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabihf'
+triple = 'arm-linux-androideabi'
 target-features = ['xsave', 'xsavec', 'xsaves']
 flags = ['bar', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-2.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-pc-solaris'
+triple = 'x86_64-pc-nto-qnx710'
 target-features = ['avx2']
 [[metadata.omitted-packages.ids]]
 name = 'namespaced-weak'

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-5.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv5te-unknown-linux-uclibceabi'
+triple = 'armv5te-none-eabi'
 target-features = 'unknown'
 flags = ['abc', 'cargo_web']
 

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-6.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-linux-gnu'
+triple = 'mipsel-sony-psp'
 target-features = 'all'
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-7.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-7.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'i586-unknown-netbsd'
+triple = 'i586-unknown-linux-musl'
 target-features = 'all'
 flags = ['abc']
 

--- a/guppy/src/graph/feature/graph_impl.rs
+++ b/guppy/src/graph/feature/graph_impl.rs
@@ -593,7 +593,7 @@ impl<'g> fmt::Display for FeatureLabel<'g> {
 }
 
 /// Metadata for a feature within a package.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct FeatureMetadata<'g> {
     graph: DebugIgnore<FeatureGraph<'g>>,
     node: FeatureNode,
@@ -638,6 +638,14 @@ impl<'g> FeatureMetadata<'g> {
     #[inline]
     pub(in crate::graph) fn feature_ix(&self) -> NodeIndex<FeatureIx> {
         self.inner.feature_ix
+    }
+}
+
+impl fmt::Debug for FeatureMetadata<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FeatureMetadata")
+            .field("id", &self.feature_id())
+            .finish()
     }
 }
 
@@ -722,7 +730,7 @@ impl FeatureGraphImpl {
 /// If a dependency, for example `unix-dep` above, is optional, an implicit feature is created in
 /// the package `main` with the name `unix-dep`. In this case, the dependency from `main/feat` to
 /// `main/unix-dep` is also a `ConditionalLink` representing the same `cfg(unix)` condition.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone)]
 pub struct ConditionalLink<'g> {
     graph: DebugIgnore<FeatureGraph<'g>>,
     from: &'g FeatureMetadataImpl,
@@ -829,6 +837,18 @@ impl<'g> ConditionalLink<'g> {
     #[allow(dead_code)]
     pub(in crate::graph) fn package_edge_ix(&self) -> EdgeIndex<PackageIx> {
         self.inner.package_edge_ix
+    }
+}
+
+impl fmt::Debug for ConditionalLink<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConditionalLink")
+            .field("from", &self.from())
+            .field("to", &self.to())
+            .field("normal", &self.normal())
+            .field("build", &self.build())
+            .field("dev", &self.dev())
+            .finish()
     }
 }
 

--- a/internal-tools/cargo-compare/Cargo.toml
+++ b/internal-tools/cargo-compare/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.83"
-cargo = { version = "0.76.0", features = ["vendored-libgit2"] }
+cargo = { version = "0.81.0", features = ["vendored-libgit2"] }
 clap = { version = "3.2.25", features = ["derive"] }
 color-eyre = { version = "0.6.3", default-features = false }
 diffus = "0.10.0"

--- a/internal-tools/cargo-compare/src/diff.rs
+++ b/internal-tools/cargo-compare/src/diff.rs
@@ -43,6 +43,9 @@ impl DiffOpts {
         let cargo_map = anyhow_to_eyre(self.common.resolve_cargo(ctx))?;
         let guppy_map = self.common.resolve_guppy(ctx)?;
 
+        // println!("guppy_map: {:#?}", guppy_map.host_map);
+        // println!("cargo_map: {:#?}", cargo_map.host_map);
+
         let target_diff = FeatureDiff {
             graph: ctx.graph(),
             a: guppy_map.target_map,

--- a/internal-tools/cargo-compare/src/type_conversions.rs
+++ b/internal-tools/cargo-compare/src/type_conversions.rs
@@ -16,12 +16,7 @@ impl ToGuppy for cargo::core::PackageId {
 
     fn to_guppy(&self) -> Self::Guppy {
         // This is the same format as the Serialize impl of cargo's PackageId.
-        guppy::PackageId::new(format!(
-            "{} {} ({})",
-            self.name(),
-            self.version(),
-            self.source_id().as_url(),
-        ))
+        guppy::PackageId::new(self.to_spec().to_string())
     }
 }
 

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg=doc_cfg"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-cfg-expr = { version = "0.15.6", features = ["targets"] }
+cfg-expr = { version = "0.16.0", features = ["targets"] }
 proptest = { version = "1.4.0", optional = true }
 serde = { version = "1.0.202", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.117", optional = true }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -17,15 +17,15 @@ repository = "https://github.com/guppy-rs/guppy"
 ### BEGIN HAKARI SECTION
 [dependencies]
 aho-corasick = { version = "1.1.2" }
-clap = { version = "4.4.18", features = ["derive"] }
-clap_builder = { version = "4.4.18", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
+clap = { version = "4.5.11", features = ["derive"] }
+clap_builder = { version = "4.5.11", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 getrandom = { version = "0.2.12", default-features = false, features = ["std"] }
 indexmap = { version = "1.9.3", default-features = false, features = ["std"] }
 log = { version = "0.4.21", default-features = false, features = ["std"] }
 num-traits = { version = "0.2.17", features = ["libm"] }
 owo-colors = { version = "3.5.0", default-features = false, features = ["supports-colors"] }
 petgraph = { version = "0.6.5", default-features = false, features = ["graphmap"] }
-regex = { version = "1.10.3", default-features = false, features = ["perf", "std"] }
+regex = { version = "1.10.5", default-features = false, features = ["perf", "std"] }
 regex-automata = { version = "0.4.5", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa", "perf"] }
 regex-syntax = { version = "0.8.2" }
 semver = { version = "1.0.23", features = ["serde"] }
@@ -40,31 +40,31 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.48", features = ["extra-traits", "full"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-libc = { version = "0.2.153" }
-memchr = { version = "2.7.1", default-features = false, features = ["std"] }
+libc = { version = "0.2.155" }
+memchr = { version = "2.7.4", default-features = false, features = ["std"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.31", features = ["fs", "termios"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-libc = { version = "0.2.153" }
+libc = { version = "0.2.155" }
 
 [target.x86_64-apple-darwin.dependencies]
-libc = { version = "0.2.153", features = ["extra_traits"] }
-memchr = { version = "2.7.1", default-features = false, features = ["std"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
+memchr = { version = "2.7.4", default-features = false, features = ["std"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.31", features = ["fs", "termios"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-libc = { version = "0.2.153", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 
 [target.aarch64-apple-darwin.dependencies]
-libc = { version = "0.2.153", features = ["extra_traits"] }
-memchr = { version = "2.7.1", default-features = false, features = ["std"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
+memchr = { version = "2.7.4", default-features = false, features = ["std"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.31", features = ["fs", "termios"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-libc = { version = "0.2.153", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 once_cell = { version = "1.19.0" }


### PR DESCRIPTION
Fix a small bug in feature resolution, and update cfg-expr and Cargo to the new versions.