### PR TITLE
Fix: Allow Nextest to Work with Manifests Outside of Workspace Root Path (nextest-rs/nextest issue #1684) v2

### DIFF
--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -1047,7 +1047,6 @@ mod tests {
         path_workspace_root: &str,
         expected_relative_path: &str,
     ) {
-        use crate::graph::build::Utf8Path;
         let relative_path = pathdiff::diff_utf8_paths(
             Utf8Path::new(path_manifest),
             Utf8Path::new(path_workspace_root),

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -1052,12 +1052,21 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_forward_slashes() {
+    fn test_convert_relative_forward_slashes() {
         let components = vec!["..", "..", "foo", "bar", "baz.txt"];
         let path: Utf8PathBuf = components.into_iter().collect();
         let path = convert_relative_forward_slashes(path);
-        // This should have forward slashes, even on Windows.
+        // This should have forward-slashes, even on Windows.
         assert_eq!(path.as_str(), "../../foo/bar/baz.txt");
+    }
+
+    #[test]
+    fn test_convert_relative_forward_slashes_absolute() {
+        let components = vec![r"D:\", "X", "..", "foo", "bar", "baz.txt"];
+        let path: Utf8PathBuf = components.into_iter().collect();
+        let path = convert_relative_forward_slashes(path);
+        // Absolute path keep using backslash on Windows.
+        assert_eq!(path.as_str(), r"D:\X\..\foo\bar\baz.txt");
     }
 
     #[track_caller]

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -1090,13 +1090,13 @@ mod tests {
             // Absolute path keep using backslash on Windows.
             assert_eq!(path.as_str(), r"D:\X\..\foo\bar\baz.txt");
         }
-    
+
         #[test]
         fn test_workspace_path_out_of_pocket_on_windows_same_driver() {
             verify_result_of_diff_utf8_paths(
                 r"C:\workspace\a\b\Crate\Cargo.toml",
                 r"C:\workspace\a\b\.cargo\workspace",
-                r"..\..\Crate\Cargo.toml"
+                r"..\..\Crate\Cargo.toml",
             );
         }
 
@@ -1105,7 +1105,7 @@ mod tests {
             verify_result_of_diff_utf8_paths(
                 r"D:\workspace\a\b\Crate\Cargo.toml",
                 r"C:\workspace\a\b\.cargo\workspace",
-                r"D:\workspace\a\b\Crate\Cargo.toml"
+                r"D:\workspace\a\b\Crate\Cargo.toml",
             );
         }
     }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -392,20 +392,18 @@ impl<'a> GraphBuildState<'a> {
         Ok((package_data, build_targets))
     }
 
-    /// Computes the workspace path for this package. Errors if this package is not in the
-    /// workspace.
+    /// Computes the relative path from workspace root to this package, which might be out of root sub tree.
     fn workspace_path(
         &self,
         id: &PackageId,
         manifest_path: &Utf8Path,
     ) -> Result<Box<Utf8Path>, Box<Error>> {
-        // Strip off the workspace path from the manifest path.
-        let workspace_path = manifest_path
-            .strip_prefix(self.workspace_root)
-            .map_err(|_| {
+        // Get relative path from workspace root to manifest path.
+        let workspace_path = pathdiff::diff_utf8_paths(manifest_path, self.workspace_root)
+            .ok_or_else(|| {
                 Error::PackageGraphConstructError(format!(
-                    "workspace member '{}' at path {} not in workspace (root: {})",
-                    id, manifest_path, self.workspace_root
+                    "failed to find relative path from workspace (root: {}) to member '{}' at path {}",
+                    self.workspace_root, id, manifest_path 
                 ))
             })?;
         let workspace_path = workspace_path.parent().ok_or_else(|| {
@@ -983,21 +981,16 @@ impl PackagePublishImpl {
     }
 }
 
-/// Replace backslashes in a relative path with forward slashes on Windows.
+/// Replace backslashes in a path with forward slashes on Windows.
 #[track_caller]
-fn convert_forward_slashes<'a>(rel_path: impl Into<Cow<'a, Utf8Path>>) -> Utf8PathBuf {
-    let rel_path = rel_path.into();
-    debug_assert!(
-        rel_path.is_relative(),
-        "path {} should be relative",
-        rel_path,
-    );
+fn convert_forward_slashes<'a>(path: impl Into<Cow<'a, Utf8Path>>) -> Utf8PathBuf {
+    let path = path.into();
 
     cfg_if::cfg_if! {
         if #[cfg(windows)] {
-            rel_path.as_str().replace("\\", "/").into()
+            path.as_str().replace("\\", "/").into()
         } else {
-            rel_path.into_owned()
+            path.into_owned()
         }
     }
 }
@@ -1060,5 +1053,50 @@ mod tests {
         let path = convert_forward_slashes(path);
         // This should have forward slashes, even on Windows.
         assert_eq!(path.as_str(), "../../foo/bar/baz.txt");
+    }
+
+    mod for_nextest_issue_1684 {
+        use super::convert_forward_slashes;
+        use crate::graph::build::Utf8Path;
+        #[track_caller]
+        fn verify_result_of_diff_utf8_paths(path_manifest: &str, path_workspace_root: &str, expected_relative_path: &str) {
+            let relative_path = pathdiff::diff_utf8_paths(
+                Utf8Path::new(path_manifest),
+                Utf8Path::new(path_workspace_root),
+            ).unwrap();
+            assert_eq!(convert_forward_slashes(relative_path), expected_relative_path);
+        }
+
+        #[test]
+        fn test_nextest_issue_1684_workspace_path_out_of_pocket() {
+            verify_result_of_diff_utf8_paths(
+                "/workspace/a/b/Crate/Cargo.toml",
+                "/workspace/a/b/.cargo/workspace",
+                r"../../Crate/Cargo.toml"
+            );
+        }
+
+        cfg_if::cfg_if! {
+            if #[cfg(windows)] {
+                // These cases can only pass on Windows platform
+                #[test]
+                fn test_nextest_issue_1684_workspace_path_out_of_pocket_on_windows_same_driver() {
+                    verify_result_of_diff_utf8_paths(
+                        r"C:\workspace\a\b\Crate\Cargo.toml",
+                        r"C:\workspace\a\b\.cargo\workspace",
+                        r"../../Crate/Cargo.toml"
+                    );
+                }
+
+                #[test]
+                fn test_nextest_issue_1684_workspace_path_out_of_pocket_on_windows_different_driver() {
+                    verify_result_of_diff_utf8_paths(
+                        r"D:\workspace\a\b\Crate\Cargo.toml",
+                        r"C:\workspace\a\b\.cargo\workspace",
+                        r"D:/workspace/a/b/Crate/Cargo.toml"
+                    );
+                }
+            }
+        }
     }
 }

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -541,14 +541,10 @@ impl PackageSourceImpl {
     fn create_path(path: &Utf8Path, workspace_root: &Utf8Path) -> Self {
         let path_diff =
             pathdiff::diff_utf8_paths(path, workspace_root).expect("workspace root is absolute");
-        // On Windows, the directory name and the workspace root might be on different drives,
-        // in which case the path can't be relative.
-        let path_diff = if path_diff.is_absolute() {
-            path_diff
-        } else {
-            convert_relative_forward_slashes(path_diff)
-        };
-        Self::Path(path_diff.into_boxed_path())
+        // convert_relative_forward_slashes() can handle both situations, i.e.,
+        // on windows and for relative path, convert forward slashes, otherwise,
+        // (absolute path, or not on windows) just clone.
+        Self::Path(convert_relative_forward_slashes(path_diff).into_boxed_path())
     }
 }
 

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -403,7 +403,7 @@ impl<'a> GraphBuildState<'a> {
             .ok_or_else(|| {
                 Error::PackageGraphConstructError(format!(
                     "failed to find relative path from workspace (root: {}) to member '{}' at path {}",
-                    self.workspace_root, id, manifest_path 
+                    self.workspace_root, id, manifest_path
                 ))
             })?;
         let workspace_path = workspace_path.parent().ok_or_else(|| {
@@ -413,7 +413,7 @@ impl<'a> GraphBuildState<'a> {
             ))
         })?;
         let workspace_path_buf = if workspace_path.is_absolute() {
-            workspace_path.into_path_buf()
+            workspace_path.to_path_buf()
         } else {
             convert_forward_slashes(workspace_path)
         };
@@ -1065,12 +1065,17 @@ mod tests {
     }
 
     #[track_caller]
-    fn verify_result_of_diff_utf8_paths(path_manifest: &str, path_workspace_root: &str, expected_relative_path: &str) {
+    fn verify_result_of_diff_utf8_paths(
+        path_manifest: &str,
+        path_workspace_root: &str,
+        expected_relative_path: &str,
+    ) {
         use crate::graph::build::Utf8Path;
         let relative_path = pathdiff::diff_utf8_paths(
             Utf8Path::new(path_manifest),
             Utf8Path::new(path_workspace_root),
-        ).unwrap();
+        )
+        .unwrap();
         assert_eq!(relative_path, expected_relative_path);
     }
 
@@ -1079,7 +1084,7 @@ mod tests {
         verify_result_of_diff_utf8_paths(
             "/workspace/a/b/Crate/Cargo.toml",
             "/workspace/a/b/.cargo/workspace",
-            r"../../Crate/Cargo.toml"
+            r"../../Crate/Cargo.toml",
         );
     }
 

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -1060,6 +1060,7 @@ mod tests {
         assert_eq!(path.as_str(), "../../foo/bar/baz.txt");
     }
 
+    #[cfg(windows)]
     #[test]
     fn test_convert_relative_forward_slashes_absolute() {
         let components = vec![r"D:\", "X", "..", "foo", "bar", "baz.txt"];


### PR DESCRIPTION
Resubmitting for previous one polluted by huge background file commits in GitHub codespace.

Fix: Allow Nextest to Work with Manifests Outside of Workspace Root Path
Description
This pull request addresses an issue where Nextest fails to function correctly when the Cargo.toml manifest file is located outside of the workspace root path. The changes ensure that Nextest can handle such scenarios gracefully.

Changes
Updated the guppy crate to use pathdiff for relative path of manifest from workspace root, no matter it is outside of the workspace root.

Modified guppy/src/graph/build.rs fn workspace_path() #402~#408 , add 3 test cases on relative path result for unix and windodws.
Remove debug assert for relative path in fn convert_forward_slashes() #990-#994 so that if manifest path may be on another driver on windows.

Issue
This pull request fixes nextest-rs/nextest issue #1684.

Testing
Verified that Nextest can now correctly locate and use Cargo.toml files outside the workspace root.

Ran existing test suites to ensure no regressions were introduced.