### PR TITLE
Help fix nextest-issue-1684

### DIFF
--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -399,15 +399,21 @@ impl<'a> GraphBuildState<'a> {
         id: &PackageId,
         manifest_path: &Utf8Path,
     ) -> Result<Box<Utf8Path>, Box<Error>> {
-        // Strip off the workspace path from the manifest path.
-        let workspace_path = manifest_path
-            .strip_prefix(self.workspace_root)
-            .map_err(|_| {
-                Error::PackageGraphConstructError(format!(
-                    "workspace member '{}' at path {} not in workspace (root: {})",
-                    id, manifest_path, self.workspace_root
-                ))
-            })?;
+        // Try to strip off the workspace path from the manifest path.
+        let _utf8_path_buf; // relative path lifetime helper
+        let workspace_path = if let Ok(stripped_workspace_path) =
+            manifest_path.strip_prefix(self.workspace_root)
+        {
+            stripped_workspace_path
+        } else {
+            // Error::PackageGraphConstructError(format!(
+            //     "workspace member '{}' at path {} not in workspace (root: {})",
+            //     id, manifest_path, self.workspace_root
+            // ));
+            // If manifest path is out of workspace root, try find relative path instead
+            _utf8_path_buf = find_relative_path_utf8(self.workspace_root, manifest_path);
+            _utf8_path_buf.as_path()
+        };
         let workspace_path = workspace_path.parent().ok_or_else(|| {
             Error::PackageGraphConstructError(format!(
                 "workspace member '{}' has invalid manifest path {:?}",
@@ -1002,6 +1008,42 @@ fn convert_forward_slashes<'a>(rel_path: impl Into<Cow<'a, Utf8Path>>) -> Utf8Pa
     }
 }
 
+// Calculate the relative path from `from` to `to`.
+// This function finds the relative path between two given paths.
+// It first identifies the common prefix between the two paths and then
+// constructs the relative path by adding ".." for each remaining component
+// in the `from` path and appending the remaining components from the `to` path.
+#[track_caller]
+pub fn find_relative_path_utf8(from: &Utf8Path, to: &Utf8Path) -> Utf8PathBuf {
+    let from_path = from;
+    let to_path = to;
+
+    let mut from_components = from_path.components();
+    let mut to_components = to_path.components();
+
+    // Initialize an empty Utf8PathBuf to store the relative path
+    let mut relative_path = Utf8PathBuf::new();
+
+    // Iterate through the components of both paths to find the common prefix
+    while let (Some(f), Some(t)) = (from_components.next(), to_components.next()) {
+        if f != t {
+            // If the components differ, add ".." for each remaining component in the `from` path
+            relative_path.push("..");
+            let from_remaining = from_components.as_path();
+            for _ in from_remaining.components() {
+                relative_path.push("..");
+            }
+            // Add the current component from the `to` path
+            relative_path.push(t);
+            break;
+        }
+    }
+
+    // Append the remaining components from the `to` path
+    relative_path.extend(to_components.as_path().components());
+    relative_path
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1060,5 +1102,19 @@ mod tests {
         let path = convert_forward_slashes(path);
         // This should have forward slashes, even on Windows.
         assert_eq!(path.as_str(), "../../foo/bar/baz.txt");
+    }
+
+    #[test]
+    fn test_workspace_path_out_of_pocket() {
+        let path_workspace_root = "/workspace/a/b/.cargo/workspace";
+        let path_manifest = "/workspace/a/b/Crate/Cargo.toml";
+
+        let expected_relative_path = r"../../Crate/Cargo.toml";
+
+        let relative_path = find_relative_path_utf8(
+            Utf8Path::new(path_workspace_root),
+            Utf8Path::new(path_manifest),
+        );
+        assert_eq!(convert_forward_slashes(relative_path), expected_relative_path);
     }
 }


### PR DESCRIPTION
Fix: Allow Nextest to Work with Manifests Outside of Workspace Root Path
Description
This pull request addresses an issue where Nextest fails to function correctly when the Cargo.toml manifest file is located outside of the workspace root path. The changes ensure that Nextest can handle such scenarios gracefully.

Changes
Updated the guppy crate to include a helper function for resolving paths outside the workspace root.

Modified the guppy/src/graph/build.rs fn workspace_path() #402~#410 to incorporate the new path resolution logic in case there's out of root.
Helper fn find_relative_path_utf8() placed at the end of build.rs, together with test case.

Issue
This pull request fixes nextest-rs/nextest issue #1684.

Testing
Verified that Nextest can now correctly locate and use Cargo.toml files outside the workspace root.

Ran existing test suites to ensure no regressions were introduced.