### PR TITLE
[cargo-hakari] add edition = 2021 to new project template

### DIFF
--- a/tools/hakari/templates/crate/Cargo.toml-in
+++ b/tools/hakari/templates/crate/Cargo.toml-in
@@ -3,6 +3,7 @@
 [package]
 name = "%PACKAGE_NAME%"
 version = "0.1.0"
+edition = "2021"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false


### PR DESCRIPTION
Newer versions of Rust add a warning if the edition isn't set.

Fixes #318.