### PR TITLE
[guppy] add support for resolver v3

### DIFF
--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-0.toml
@@ -2,8 +2,8 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_44b62fa
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'unify-if-both'
+# resolver = 'install'
+# unify-target-host = 'auto'
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
@@ -19,24 +19,14 @@
 # workspace-path = 'cargo-guppy'
 #
 # [[traversal-excludes.ids]]
-# name = 'cargo-hakari'
-# version = '0.9.11'
-# workspace-path = 'tools/cargo-hakari'
-#
-# [[traversal-excludes.ids]]
-# name = 'fixtures'
+# name = 'fixture-manager'
 # version = '0.1.0'
-# workspace-path = 'fixtures'
+# workspace-path = 'internal-tools/fixture-manager'
 #
 # [[traversal-excludes.ids]]
 # name = 'proptest-ext'
 # version = '0.1.0'
 # workspace-path = 'internal-tools/proptest-ext'
-#
-# [[traversal-excludes.ids]]
-# name = 'target-spec'
-# version = '0.9.0'
-# workspace-path = 'target-spec'
 # [[final-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'
@@ -46,6 +36,21 @@
 # name = 'cargo-hakari'
 # version = '0.9.11'
 # workspace-path = 'tools/cargo-hakari'
+#
+# [[final-excludes.ids]]
+# name = 'fixture-manager'
+# version = '0.1.0'
+# workspace-path = 'internal-tools/fixture-manager'
+#
+# [[final-excludes.ids]]
+# name = 'guppy-cmdlib'
+# version = '0.1.0'
+# workspace-path = 'guppy-cmdlib'
+#
+# [[final-excludes.ids]]
+# name = 'hakari'
+# version = '0.8.1'
+# workspace-path = 'tools/hakari'
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-1.toml
@@ -2,50 +2,40 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_44b62fa
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'unify-if-both'
+# resolver = '2'
+# unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '2'
 # workspace-hack-line-style = 'full'
 # platforms = []
 # [[traversal-excludes.ids]]
-# name = 'cargo-hakari'
-# version = '0.9.11'
-# workspace-path = 'tools/cargo-hakari'
+# name = 'determinator'
+# version = '0.7.0'
+# workspace-path = 'tools/determinator'
 #
 # [[traversal-excludes.ids]]
-# name = 'fixtures'
+# name = 'guppy-cmdlib'
 # version = '0.1.0'
-# workspace-path = 'fixtures'
+# workspace-path = 'guppy-cmdlib'
 #
 # [[traversal-excludes.ids]]
-# name = 'guppy-benchmarks'
-# version = '0.1.0'
-# workspace-path = 'internal-tools/benchmarks'
-#
-# [[traversal-excludes.ids]]
-# name = 'hakari'
-# version = '0.8.1'
-# workspace-path = 'tools/hakari'
+# name = 'target-spec'
+# version = '0.9.0'
+# workspace-path = 'target-spec'
 # [[final-excludes.ids]]
 # name = 'cargo-compare'
 # version = '0.1.0'
 # workspace-path = 'internal-tools/cargo-compare'
 #
 # [[final-excludes.ids]]
-# name = 'cargo-guppy'
-# version = '0.1.0'
-# workspace-path = 'cargo-guppy'
-#
-# [[final-excludes.ids]]
 # name = 'cargo-hakari'
 # version = '0.9.11'
 # workspace-path = 'tools/cargo-hakari'
 #
 # [[final-excludes.ids]]
-# name = 'determinator'
-# version = '0.7.0'
-# workspace-path = 'tools/determinator'
+# name = 'guppy-summaries'
+# version = '0.6.1'
+# workspace-path = 'guppy-summaries'
 #
 # [[final-excludes.ids]]
 # name = 'guppy-workspace-hack'
@@ -56,11 +46,6 @@
 # name = 'hakari'
 # version = '0.8.1'
 # workspace-path = 'tools/hakari'
-#
-# [[final-excludes.ids]]
-# name = 'proptest-ext'
-# version = '0.1.0'
-# workspace-path = 'internal-tools/proptest-ext'
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -2,18 +2,60 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_44b62fa
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
+# resolver = '3'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # workspace-hack-line-style = 'full'
 # platforms = ['aarch64-unknown-illumos', 'armv7-unknown-freebsd']
-#
-# [traversal-excludes]
-# [[final-excludes.ids]]
-# name = 'guppy-cmdlib'
+# [[traversal-excludes.ids]]
+# name = 'cargo-compare'
 # version = '0.1.0'
-# workspace-path = 'guppy-cmdlib'
+# workspace-path = 'internal-tools/cargo-compare'
+#
+# [[traversal-excludes.ids]]
+# name = 'determinator'
+# version = '0.7.0'
+# workspace-path = 'tools/determinator'
+#
+# [[traversal-excludes.ids]]
+# name = 'guppy-summaries'
+# version = '0.6.1'
+# workspace-path = 'guppy-summaries'
+#
+# [[traversal-excludes.ids]]
+# name = 'hakari'
+# version = '0.8.1'
+# workspace-path = 'tools/hakari'
+#
+# [[traversal-excludes.ids]]
+# name = 'proptest-ext'
+# version = '0.1.0'
+# workspace-path = 'internal-tools/proptest-ext'
+# [[final-excludes.ids]]
+# name = 'cargo-guppy'
+# version = '0.1.0'
+# workspace-path = 'cargo-guppy'
+#
+# [[final-excludes.ids]]
+# name = 'determinator'
+# version = '0.7.0'
+# workspace-path = 'tools/determinator'
+#
+# [[final-excludes.ids]]
+# name = 'guppy-summaries'
+# version = '0.6.1'
+# workspace-path = 'guppy-summaries'
+#
+# [[final-excludes.ids]]
+# name = 'proptest-ext'
+# version = '0.1.0'
+# workspace-path = 'internal-tools/proptest-ext'
+#
+# [[final-excludes.ids]]
+# name = 'target-spec'
+# version = '0.9.0'
+# workspace-path = 'target-spec'
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-0.toml
@@ -2,54 +2,34 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_78cb7e8
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'unify-if-both'
+# resolver = '3'
+# unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '2'
-# workspace-hack-line-style = 'full'
+# dep-format-version = '1'
+# workspace-hack-line-style = 'version-only'
 # platforms = []
 # [[traversal-excludes.ids]]
-# name = 'csv-core'
-# version = '0.1.10'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'git2-curl'
-# version = '0.14.1'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'opener'
-# version = '0.4.1'
+# name = 'rand_hc'
+# version = '0.2.0'
 # crates-io = true
 # [[final-excludes.ids]]
-# name = 'bstr'
-# version = '0.2.13'
+# name = 'regex'
+# version = '1.3.9'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'criterion-plot'
-# version = '0.4.3'
+# name = 'regex-syntax'
+# version = '0.6.18'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'libssh2-sys'
-# version = '0.2.19'
+# name = 'ryu'
+# version = '1.0.5'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'pkg-config'
-# version = '0.3.18'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'sized-chunks'
-# version = '0.6.2'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'tar'
-# version = '0.4.30'
+# name = 'tinyvec'
+# version = '0.3.4'
 # crates-io = true
 
 [dependencies]
@@ -63,6 +43,7 @@ bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bitflags = { version = "1" }
 bitmaps = { version = "2", features = ["std"] }
+bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byteorder = { version = "1", default-features = false, features = ["std"] }
 bytesize = { version = "1", default-features = false }
 cargo = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
@@ -78,12 +59,14 @@ console = { version = "0.11", features = ["ansi-parsing", "regex", "unicode-widt
 crates-io = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
 crc32fast = { version = "1", features = ["std"] }
 criterion = { version = "0.3" }
+criterion-plot = { version = "0.4", default-features = false }
 crossbeam-channel = { version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
 crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
 crypto-hash = { version = "0.3", default-features = false }
 csv = { version = "1", default-features = false }
+csv-core = { version = "0.1" }
 curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
 curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
 dialoguer = { version = "0.6", default-features = false }
@@ -97,6 +80,7 @@ flate2 = { version = "1", default-features = false, features = ["any_zlib", "lib
 fnv = { version = "1", features = ["std"] }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 git2 = { version = "0.13", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2-curl = { version = "0.14", default-features = false }
 glob = { version = "0.3", default-features = false }
 globset = { version = "0.4", default-features = false }
 half = { version = "1", default-features = false }
@@ -119,6 +103,7 @@ lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", features = ["std"] }
 libgit2-sys = { version = "0.12", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.2", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked-hash-map = { version = "0.5", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
@@ -132,6 +117,7 @@ num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
 once_cell = { version = "1", features = ["std"] }
 oorandom = { version = "11", default-features = false }
+opener = { version = "0.4", default-features = false }
 pathdiff = { version = "0.2", default-features = false }
 percent-encoding = { version = "2", default-features = false }
 petgraph = { version = "0.5", default-features = false }
@@ -147,14 +133,11 @@ rand_xorshift = { version = "0.2", default-features = false }
 rand_xoshiro = { version = "0.4", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
 rustc-workspace-hack = { version = "1", default-features = false }
 rustfix = { version = "0.5", default-features = false }
 rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
-ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard = { version = "1", default-features = false }
 semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
@@ -164,12 +147,14 @@ serde_cbor = { version = "0.11", features = ["std"] }
 serde_ignored = { version = "0.1", default-features = false }
 serde_json = { version = "1", features = ["raw_value", "std"] }
 shell-escape = { version = "0.1", default-features = false }
+sized-chunks = { version = "0.6", features = ["std"] }
 smallvec = { version = "1", default-features = false }
 socket2 = { version = "0.3", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
 strsim = { version = "0.8", default-features = false }
 structopt = { version = "0.3" }
 supercow = { version = "0.1", default-features = false }
+tar = { version = "0.4", default-features = false }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
 terminal_size = { version = "0.1", default-features = false }
@@ -177,7 +162,6 @@ textwrap = { version = "0.11", default-features = false }
 thread_local = { version = "1", default-features = false }
 time = { version = "0.1", default-features = false }
 tinytemplate = { version = "1", default-features = false }
-tinyvec = { version = "0.3", features = ["alloc"] }
 toml = { version = "0.5" }
 toml_edit = { version = "0.2", default-features = false }
 typenum = { version = "1", default-features = false }
@@ -199,6 +183,7 @@ autocfg = { version = "1", default-features = false }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 heck = { version = "0.3", default-features = false }
 jobserver = { version = "0.1", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
 proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
 proc-macro-error-attr = { version = "1", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
@@ -2,356 +2,86 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_78cb7e8
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'replicate-target-on-host'
-# output-single-feature = true
+# resolver = '3'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = false
 # dep-format-version = '4'
-# workspace-hack-line-style = 'full'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['aarch64-apple-watchos']
+# [[traversal-excludes.ids]]
+# name = 'bstr'
+# version = '0.2.13'
+# crates-io = true
 #
-# [traversal-excludes]
+# [[traversal-excludes.ids]]
+# name = 'console'
+# version = '0.11.3'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'crossbeam-deque'
+# version = '0.7.3'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'fwdansi'
+# version = '1.1.0'
+# crates-io = true
 # [[final-excludes.ids]]
-# name = 'wait-timeout'
-# version = '0.2.0'
+# name = 'adler'
+# version = '0.2.3'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'bitmaps'
+# version = '2.1.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'cargo-platform'
+# version = '0.1.1'
+# source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+#
+# [[final-excludes.ids]]
+# name = 'foreign-types-shared'
+# version = '0.1.1'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'ignore'
+# version = '0.4.16'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'nested'
+# version = '0.1.1'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'rayon'
+# version = '1.4.1'
 # crates-io = true
 
 [dependencies]
-aho-corasick = { version = "0.7" }
-ansi_term = { version = "0.11", default-features = false }
-anyhow = { version = "1" }
-ascii = { version = "0.9", default-features = false, features = ["std"] }
-assert_matches = { version = "1", default-features = false }
-atty = { version = "0.2", default-features = false }
-bit-set = { version = "0.5" }
-bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitflags = { version = "1" }
-bitmaps = { version = "2" }
-bstr = { version = "0.2", features = ["serde1"] }
-byteorder = { version = "1", default-features = false, features = ["std"] }
-bytesize = { version = "1", default-features = false }
-cargo = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-cargo-platform = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-cargo_metadata = { version = "0.11" }
-cast = { version = "0.2" }
-cfg-expr = { version = "0.4" }
-cfg-if = { version = "0.1", default-features = false }
-chrono = { version = "0.4" }
 clap = { version = "2" }
-combine = { version = "3" }
-console = { version = "0.11" }
-crates-io = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-crc32fast = { version = "1" }
-criterion = { version = "0.3" }
-criterion-plot = { version = "0.4", default-features = false }
-crossbeam-channel = { version = "0.4", default-features = false }
-crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.8" }
-crossbeam-utils = { version = "0.7" }
-crypto-hash = { version = "0.3", default-features = false }
-csv = { version = "1", default-features = false }
-csv-core = { version = "0.1" }
-curl = { version = "0.4", features = ["http2"] }
-curl-sys = { version = "0.4", features = ["http2"] }
-dialoguer = { version = "0.6", default-features = false }
-difference = { version = "2" }
-diffus = { version = "0.9" }
 either = { version = "1" }
-env_logger = { version = "0.7" }
-filetime = { version = "0.2", default-features = false }
-fixedbitset = { version = "0.2", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
-fnv = { version = "1" }
-getrandom = { version = "0.1", default-features = false, features = ["std"] }
-git2 = { version = "0.13" }
-git2-curl = { version = "0.14", default-features = false }
-glob = { version = "0.3", default-features = false }
-globset = { version = "0.4", default-features = false }
-half = { version = "1", default-features = false }
-hashbrown = { version = "0.9", default-features = false, features = ["raw"] }
-hex-468e82937335b1c9 = { package = "hex", version = "0.3", default-features = false }
-hex-9fbad63c4bcf4a8f = { package = "hex", version = "0.4" }
-home = { version = "0.5", default-features = false }
-humantime-dff4ba8e3ae991db = { package = "humantime", version = "1", default-features = false }
-humantime-f595c2ba2a3f28df = { package = "humantime", version = "2", default-features = false }
-idna = { version = "0.2", default-features = false }
-ignore = { version = "0.4", default-features = false }
-im-rc = { version = "15", default-features = false }
-indexmap = { version = "1", default-features = false }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
 itoa = { version = "0.4" }
-jobserver = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false }
-lazycell = { version = "1", default-features = false }
-libc = { version = "0.2" }
-libgit2-sys = { version = "0.12", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
-libnghttp2-sys = { version = "0.1", default-features = false }
-libssh2-sys = { version = "0.2", default-features = false }
-libz-sys = { version = "1", default-features = false, features = ["libc"] }
-linked-hash-map = { version = "0.5", default-features = false }
-log = { version = "0.4", default-features = false, features = ["std"] }
-matches = { version = "0.1", default-features = false }
-maybe-uninit = { version = "2", default-features = false }
 memchr = { version = "2", features = ["use_std"] }
-memoffset = { version = "0.5" }
-nested = { version = "0.1", default-features = false }
-num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2" }
-num_cpus = { version = "1", default-features = false }
-once_cell = { version = "1" }
-oorandom = { version = "11", default-features = false }
-opener = { version = "0.4", default-features = false }
-pathdiff = { version = "0.2", default-features = false }
-percent-encoding = { version = "2", default-features = false }
-petgraph = { version = "0.5", default-features = false }
-plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["simd"] }
-pretty_assertions = { version = "0.6", default-features = false }
-proptest = { version = "0.10" }
-quick-error = { version = "1", default-features = false }
-rand = { version = "0.7" }
-rand_chacha = { version = "0.2", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["std"] }
-rand_xorshift = { version = "0.2", default-features = false }
-rand_xoshiro = { version = "0.4", default-features = false }
-rayon = { version = "1", default-features = false }
-rayon-core = { version = "1", default-features = false }
 regex = { version = "1" }
-regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6" }
-remove_dir_all = { version = "0.5", default-features = false }
-rustc-workspace-hack = { version = "1", default-features = false }
-rustfix = { version = "0.5", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
-ryu = { version = "1", default-features = false }
-same-file = { version = "1", default-features = false }
-scopeguard = { version = "1", default-features = false }
-semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
-semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive"] }
-serde_cbor = { version = "0.11" }
-serde_ignored = { version = "0.1", default-features = false }
 serde_json = { version = "1", features = ["raw_value"] }
-shell-escape = { version = "0.1", default-features = false }
-sized-chunks = { version = "0.6" }
-smallvec = { version = "1", default-features = false }
-socket2 = { version = "0.3", default-features = false }
-strip-ansi-escapes = { version = "0.1", default-features = false }
-strsim = { version = "0.8", default-features = false }
-structopt = { version = "0.3" }
-supercow = { version = "0.1", default-features = false }
-tar = { version = "0.4", default-features = false }
-tempfile = { version = "3", default-features = false }
-termcolor = { version = "1", default-features = false }
-terminal_size = { version = "0.1", default-features = false }
-textwrap = { version = "0.11", default-features = false }
-thread_local = { version = "1", default-features = false }
-time = { version = "0.1", default-features = false }
-tinytemplate = { version = "1", default-features = false }
-tinyvec = { version = "0.3", features = ["alloc"] }
-toml = { version = "0.5" }
-toml_edit = { version = "0.2", default-features = false }
-typenum = { version = "1", default-features = false }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1" }
-unicode-width = { version = "0.1" }
-unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
-unreachable = { version = "1", default-features = false }
-url = { version = "2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-vec_map = { version = "0.8", default-features = false }
-void = { version = "1", default-features = false }
-vte = { version = "0.3", default-features = false }
-walkdir = { version = "2", default-features = false }
 
 [build-dependencies]
-aho-corasick = { version = "0.7" }
-ansi_term = { version = "0.11", default-features = false }
-anyhow = { version = "1" }
-ascii = { version = "0.9", default-features = false, features = ["std"] }
-assert_matches = { version = "1", default-features = false }
-atty = { version = "0.2", default-features = false }
-autocfg = { version = "1", default-features = false }
-bit-set = { version = "0.5" }
-bit-vec = { version = "0.6", default-features = false, features = ["std"] }
-bitflags = { version = "1" }
-bitmaps = { version = "2" }
-bstr = { version = "0.2", features = ["serde1"] }
-byteorder = { version = "1", default-features = false, features = ["std"] }
-bytesize = { version = "1", default-features = false }
-cargo = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-cargo-platform = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-cargo_metadata = { version = "0.11" }
-cast = { version = "0.2" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-cfg-expr = { version = "0.4" }
-cfg-if = { version = "0.1", default-features = false }
-chrono = { version = "0.4" }
-clap = { version = "2" }
-combine = { version = "3" }
-console = { version = "0.11" }
-crates-io = { git = "https://github.com/rust-lang/cargo.git", rev = "0227f048fcb7c798026ede6cc20c92befc84c3a4", default-features = false }
-crc32fast = { version = "1" }
-criterion = { version = "0.3" }
-criterion-plot = { version = "0.4", default-features = false }
-crossbeam-channel = { version = "0.4", default-features = false }
-crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.8" }
-crossbeam-utils = { version = "0.7" }
-crypto-hash = { version = "0.3", default-features = false }
-csv = { version = "1", default-features = false }
-csv-core = { version = "0.1" }
-curl = { version = "0.4", features = ["http2"] }
-curl-sys = { version = "0.4", features = ["http2"] }
-dialoguer = { version = "0.6", default-features = false }
-difference = { version = "2" }
-diffus = { version = "0.9" }
-either = { version = "1" }
-env_logger = { version = "0.7" }
-filetime = { version = "0.2", default-features = false }
-fixedbitset = { version = "0.2", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
-fnv = { version = "1" }
-getrandom = { version = "0.1", default-features = false, features = ["std"] }
-git2 = { version = "0.13" }
-git2-curl = { version = "0.14", default-features = false }
-glob = { version = "0.3", default-features = false }
-globset = { version = "0.4", default-features = false }
-half = { version = "1", default-features = false }
-hashbrown = { version = "0.9", default-features = false, features = ["raw"] }
-heck = { version = "0.3", default-features = false }
-hex-468e82937335b1c9 = { package = "hex", version = "0.3", default-features = false }
-hex-9fbad63c4bcf4a8f = { package = "hex", version = "0.4" }
-home = { version = "0.5", default-features = false }
-humantime-dff4ba8e3ae991db = { package = "humantime", version = "1", default-features = false }
-humantime-f595c2ba2a3f28df = { package = "humantime", version = "2", default-features = false }
-idna = { version = "0.2", default-features = false }
-ignore = { version = "0.4", default-features = false }
-im-rc = { version = "15", default-features = false }
-indexmap = { version = "1", default-features = false }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
-itoa = { version = "0.4" }
-jobserver = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false }
-lazycell = { version = "1", default-features = false }
-libc = { version = "0.2" }
-libgit2-sys = { version = "0.12", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
-libnghttp2-sys = { version = "0.1", default-features = false }
-libssh2-sys = { version = "0.2", default-features = false }
-libz-sys = { version = "1", default-features = false, features = ["libc"] }
-linked-hash-map = { version = "0.5", default-features = false }
-log = { version = "0.4", default-features = false, features = ["std"] }
-matches = { version = "0.1", default-features = false }
-maybe-uninit = { version = "2", default-features = false }
-memchr = { version = "2", features = ["use_std"] }
-memoffset = { version = "0.5" }
-nested = { version = "0.1", default-features = false }
-num-integer = { version = "0.1", default-features = false }
-num-traits = { version = "0.2" }
-num_cpus = { version = "1", default-features = false }
-once_cell = { version = "1" }
-oorandom = { version = "11", default-features = false }
-opener = { version = "0.4", default-features = false }
-pathdiff = { version = "0.2", default-features = false }
-percent-encoding = { version = "2", default-features = false }
-petgraph = { version = "0.5", default-features = false }
-pkg-config = { version = "0.3", default-features = false }
-plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["simd"] }
-pretty_assertions = { version = "0.6", default-features = false }
-proc-macro-error = { version = "1" }
-proc-macro-error-attr = { version = "1", default-features = false }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1" }
-proptest = { version = "0.10" }
-proptest-derive = { version = "0.2", default-features = false }
-quick-error = { version = "1", default-features = false }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
-rand = { version = "0.7" }
-rand_chacha = { version = "0.2", default-features = false }
-rand_core = { version = "0.5", default-features = false, features = ["std"] }
-rand_xorshift = { version = "0.2", default-features = false }
-rand_xoshiro = { version = "0.4", default-features = false }
-rayon = { version = "1", default-features = false }
-rayon-core = { version = "1", default-features = false }
-regex = { version = "1" }
-regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6" }
-remove_dir_all = { version = "0.5", default-features = false }
-rustc-workspace-hack = { version = "1", default-features = false }
-rustc_version = { version = "0.2", default-features = false }
-rustfix = { version = "0.5", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
-ryu = { version = "1", default-features = false }
-same-file = { version = "1", default-features = false }
-scopeguard = { version = "1", default-features = false }
-semver-274715c4dabd11b0 = { package = "semver", version = "0.9" }
-semver-93f6ce9d446188ac = { package = "semver", version = "0.10", features = ["serde"] }
-semver-parser = { version = "0.7", default-features = false }
-serde = { version = "1", features = ["derive"] }
-serde_cbor = { version = "0.11" }
-serde_derive = { version = "1" }
-serde_ignored = { version = "0.1", default-features = false }
-serde_json = { version = "1", features = ["raw_value"] }
-shell-escape = { version = "0.1", default-features = false }
-sized-chunks = { version = "0.6" }
-smallvec = { version = "1", default-features = false }
-socket2 = { version = "0.3", default-features = false }
-strip-ansi-escapes = { version = "0.1", default-features = false }
-strsim = { version = "0.8", default-features = false }
-structopt = { version = "0.3" }
-structopt-derive = { version = "0.4", default-features = false }
-supercow = { version = "0.1", default-features = false }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["full", "visit"] }
-tar = { version = "0.4", default-features = false }
-tempfile = { version = "3", default-features = false }
-termcolor = { version = "1", default-features = false }
-terminal_size = { version = "0.1", default-features = false }
-textwrap = { version = "0.11", default-features = false }
-thread_local = { version = "1", default-features = false }
-time = { version = "0.1", default-features = false }
-tinytemplate = { version = "1", default-features = false }
-tinyvec = { version = "0.3", features = ["alloc"] }
-toml = { version = "0.5" }
-toml_edit = { version = "0.2", default-features = false }
-typenum = { version = "1", default-features = false }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1" }
-unicode-segmentation = { version = "1", default-features = false }
-unicode-width = { version = "0.1" }
-unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
-unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
-unreachable = { version = "1", default-features = false }
-url = { version = "2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-vec_map = { version = "0.8", default-features = false }
-version_check = { version = "0.9", default-features = false }
-void = { version = "1", default-features = false }
-vte = { version = "0.3", default-features = false }
-walkdir = { version = "2", default-features = false }
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+syn = { version = "1", features = ["full", "visit"] }
 
 [target.aarch64-apple-watchos.dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["std"] }
-rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
-termios = { version = "0.3", default-features = false }
+libc = { version = "0.2" }
 
 [target.aarch64-apple-watchos.build-dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["std"] }
-rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
-termios = { version = "0.3", default-features = false }
+libc = { version = "0.2" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -2,53 +2,37 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_869476c
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
+# resolver = '2'
 # unify-target-host = 'none'
 # output-single-feature = false
-# dep-format-version = '4'
+# dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['xtensa-esp32s3-none-elf', 'aarch64_be-unknown-linux-gnu_ilp32']
 # [[traversal-excludes.ids]]
-# name = 'bit-set'
-# version = '0.5.2'
+# name = 'libz-sys'
+# version = '1.1.2'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'fixtures'
-# version = '0.1.0'
-# workspace-path = 'fixtures'
-#
-# [[traversal-excludes.ids]]
-# name = 'hex'
-# version = '0.3.2'
+# name = 'rand_xorshift'
+# version = '0.2.0'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'libgit2-sys'
-# version = '0.12.13+1.0.1'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'serde'
-# version = '1.0.116'
+# name = 'rustc-workspace-hack'
+# version = '1.0.0'
 # crates-io = true
 # [[final-excludes.ids]]
-# name = 'fixtures'
-# version = '0.1.0'
-# workspace-path = 'fixtures'
-#
-# [[final-excludes.ids]]
-# name = 'quote'
-# version = '1.0.7'
+# name = 'bstr'
+# version = '0.2.13'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'rand_xoshiro'
+# name = 'winapi-i686-pc-windows-gnu'
 # version = '0.4.0'
 # crates-io = true
 
 [dependencies]
-bstr = { version = "0.2", features = ["serde1"] }
 byteorder = { version = "1", default-features = false, features = ["std"] }
 clap = { version = "2" }
 either = { version = "1" }
@@ -57,13 +41,18 @@ memchr = { version = "2", features = ["use_std"] }
 num-traits = { version = "0.2" }
 regex = { version = "1" }
 regex-syntax = { version = "0.6" }
+serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }
 
 [build-dependencies]
 proc-macro2 = { version = "1" }
+quote = { version = "1" }
 syn = { version = "1", features = ["full", "visit"] }
 
 [target.aarch64_be-unknown-linux-gnu_ilp32.dependencies]
+libc = { version = "0.2" }
+
+[target.aarch64_be-unknown-linux-gnu_ilp32.build-dependencies]
 libc = { version = "0.2" }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-2.toml
@@ -2,44 +2,54 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_guppy_c9b4f76
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'auto'
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '3'
-# workspace-hack-line-style = 'full'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = []
 # [[traversal-excludes.ids]]
-# name = 'cargo-guppy'
-# version = '0.1.0'
-# workspace-path = 'cargo-guppy'
-#
-# [[traversal-excludes.ids]]
-# name = 'proptest'
-# version = '0.10.1'
+# name = 'difference'
+# version = '2.0.0'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'schannel'
-# version = '0.1.19'
+# name = 'git2'
+# version = '0.13.11'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'textwrap'
-# version = '0.11.0'
+# name = 'tar'
+# version = '0.4.30'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'thread_local'
-# version = '1.0.1'
+# name = 'void'
+# version = '1.0.2'
 # crates-io = true
 # [[final-excludes.ids]]
-# name = 'fnv'
-# version = '1.0.7'
+# name = 'byteorder'
+# version = '1.3.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'walkdir'
-# version = '2.3.1'
+# name = 'csv-core'
+# version = '0.1.10'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'encode_unicode'
+# version = '0.3.6'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'rustfix'
+# version = '0.5.1'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'unicode-bidi'
+# version = '0.3.4'
 # crates-io = true
 
 [dependencies]
@@ -48,6 +58,7 @@ clap = { version = "2" }
 either = { version = "1" }
 itoa = { version = "0.4" }
 memchr = { version = "2", features = ["use_std"] }
+num-traits = { version = "0.2" }
 regex = { version = "1" }
 regex-syntax = { version = "0.6" }
 serde = { version = "1", features = ["derive"] }

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
@@ -2,31 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_44b62fa
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'arm-linux-androideabi'
-target-features = 'unknown'
-flags = ['foo']
+triple = 'x86_64-unknown-haiku'
+target-features = 'all'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'armv8r-none-eabihf'
+target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
-name = 'cargo-compare'
-version = '0.1.0'
-workspace-path = 'internal-tools/cargo-compare'
-
-[[metadata.omitted-packages.ids]]
-name = 'guppy'
-version = '0.12.4'
-workspace-path = 'guppy'
-
-[[metadata.omitted-packages.ids]]
-name = 'guppy-cmdlib'
-version = '0.1.0'
-workspace-path = 'guppy-cmdlib'
+name = 'cargo-hakari'
+version = '0.9.11'
+workspace-path = 'tools/cargo-hakari'
 
 [[metadata.features-only]]
 name = 'cargo-compare'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
@@ -2,25 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_44b62fa
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = false
-initials-platform = 'host'
+initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'sparc-unknown-linux-gnu'
+target-features = ['bmi2', 'sse2', 'sse4.1']
+flags = ['flag-test']
 
 [metadata.target-platform]
-triple = 'mips64-unknown-linux-muslabi64'
-target-features = ['bmi1', 'xsaveopt']
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'guppy-summaries'
-version = '0.6.1'
-workspace-path = 'guppy-summaries'
-
-[[metadata.omitted-packages.ids]]
-name = 'proptest-ext'
+name = 'guppy-benchmarks'
 version = '0.1.0'
-workspace-path = 'internal-tools/proptest-ext'
+workspace-path = 'internal-tools/benchmarks'
 
 [[metadata.features-only]]
 name = 'cargo-compare'
@@ -41,49 +37,49 @@ version = '0.1.0'
 workspace-path = 'internal-tools/proptest-ext'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cargo-compare'
 version = '0.1.0'
 workspace-path = 'internal-tools/cargo-compare'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cargo-guppy'
 version = '0.1.0'
 workspace-path = 'cargo-guppy'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cargo-hakari'
 version = '0.9.11'
 workspace-path = 'tools/cargo-hakari'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'determinator'
 version = '0.7.0'
 workspace-path = 'tools/determinator'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'fixture-manager'
 version = '0.1.0'
 workspace-path = 'internal-tools/fixture-manager'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'fixtures'
 version = '0.1.0'
 workspace-path = 'fixtures'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy'
 version = '0.12.4'
 workspace-path = 'guppy'
@@ -91,14 +87,14 @@ status = 'initial'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest1', 'rayon', 'rayon1', 'summaries', 'toml']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive', 'rayon', 'toml']
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-benchmarks'
 version = '0.1.0'
 workspace-path = 'internal-tools/benchmarks'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-cmdlib'
 version = '0.1.0'
 workspace-path = 'guppy-cmdlib'
@@ -106,21 +102,21 @@ status = 'initial'
 features = ['proptest', 'proptest1']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-summaries'
 version = '0.6.1'
 workspace-path = 'guppy-summaries'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-workspace-hack'
 version = '0.1.0'
 workspace-path = 'workspace-hack'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'hakari'
 version = '0.8.1'
 workspace-path = 'tools/hakari'
@@ -128,14 +124,14 @@ status = 'initial'
 features = ['cli-support', 'include_dir', 'owo-colors', 'proptest', 'proptest-derive', 'proptest1', 'serde', 'strip-ansi-escapes', 'toml']
 optional-deps = ['include_dir', 'owo-colors', 'proptest', 'proptest-derive', 'serde', 'strip-ansi-escapes', 'toml']
 
-[[host-package]]
+[[target-package]]
 name = 'proptest-ext'
 version = '0.1.0'
 workspace-path = 'internal-tools/proptest-ext'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'target-spec'
 version = '0.9.0'
 workspace-path = 'target-spec'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-2.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_44b62fa
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'standard'
+resolver = '2'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'any'
@@ -28,28 +28,28 @@ version = '0.8.1'
 workspace-path = 'tools/hakari'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'cargo-compare'
 version = '0.1.0'
 workspace-path = 'internal-tools/cargo-compare'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'fixture-manager'
 version = '0.1.0'
 workspace-path = 'internal-tools/fixture-manager'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'fixtures'
 version = '0.1.0'
 workspace-path = 'fixtures'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'hakari'
 version = '0.8.1'
 workspace-path = 'tools/hakari'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
@@ -2,21 +2,32 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_44b62fa
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'proc-macros-on-target'
+resolver = '3'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'powerpc-unknown-linux-gnu'
-target-features = ['sse2', 'sse3']
-flags = ['abc', 'cargo_web']
+spec = 'any'
 
 [metadata.target-platform]
-triple = 'x86_64-apple-tvos'
-target-features = 'unknown'
-flags = ['foo']
+triple = 'aarch64-unknown-redox'
+target-features = 'all'
+[[metadata.omitted-packages.ids]]
+name = 'cargo-guppy'
+version = '0.1.0'
+workspace-path = 'cargo-guppy'
 
-[[target-package]]
+[[metadata.omitted-packages.ids]]
+name = 'guppy-cmdlib'
+version = '0.1.0'
+workspace-path = 'guppy-cmdlib'
+
+[[metadata.omitted-packages.ids]]
+name = 'guppy-workspace-hack'
+version = '0.1.0'
+workspace-path = 'workspace-hack'
+
+[[host-package]]
 name = 'cargo-hakari'
 version = '0.9.11'
 workspace-path = 'tools/cargo-hakari'

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-5.toml
@@ -2,7 +2,7 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_44b62fa
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = false
 initials-platform = 'standard'
 
@@ -10,11 +10,12 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'x86_64-fortanix-unknown-sgx'
+target-features = 'all'
 [[metadata.omitted-packages.ids]]
-name = 'hakari'
-version = '0.8.1'
-workspace-path = 'tools/hakari'
+name = 'guppy-workspace-hack'
+version = '0.1.0'
+workspace-path = 'workspace-hack'
 
 [[target-package]]
 name = 'guppy-summaries'

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_78cb7e8
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'any'

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-4.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_78cb7e8
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
-initials-platform = 'host'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
 spec = 'any'
@@ -12,18 +12,13 @@ spec = 'any'
 [metadata.target-platform]
 spec = 'any'
 [[metadata.omitted-packages.ids]]
-name = 'ascii'
-version = '0.9.3'
+name = 'idna'
+version = '0.2.0'
 crates-io = true
 
 [[metadata.omitted-packages.ids]]
-name = 'libz-sys'
-version = '1.1.2'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'unicode-width'
-version = '0.1.8'
+name = 'wasi'
+version = '0.10.0+wasi-snapshot-preview1'
 crates-io = true
 
 [[metadata.features-only]]
@@ -32,7 +27,7 @@ version = '0.1.0'
 workspace-path = 'internal-tools/benchmarks'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy'
 version = '0.5.0'
 workspace-path = 'guppy'
@@ -40,7 +35,7 @@ status = 'initial'
 features = ['proptest', 'proptest-derive', 'proptest010']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'target-spec'
 version = '0.4.1'
 workspace-path = 'target-spec'
@@ -48,70 +43,70 @@ status = 'workspace'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'cfg-expr'
 version = '0.4.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'indexmap'
 version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'itertools'
 version = '0.9.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[host-package]]
+[[target-package]]
 name = 'nested'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'once_cell'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'pathdiff'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'petgraph'
 version = '0.5.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
@@ -119,14 +114,7 @@ status = 'direct'
 features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
 optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
 
-[[host-package]]
-name = 'proptest-derive'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
+[[target-package]]
 name = 'semver'
 version = '0.10.0'
 crates-io = true
@@ -134,7 +122,7 @@ status = 'direct'
 features = ['default', 'serde']
 optional-deps = ['serde']
 
-[[host-package]]
+[[target-package]]
 name = 'serde'
 version = '1.0.116'
 crates-io = true
@@ -142,16 +130,257 @@ status = 'direct'
 features = ['default', 'derive', 'serde_derive', 'std']
 optional-deps = ['serde_derive']
 
-[[host-package]]
+[[target-package]]
 name = 'serde_json'
 version = '1.0.58'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'supercow'
 version = '0.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'either'
+version = '1.6.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'hashbrown'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package', 'libc']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.1.57'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'semver-parser'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wasi'
+version = '0.9.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['errhandlingapi', 'fileapi', 'handleapi', 'std', 'winbase', 'winerror']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proptest-derive'
+version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
@@ -162,104 +391,6 @@ version = '1.0.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'bit-set'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'cfg-if'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'either'
-version = '1.6.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'getrandom'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'hashbrown'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[host-package]]
-name = 'itoa'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
 
 [[host-package]]
 name = 'proc-macro2'
@@ -276,13 +407,6 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'quick-error'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -297,98 +421,11 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'rand'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[host-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'redox_syscall'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.6.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[host-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rusty-fork'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'smallvec'
-version = '1.4.2'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'syn'
@@ -407,13 +444,6 @@ features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-mac
 optional-deps = ['quote']
 
 [[host-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'unicode-xid'
 version = '0.1.0'
 crates-io = true
@@ -426,38 +456,3 @@ version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['errhandlingapi', 'fileapi', 'handleapi', 'std', 'winbase', 'winerror']
-
-[[host-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
@@ -2,42 +2,30 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_869476c
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'host'
+initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'xtensa-esp32-espidf'
-target-features = 'all'
-flags = ['cargo_web']
+triple = 'armebv7r-none-eabihf'
+target-features = 'unknown'
+flags = ['foo']
 
 [metadata.target-platform]
-triple = 'x86_64h-apple-darwin'
-target-features = 'unknown'
-flags = ['flag-test', 'test-flag']
+spec = 'any'
 [[metadata.omitted-packages.ids]]
-name = 'miniz_oxide'
-version = '0.4.3'
+name = 'aho-corasick'
+version = '0.7.13'
 crates-io = true
 
-[[metadata.omitted-packages.ids]]
-name = 'smallvec'
-version = '1.4.2'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-
-[[host-package]]
+[[target-package]]
 name = 'cargo-guppy'
 version = '0.1.0'
 workspace-path = 'cargo-guppy'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy'
 version = '0.5.0'
 workspace-path = 'guppy'
@@ -45,7 +33,7 @@ status = 'initial'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest010', 'summaries']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-cmdlib'
 version = '0.1.0'
 workspace-path = 'guppy-cmdlib'
@@ -53,7 +41,7 @@ status = 'initial'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'target-spec'
 version = '0.4.1'
 workspace-path = 'target-spec'
@@ -61,35 +49,49 @@ status = 'initial'
 features = ['proptest', 'proptest010', 'serde', 'summaries']
 optional-deps = ['proptest', 'serde']
 
-[[host-package]]
+[[target-package]]
+name = 'fixtures'
+version = '0.1.0'
+workspace-path = 'fixtures'
+status = 'workspace'
+features = []
+
+[[target-package]]
 name = 'guppy-summaries'
 version = '0.2.0'
 workspace-path = 'guppy-summaries'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'anyhow'
 version = '1.0.33'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
+name = 'assert_matches'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'cfg-expr'
 version = '0.4.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'clap'
 version = '2.33.3'
 crates-io = true
@@ -97,70 +99,77 @@ status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
 optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
 
-[[host-package]]
+[[target-package]]
 name = 'dialoguer'
 version = '0.6.2'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'diffus'
 version = '0.9.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'indexmap'
 version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'itertools'
 version = '0.9.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[host-package]]
+[[target-package]]
 name = 'nested'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'once_cell'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'pathdiff'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'petgraph'
 version = '0.5.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
+name = 'pretty_assertions'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
@@ -168,14 +177,7 @@ status = 'direct'
 features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
 optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
 
-[[host-package]]
-name = 'proptest-derive'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
+[[target-package]]
 name = 'semver'
 version = '0.10.0'
 crates-io = true
@@ -183,7 +185,7 @@ status = 'direct'
 features = ['default', 'serde']
 optional-deps = ['serde']
 
-[[host-package]]
+[[target-package]]
 name = 'serde'
 version = '1.0.116'
 crates-io = true
@@ -191,60 +193,464 @@ status = 'direct'
 features = ['default', 'derive', 'serde_derive', 'std']
 optional-deps = ['serde_derive']
 
-[[host-package]]
+[[target-package]]
 name = 'serde_json'
 version = '1.0.58'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'structopt'
 version = '0.3.19'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'supercow'
 version = '0.1.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'toml'
 version = '0.5.7'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'toml_edit'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'ansi_term'
 version = '0.11.0'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'ascii'
 version = '0.9.3'
 crates-io = true
 status = 'transitive'
 features = ['std']
 
-[[host-package]]
+[[target-package]]
 name = 'atty'
 version = '0.2.14'
 crates-io = true
 status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'chrono'
+version = '0.4.19'
+crates-io = true
+status = 'transitive'
+features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
+optional-deps = ['libc', 'time', 'winapi']
+
+[[target-package]]
+name = 'combine'
+version = '3.8.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'console'
+version = '0.11.3'
+crates-io = true
+status = 'transitive'
+features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
+optional-deps = ['regex', 'unicode-width', 'winapi-util']
+
+[[target-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'either'
+version = '1.6.1'
+crates-io = true
+status = 'transitive'
+features = ['use_std']
+
+[[target-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'hashbrown'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[target-package]]
+name = 'hermit-abi'
+version = '0.1.17'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'itertools'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'linked-hash-map'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['std', 'use_std']
+
+[[target-package]]
+name = 'num-integer'
+version = '0.1.43'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'output_vt100'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package', 'libc']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.1.57'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.3.9'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'semver-parser'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'terminal_size'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'termios'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'time'
+version = '0.1.44'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-width'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unreachable'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vec_map'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wasi'
+version = '0.9.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'wasi'
+version = '0.10.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'minwinbase', 'minwindef', 'ntdef', 'processenv', 'profileapi', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winuser']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proptest-derive'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
 features = []
 
 [[host-package]]
@@ -255,90 +661,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'bit-set'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'cfg-if'
-version = '0.1.10'
+name = 'ctor'
+version = '0.1.16'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'chrono'
-version = '0.4.19'
-crates-io = true
-status = 'transitive'
-features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
-optional-deps = ['libc', 'time']
-
-[[host-package]]
-name = 'combine'
-version = '3.8.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'console'
-version = '0.11.3'
-crates-io = true
-status = 'transitive'
-features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
-optional-deps = ['regex', 'unicode-width']
-
-[[host-package]]
-name = 'either'
-version = '1.6.1'
-crates-io = true
-status = 'transitive'
-features = ['use_std']
-
-[[host-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'getrandom'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'hashbrown'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = ['raw']
 
 [[host-package]]
 name = 'heck'
@@ -346,69 +673,6 @@ version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'itertools'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[host-package]]
-name = 'itoa'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'linked-hash-map'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memchr'
-version = '2.3.3'
-crates-io = true
-status = 'transitive'
-features = ['std', 'use_std']
-
-[[host-package]]
-name = 'num-integer'
-version = '0.1.43'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
 
 [[host-package]]
 name = 'proc-macro-error'
@@ -440,13 +704,6 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'quick-error'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -461,91 +718,11 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'rand'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'regex'
-version = '1.3.9'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.6.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[host-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rusty-fork'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'structopt-derive'
@@ -571,53 +748,11 @@ features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', '
 optional-deps = ['quote']
 
 [[host-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'terminal_size'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'termios'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'time'
-version = '0.1.44'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'unicode-segmentation'
 version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'unicode-width'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -634,36 +769,8 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'unreachable'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'vec_map'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'version_check'
 version = '0.9.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'void'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
@@ -2,31 +2,16 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_869476c
 
 [metadata]
-resolver = '1'
-include-dev = true
+resolver = 'install'
+include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64-wrs-vxworks'
-target-features = 'unknown'
-flags = ['foo']
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'csv-core'
-version = '0.1.10'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'miow'
-version = '0.3.5'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'void'
-version = '1.0.2'
-crates-io = true
+triple = 'armv6k-nintendo-3ds'
+target-features = 'unknown'
 
 [[host-package]]
 name = 'cargo-guppy'
@@ -209,13 +194,6 @@ status = 'direct'
 features = []
 
 [[host-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ascii'
 version = '0.9.3'
 crates-io = true
@@ -365,13 +343,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
-
-[[host-package]]
 name = 'proc-macro-error'
 version = '1.0.4'
 crates-io = true
@@ -407,13 +378,6 @@ crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
 optional-deps = ['getrandom_package', 'libc']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
 
 [[host-package]]
 name = 'rand_core'
@@ -509,13 +473,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'termios'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'textwrap'
 version = '0.11.0'
 crates-io = true
@@ -567,6 +524,13 @@ features = []
 [[host-package]]
 name = 'version_check'
 version = '0.9.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'void'
+version = '1.0.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
@@ -2,25 +2,16 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_869476c
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-fuchsia'
-target-features = 'unknown'
-[[metadata.omitted-packages.ids]]
-name = 'guppy-cmdlib'
-version = '0.1.0'
-workspace-path = 'guppy-cmdlib'
-
-[[metadata.omitted-packages.ids]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
+triple = 'sparc64-unknown-netbsd'
+target-features = ['sha', 'sse4.1']
 
 [[target-package]]
 name = 'fixture-manager'
@@ -51,6 +42,14 @@ workspace-path = 'guppy'
 status = 'workspace'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest010', 'summaries']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'guppy-cmdlib'
+version = '0.1.0'
+workspace-path = 'guppy-cmdlib'
+status = 'workspace'
+features = ['proptest', 'proptest010']
+optional-deps = ['proptest']
 
 [[target-package]]
 name = 'guppy-summaries'
@@ -365,6 +364,13 @@ crates-io = true
 status = 'transitive'
 features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'regex-syntax'

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-5.toml
@@ -2,23 +2,32 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_869476c
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'aarch64-unknown-linux-ohos'
+target-features = 'unknown'
+flags = ['abc']
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'x86_64-unknown-fuchsia'
+target-features = ['bmi2', 'sse', 'sse4.1']
+flags = ['abc']
 [[metadata.omitted-packages.ids]]
-name = 'cfg-expr'
-version = '0.4.1'
-crates-io = true
+name = 'cargo-guppy'
+version = '0.1.0'
+workspace-path = 'cargo-guppy'
 
 [[metadata.omitted-packages.ids]]
-name = 'fixedbitset'
-version = '0.2.0'
+name = 'crates-io'
+version = '0.31.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+
+[[metadata.omitted-packages.ids]]
+name = 'unicode-xid'
+version = '0.1.0'
 crates-io = true
 
 [[metadata.features-only]]
@@ -128,6 +137,13 @@ status = 'direct'
 features = ['default']
 
 [[target-package]]
+name = 'cfg-expr'
+version = '0.4.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
 name = 'clap'
 version = '2.33.3'
 crates-io = true
@@ -155,6 +171,13 @@ version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
+
+[[target-package]]
+name = 'fixedbitset'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[target-package]]
 name = 'indexmap'
@@ -272,13 +295,6 @@ status = 'direct'
 features = []
 
 [[target-package]]
-name = 'adler'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'aho-corasick'
 version = '0.7.13'
 crates-io = true
@@ -375,7 +391,7 @@ version = '0.4.19'
 crates-io = true
 status = 'transitive'
 features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
-optional-deps = ['libc', 'time', 'winapi']
+optional-deps = ['libc', 'time']
 
 [[target-package]]
 name = 'combine'
@@ -385,47 +401,12 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'commoncrypto'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'commoncrypto-sys'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'console'
 version = '0.11.3'
 crates-io = true
 status = 'transitive'
 features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
-optional-deps = ['regex', 'unicode-width', 'winapi-util']
-
-[[target-package]]
-name = 'core-foundation'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[target-package]]
-name = 'core-foundation-sys'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[target-package]]
-name = 'crates-io'
-version = '0.31.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
+optional-deps = ['regex', 'unicode-width']
 
 [[target-package]]
 name = 'crc32fast'
@@ -473,13 +454,6 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
-name = 'encode_unicode'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'env_logger'
 version = '0.7.1'
 crates-io = true
@@ -519,13 +493,6 @@ features = []
 [[target-package]]
 name = 'foreign-types-shared'
 version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fwdansi'
-version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -572,13 +539,6 @@ version = '0.9.1'
 crates-io = true
 status = 'transitive'
 features = ['raw']
-
-[[target-package]]
-name = 'hermit-abi'
-version = '0.1.17'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'hex'
@@ -737,20 +697,6 @@ status = 'transitive'
 features = ['default', 'std', 'use_std']
 
 [[target-package]]
-name = 'miniz_oxide'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'miow'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'num-integer'
 version = '0.1.43'
 crates-io = true
@@ -800,13 +746,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'output_vt100'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'percent-encoding'
 version = '2.1.0'
 crates-io = true
@@ -851,13 +790,6 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[target-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'rand_xorshift'
 version = '0.2.0'
 crates-io = true
@@ -867,13 +799,6 @@ features = []
 [[target-package]]
 name = 'rand_xoshiro'
 version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.1.57'
 crates-io = true
 status = 'transitive'
 features = []
@@ -937,13 +862,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'schannel'
-version = '0.1.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'semver-parser'
 version = '0.7.0'
 crates-io = true
@@ -970,6 +888,13 @@ version = '0.6.2'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
+
+[[target-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'socket2'
@@ -1139,48 +1064,6 @@ crates-io = true
 status = 'transitive'
 features = []
 
-[[target-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'wasi'
-version = '0.10.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['basetsd', 'consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'jobapi', 'jobapi2', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntstatus', 'processenv', 'processthreadsapi', 'profileapi', 'psapi', 'schannel', 'securitybaseapi', 'shellapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
 [[host-package]]
 name = 'proptest-derive'
 version = '0.2.0'
@@ -1204,13 +1087,6 @@ features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
 
 [[host-package]]
-name = 'ctor'
-version = '0.1.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'heck'
 version = '0.3.1'
 crates-io = true
@@ -1223,6 +1099,13 @@ version = '0.1.21'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'pkg-config'
@@ -1310,13 +1193,6 @@ version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'unicode-xid'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-7.toml
@@ -2,12 +2,12 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_869476c
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'always'
+spec = 'any'
 
 [metadata.target-platform]
 spec = 'always'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'standard'
+resolver = '3'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'always'
@@ -33,14 +33,14 @@ workspace-path = 'target-spec'
 features = ['proptest', 'proptest010', 'serde', 'summaries']
 optional-deps = ['proptest', 'serde']
 
-[[target-package]]
+[[host-package]]
 name = 'cargo-compare'
 version = '0.1.0'
 workspace-path = 'internal-tools/cargo-compare'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'guppy'
 version = '0.5.0'
 workspace-path = 'guppy'
@@ -48,7 +48,7 @@ status = 'workspace'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest010', 'summaries']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'guppy-cmdlib'
 version = '0.1.0'
 workspace-path = 'guppy-cmdlib'
@@ -56,14 +56,14 @@ status = 'workspace'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'guppy-summaries'
 version = '0.2.0'
 workspace-path = 'guppy-summaries'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'target-spec'
 version = '0.4.1'
 workspace-path = 'target-spec'
@@ -71,854 +71,104 @@ status = 'workspace'
 features = ['proptest', 'proptest010', 'serde', 'summaries']
 optional-deps = ['proptest', 'serde']
 
-[[target-package]]
+[[host-package]]
 name = 'anyhow'
 version = '1.0.33'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'cargo'
 version = '0.46.0'
 source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'cfg-expr'
 version = '0.4.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'diffus'
 version = '0.9.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'either'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[target-package]]
+[[host-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'indexmap'
 version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'itertools'
 version = '0.9.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[target-package]]
+[[host-package]]
 name = 'nested'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'once_cell'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'pathdiff'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'petgraph'
 version = '0.5.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
 status = 'direct'
 features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
 optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[target-package]]
-name = 'semver'
-version = '0.10.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'serde']
-optional-deps = ['serde']
-
-[[target-package]]
-name = 'serde'
-version = '1.0.116'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'serde_json'
-version = '1.0.58'
-crates-io = true
-status = 'direct'
-features = ['default', 'raw_value', 'std']
-
-[[target-package]]
-name = 'structopt'
-version = '0.3.19'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'supercow'
-version = '0.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'toml'
-version = '0.5.7'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'aho-corasick'
-version = '0.7.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atty'
-version = '0.2.14'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit-set'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'bitmaps'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bstr'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bytesize'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cargo-platform'
-version = '0.1.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cfg-if'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clap'
-version = '2.33.3'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'crates-io'
-version = '0.31.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crc32fast'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crypto-hash'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'curl'
-version = '0.4.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[target-package]]
-name = 'curl-sys'
-version = '0.4.36+curl-7.71.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
-optional-deps = ['libnghttp2-sys', 'openssl-sys']
-
-[[target-package]]
-name = 'env_logger'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
-optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
-
-[[target-package]]
-name = 'filetime'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'flate2'
-version = '1.0.18'
-crates-io = true
-status = 'transitive'
-features = ['any_zlib', 'libz-sys', 'zlib']
-optional-deps = ['libz-sys']
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'foreign-types'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'foreign-types-shared'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'getrandom'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'git2'
-version = '0.13.11'
-crates-io = true
-status = 'transitive'
-features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[target-package]]
-name = 'git2-curl'
-version = '0.14.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'glob'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'globset'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hashbrown'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[target-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hex'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'home'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '2.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'idna'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ignore'
-version = '0.4.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'im-rc'
-version = '15.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itertools'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'itoa'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'jobserver'
-version = '0.1.21'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lazycell'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'libgit2-sys'
-version = '0.12.13+1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['libssh2-sys', 'openssl-sys']
-
-[[target-package]]
-name = 'libnghttp2-sys'
-version = '0.1.4+1.41.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libssh2-sys'
-version = '0.2.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libz-sys'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = ['libc']
-optional-deps = ['libc']
-
-[[target-package]]
-name = 'log'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'use_std']
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'opener'
-version = '0.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl'
-version = '0.10.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-probe'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-sys'
-version = '0.9.58'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'percent-encoding'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
-
-[[target-package]]
-name = 'quick-error'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[target-package]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xoshiro'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex'
-version = '1.3.9'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustc-workspace-hack'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustfix'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rusty-fork'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[target-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'serde_ignored'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'shell-escape'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'sized-chunks'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'smallvec'
-version = '1.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'socket2'
-version = '0.3.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'strip-ansi-escapes'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tar'
-version = '0.4.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'termcolor'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tinyvec'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default']
-
-[[target-package]]
-name = 'typenum'
-version = '1.12.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-normalization'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'unicode-width'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-xid'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'url'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'utf8parse'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vec_map'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vte'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'proptest-derive'
@@ -928,9 +178,130 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'semver'
+version = '0.10.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.116'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.58'
+crates-io = true
+status = 'direct'
+features = ['default', 'raw_value', 'std']
+
+[[host-package]]
+name = 'structopt'
+version = '0.3.19'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'supercow'
+version = '0.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'toml'
+version = '0.5.7'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'aho-corasick'
+version = '0.7.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'autocfg'
 version = '1.0.1'
 crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bit-set'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'bitmaps'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bstr'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'bytesize'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cargo-platform'
+version = '0.1.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'transitive'
 features = []
 
@@ -943,8 +314,209 @@ features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
 
 [[host-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'clap'
+version = '2.33.3'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
+
+[[host-package]]
+name = 'crates-io'
+version = '0.31.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc32fast'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'crossbeam-utils'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crypto-hash'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'curl'
+version = '0.4.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
+
+[[host-package]]
+name = 'curl-sys'
+version = '0.4.36+curl-7.71.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
+optional-deps = ['libnghttp2-sys']
+
+[[host-package]]
+name = 'env_logger'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
+optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
+
+[[host-package]]
+name = 'filetime'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'flate2'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['any_zlib', 'libz-sys', 'zlib']
+optional-deps = ['libz-sys']
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'getrandom'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'git2'
+version = '0.13.11'
+crates-io = true
+status = 'transitive'
+features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+
+[[host-package]]
+name = 'git2-curl'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'glob'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'globset'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
 name = 'heck'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'home'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'humantime'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'humantime'
+version = '2.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ignore'
+version = '0.4.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'im-rc'
+version = '15.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itertools'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'itoa'
+version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -957,11 +529,118 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lazycell'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'libgit2-sys'
+version = '0.12.13+1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+optional-deps = ['libssh2-sys']
+
+[[host-package]]
+name = 'libnghttp2-sys'
+version = '0.1.4+1.41.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libssh2-sys'
+version = '0.2.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libz-sys'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = ['libc']
+optional-deps = ['libc']
+
+[[host-package]]
+name = 'log'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'num_cpus'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'opener'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'pkg-config'
 version = '0.3.18'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'ppv-lite86'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = ['simd']
 
 [[host-package]]
 name = 'proc-macro-error'
@@ -993,6 +672,13 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -1007,11 +693,162 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package']
+
+[[host-package]]
+name = 'rand_chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[host-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_xoshiro'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'regex'
+version = '1.3.9'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.6.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'remove_dir_all'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc-workspace-hack'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustfix'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'same-file'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver-parser'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[host-package]]
+name = 'serde_ignored'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'shell-escape'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'sized-chunks'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'socket2'
+version = '0.3.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strip-ansi-escapes'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'structopt-derive'
@@ -1037,11 +874,74 @@ features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', '
 optional-deps = ['quote']
 
 [[host-package]]
+name = 'tar'
+version = '0.4.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thread_local'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tinyvec'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'typenum'
+version = '1.12.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'unicode-normalization'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'unicode-segmentation'
 version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -1058,8 +958,50 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'url'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vec_map'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.9.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vte'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'walkdir'
+version = '2.3.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-1.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'proc-macros-on-target'
+resolver = '3'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'any'
@@ -62,6 +62,13 @@ crates-io = true
 status = 'direct'
 features = ['default', 'derive', 'serde_derive', 'std']
 optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'toml'
+version = '0.5.7'
+crates-io = true
+status = 'direct'
+features = ['default']
 
 [[target-package]]
 name = 'bit-set'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-2.toml
@@ -2,20 +2,19 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'standard'
+resolver = '3'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'i686-linux-android'
+target-features = ['bmi1', 'sse', 'sse4.2']
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-hermit'
-target-features = ['avx2', 'sha', 'sse2', 'sse3']
-flags = ['test-flag']
+spec = 'any'
 [[metadata.omitted-packages.ids]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
+name = 'remove_dir_all'
+version = '0.5.3'
 crates-io = true
 
 [[metadata.features-only]]
@@ -118,13 +117,6 @@ status = 'direct'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'assert_matches'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
 name = 'cargo'
 version = '0.46.0'
 source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
@@ -152,13 +144,6 @@ crates-io = true
 status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
 optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'criterion'
-version = '0.3.3'
-crates-io = true
-status = 'direct'
-features = ['default']
 
 [[target-package]]
 name = 'dialoguer'
@@ -304,6 +289,13 @@ status = 'direct'
 features = []
 
 [[target-package]]
+name = 'adler'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'aho-corasick'
 version = '0.7.13'
 crates-io = true
@@ -364,8 +356,7 @@ name = 'bstr'
 version = '0.2.13'
 crates-io = true
 status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
+features = ['std']
 
 [[target-package]]
 name = 'byteorder'
@@ -389,13 +380,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'cast'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'cfg-if'
 version = '0.1.10'
 crates-io = true
@@ -408,7 +392,7 @@ version = '0.4.19'
 crates-io = true
 status = 'transitive'
 features = ['clock', 'default', 'libc', 'oldtime', 'std', 'time', 'winapi']
-optional-deps = ['libc', 'time']
+optional-deps = ['libc', 'time', 'winapi']
 
 [[target-package]]
 name = 'combine'
@@ -418,12 +402,40 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
+name = 'commoncrypto'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'commoncrypto-sys'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'console'
 version = '0.11.3'
 crates-io = true
 status = 'transitive'
 features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
-optional-deps = ['regex', 'unicode-width']
+optional-deps = ['regex', 'unicode-width', 'winapi-util']
+
+[[target-package]]
+name = 'core-foundation'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = ['mac_os_10_7_support']
+
+[[target-package]]
+name = 'core-foundation-sys'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = ['mac_os_10_7_support']
 
 [[target-package]]
 name = 'crates-io'
@@ -438,35 +450,6 @@ version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
-
-[[target-package]]
-name = 'criterion-plot'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-channel'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-deque'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-epoch'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
 
 [[target-package]]
 name = 'crossbeam-utils'
@@ -484,25 +467,12 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'csv'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'csv-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
 name = 'curl'
 version = '0.4.33'
 crates-io = true
 status = 'transitive'
 features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
+optional-deps = ['openssl-probe', 'openssl-sys']
 
 [[target-package]]
 name = 'curl-sys'
@@ -510,7 +480,7 @@ version = '0.4.36+curl-7.71.1'
 crates-io = true
 status = 'transitive'
 features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
-optional-deps = ['libnghttp2-sys']
+optional-deps = ['libnghttp2-sys', 'openssl-sys']
 
 [[target-package]]
 name = 'difference'
@@ -518,6 +488,13 @@ version = '2.0.0'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[target-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'env_logger'
@@ -564,6 +541,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'fwdansi'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'getrandom'
 version = '0.1.15'
 crates-io = true
@@ -576,6 +560,7 @@ version = '0.13.11'
 crates-io = true
 status = 'transitive'
 features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+optional-deps = ['openssl-probe', 'openssl-sys']
 
 [[target-package]]
 name = 'git2-curl'
@@ -594,13 +579,6 @@ features = []
 [[target-package]]
 name = 'globset'
 version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'half'
-version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -687,7 +665,7 @@ name = 'itoa'
 version = '0.4.6'
 crates-io = true
 status = 'transitive'
-features = ['default', 'std']
+features = []
 
 [[target-package]]
 name = 'jobserver'
@@ -723,7 +701,7 @@ version = '0.12.13+1.0.1'
 crates-io = true
 status = 'transitive'
 features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['libssh2-sys']
+optional-deps = ['libssh2-sys', 'openssl-sys']
 
 [[target-package]]
 name = 'libnghttp2-sys'
@@ -769,13 +747,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'maybe-uninit'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'memchr'
 version = '2.3.3'
 crates-io = true
@@ -783,11 +754,18 @@ status = 'transitive'
 features = ['default', 'std', 'use_std']
 
 [[target-package]]
-name = 'memoffset'
-version = '0.5.6'
+name = 'miniz_oxide'
+version = '0.4.3'
 crates-io = true
 status = 'transitive'
-features = ['default']
+features = []
+
+[[target-package]]
+name = 'miow'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'num-integer'
@@ -801,18 +779,11 @@ name = 'num-traits'
 version = '0.2.12'
 crates-io = true
 status = 'transitive'
-features = ['default', 'std']
+features = ['std']
 
 [[target-package]]
 name = 'num_cpus'
 version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'oorandom'
-version = '11.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -832,8 +803,22 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'openssl-probe'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'openssl-sys'
 version = '0.9.58'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'output_vt100'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -844,13 +829,6 @@ version = '2.1.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'plotters'
-version = '0.2.15'
-crates-io = true
-status = 'transitive'
-features = ['area_series', 'line_series', 'svg']
 
 [[target-package]]
 name = 'ppv-lite86'
@@ -872,7 +850,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package']
+optional-deps = ['getrandom_package', 'libc']
 
 [[target-package]]
 name = 'rand_chacha'
@@ -890,6 +868,13 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[target-package]]
+name = 'rand_hc'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'rand_xorshift'
 version = '0.2.0'
 crates-io = true
@@ -904,15 +889,8 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'rayon'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon-core'
-version = '1.8.1'
+name = 'redox_syscall'
+version = '0.1.57'
 crates-io = true
 status = 'transitive'
 features = []
@@ -926,25 +904,11 @@ features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa
 optional-deps = ['aho-corasick', 'memchr', 'thread_local']
 
 [[target-package]]
-name = 'regex-automata'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'regex-syntax'
 version = '0.6.18'
 crates-io = true
 status = 'transitive'
 features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'rustc-workspace-hack'
@@ -983,8 +947,8 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'scopeguard'
-version = '1.1.0'
+name = 'schannel'
+version = '0.1.19'
 crates-io = true
 status = 'transitive'
 features = []
@@ -995,13 +959,6 @@ version = '0.7.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'serde_cbor'
-version = '0.11.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'serde_ignored'
@@ -1074,6 +1031,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'termios'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'textwrap'
 version = '0.11.0'
 crates-io = true
@@ -1090,13 +1054,6 @@ features = []
 [[target-package]]
 name = 'time'
 version = '0.1.44'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tinytemplate'
-version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1199,6 +1156,48 @@ crates-io = true
 status = 'transitive'
 features = []
 
+[[target-package]]
+name = 'wasi'
+version = '0.9.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'wasi'
+version = '0.10.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['basetsd', 'consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'jobapi', 'jobapi2', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntstatus', 'processenv', 'processthreadsapi', 'profileapi', 'psapi', 'schannel', 'securitybaseapi', 'shellapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
 [[host-package]]
 name = 'proptest-derive'
 version = '0.2.0'
@@ -1220,6 +1219,13 @@ crates-io = true
 status = 'transitive'
 features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
+
+[[host-package]]
+name = 'ctor'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'heck'
@@ -1293,27 +1299,6 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'rustc_version'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'semver'
-version = '0.9.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
@@ -1363,13 +1348,6 @@ version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'vcpkg'
-version = '0.2.10'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'version_check'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-3.toml
@@ -2,24 +2,18 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'host'
+initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'thumbv7em-none-eabihf'
+target-features = 'all'
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'commoncrypto'
-version = '0.2.0'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'console'
-version = '0.11.3'
-crates-io = true
+triple = 'x86_64-pc-nto-qnx710'
+target-features = 'unknown'
+flags = ['cargo_web', 'foo']
 
 [[metadata.features-only]]
 name = 'guppy'
@@ -27,21 +21,21 @@ version = '0.5.0'
 workspace-path = 'guppy'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cargo-compare'
 version = '0.1.0'
 workspace-path = 'internal-tools/cargo-compare'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'fixtures'
 version = '0.1.0'
 workspace-path = 'fixtures'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'guppy'
 version = '0.5.0'
 workspace-path = 'guppy'
@@ -49,7 +43,7 @@ status = 'initial'
 features = ['proptest', 'proptest-derive', 'proptest010']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'guppy-cmdlib'
 version = '0.1.0'
 workspace-path = 'guppy-cmdlib'
@@ -57,7 +51,7 @@ status = 'workspace'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'target-spec'
 version = '0.4.1'
 workspace-path = 'target-spec'
@@ -65,111 +59,875 @@ status = 'workspace'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'anyhow'
 version = '1.0.33'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
+name = 'assert_matches'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
 name = 'cargo'
 version = '0.46.0'
 source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'cfg-expr'
 version = '0.4.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'diffus'
 version = '0.9.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'either'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[host-package]]
+[[target-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'indexmap'
 version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'itertools'
 version = '0.9.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[host-package]]
+[[target-package]]
 name = 'nested'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'once_cell'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'pathdiff'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'petgraph'
 version = '0.5.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'pretty_assertions'
 version = '0.6.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
 status = 'direct'
 features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
 optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[target-package]]
+name = 'semver'
+version = '0.10.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.116'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'serde_json'
+version = '1.0.58'
+crates-io = true
+status = 'direct'
+features = ['default', 'raw_value', 'std']
+
+[[target-package]]
+name = 'structopt'
+version = '0.3.19'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'supercow'
+version = '0.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'aho-corasick'
+version = '0.7.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'bitmaps'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bstr'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bytesize'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cargo-platform'
+version = '0.1.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '2.33.3'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+
+[[target-package]]
+name = 'crates-io'
+version = '0.31.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crc32fast'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'crossbeam-utils'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crypto-hash'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'curl'
+version = '0.4.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
+optional-deps = ['openssl-probe', 'openssl-sys']
+
+[[target-package]]
+name = 'curl-sys'
+version = '0.4.36+curl-7.71.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
+optional-deps = ['libnghttp2-sys', 'openssl-sys']
+
+[[target-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'env_logger'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
+optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
+
+[[target-package]]
+name = 'filetime'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'flate2'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['any_zlib', 'libz-sys', 'zlib']
+optional-deps = ['libz-sys']
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'foreign-types'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'foreign-types-shared'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'git2'
+version = '0.13.11'
+crates-io = true
+status = 'transitive'
+features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+optional-deps = ['openssl-probe', 'openssl-sys']
+
+[[target-package]]
+name = 'git2-curl'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'glob'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'globset'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hashbrown'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[target-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hex'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'home'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'humantime'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'humantime'
+version = '2.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ignore'
+version = '0.4.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'im-rc'
+version = '15.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'itertools'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'jobserver'
+version = '0.1.21'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazycell'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'libgit2-sys'
+version = '0.12.13+1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+optional-deps = ['libssh2-sys', 'openssl-sys']
+
+[[target-package]]
+name = 'libnghttp2-sys'
+version = '0.1.4+1.41.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libssh2-sys'
+version = '0.2.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libz-sys'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = ['libc']
+optional-deps = ['libc']
+
+[[target-package]]
+name = 'log'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num_cpus'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'opener'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'openssl'
+version = '0.10.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'openssl-probe'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'openssl-sys'
+version = '0.9.58'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package', 'libc']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xoshiro'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.3.9'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustc-workspace-hack'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustfix'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'semver-parser'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde_ignored'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'shell-escape'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sized-chunks'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'socket2'
+version = '0.3.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strip-ansi-escapes'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tar'
+version = '0.4.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tinyvec'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'toml'
+version = '0.5.7'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'typenum'
+version = '1.12.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-normalization'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'unicode-width'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-xid'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'url'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vec_map'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vte'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'walkdir'
+version = '2.3.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'proptest-derive'
@@ -179,137 +937,9 @@ status = 'direct'
 features = []
 
 [[host-package]]
-name = 'semver'
-version = '0.10.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'serde']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'serde'
-version = '1.0.116'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
-name = 'serde_json'
-version = '1.0.58'
-crates-io = true
-status = 'direct'
-features = ['default', 'raw_value', 'std']
-
-[[host-package]]
-name = 'structopt'
-version = '0.3.19'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'supercow'
-version = '0.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'adler'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'aho-corasick'
-version = '0.7.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'atty'
-version = '0.2.14'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'autocfg'
 version = '1.0.1'
 crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bit-set'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'bitmaps'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bstr'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'bytesize'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'cargo-platform'
-version = '0.1.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'transitive'
 features = []
 
@@ -322,267 +952,8 @@ features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
 
 [[host-package]]
-name = 'cfg-if'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'clap'
-version = '2.33.3'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[host-package]]
-name = 'core-foundation'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[host-package]]
-name = 'core-foundation-sys'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[host-package]]
-name = 'crates-io'
-version = '0.31.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crc32fast'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crypto-hash'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ctor'
-version = '0.1.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'curl'
-version = '0.4.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[host-package]]
-name = 'curl-sys'
-version = '0.4.36+curl-7.71.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
-optional-deps = ['libnghttp2-sys', 'openssl-sys']
-
-[[host-package]]
-name = 'difference'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'env_logger'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
-optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
-
-[[host-package]]
-name = 'filetime'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'flate2'
-version = '1.0.18'
-crates-io = true
-status = 'transitive'
-features = ['any_zlib', 'libz-sys', 'zlib']
-optional-deps = ['libz-sys']
-
-[[host-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'foreign-types'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'foreign-types-shared'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fwdansi'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'getrandom'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'git2'
-version = '0.13.11'
-crates-io = true
-status = 'transitive'
-features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[host-package]]
-name = 'git2-curl'
-version = '0.14.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'glob'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'globset'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hashbrown'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[host-package]]
 name = 'heck'
 version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hermit-abi'
-version = '0.1.17'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hex'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'home'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'humantime'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'humantime'
-version = '2.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'idna'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ignore'
-version = '0.4.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'im-rc'
-version = '15.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'itertools'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[host-package]]
-name = 'itoa'
-version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -595,160 +966,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lazycell'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'libgit2-sys'
-version = '0.12.13+1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['libssh2-sys', 'openssl-sys']
-
-[[host-package]]
-name = 'libnghttp2-sys'
-version = '0.1.4+1.41.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'libssh2-sys'
-version = '0.2.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'libz-sys'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = ['libc']
-optional-deps = ['libc']
-
-[[host-package]]
-name = 'log'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memchr'
-version = '2.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'use_std']
-
-[[host-package]]
-name = 'miniz_oxide'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num_cpus'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'opener'
-version = '0.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'openssl'
-version = '0.10.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'openssl-probe'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'openssl-sys'
-version = '0.9.58'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'output_vt100'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'percent-encoding'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'pkg-config'
 version = '0.3.18'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
 
 [[host-package]]
 name = 'proc-macro-error'
@@ -780,13 +1002,6 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'quick-error'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -801,183 +1016,11 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'rand'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[host-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xoshiro'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'redox_syscall'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'regex'
-version = '1.3.9'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.6.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[host-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rustc-workspace-hack'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rustfix'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rusty-fork'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'schannel'
-version = '0.1.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'serde_ignored'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'shell-escape'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'sized-chunks'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'smallvec'
-version = '1.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'socket2'
-version = '0.3.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'strip-ansi-escapes'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'structopt-derive'
@@ -1003,81 +1046,11 @@ features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', '
 optional-deps = ['quote']
 
 [[host-package]]
-name = 'tar'
-version = '0.4.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'termcolor'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'thread_local'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tinyvec'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default']
-
-[[host-package]]
-name = 'toml'
-version = '0.5.7'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'typenum'
-version = '1.12.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'unicode-normalization'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'unicode-segmentation'
 version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'unicode-width'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -1094,92 +1067,8 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'url'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'utf8parse'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'vcpkg'
-version = '0.2.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'vec_map'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'version_check'
 version = '0.9.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'vte'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['basetsd', 'consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'jobapi', 'jobapi2', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntstatus', 'processenv', 'processthreadsapi', 'psapi', 'schannel', 'securitybaseapi', 'shellapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[host-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-util'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-4.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'proc-macros-on-target'
+resolver = '3'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'any'
@@ -216,7 +216,7 @@ name = 'itoa'
 version = '0.4.6'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'std']
 
 [[target-package]]
 name = 'lazy_static'
@@ -230,7 +230,7 @@ name = 'num-traits'
 version = '0.2.12'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['default', 'std']
 
 [[target-package]]
 name = 'ppv-lite86'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
@@ -2,17 +2,33 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'standard'
+resolver = '2'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-pc-solaris'
-target-features = 'all'
-flags = ['bar']
+triple = 'x86_64-unknown-l4re-uclibc'
+target-features = ['aes', 'bmi1', 'fma', 'sse3', 'xsave']
+flags = ['test-flag']
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'x86_64-uwp-windows-msvc'
+target-features = 'all'
+flags = ['bar', 'foo']
+[[metadata.omitted-packages.ids]]
+name = 'itertools'
+version = '0.9.0'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'vte'
+version = '0.3.3'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'wasi'
+version = '0.10.0+wasi-snapshot-preview1'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'guppy'
@@ -117,14 +133,7 @@ version = '2.33.3'
 crates-io = true
 status = 'direct'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'criterion'
-version = '0.3.3'
-crates-io = true
-status = 'direct'
-features = ['default']
+optional-deps = ['atty', 'strsim', 'vec_map']
 
 [[target-package]]
 name = 'dialoguer'
@@ -153,13 +162,6 @@ version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
-
-[[target-package]]
-name = 'itertools'
-version = '0.9.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
 
 [[target-package]]
 name = 'nested'
@@ -298,26 +300,11 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
-name = 'bstr'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
-
-[[target-package]]
 name = 'byteorder'
 version = '1.3.4'
 crates-io = true
 status = 'transitive'
 features = ['std']
-
-[[target-package]]
-name = 'cast'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'cfg-if'
@@ -348,57 +335,6 @@ crates-io = true
 status = 'transitive'
 features = ['ansi-parsing', 'default', 'regex', 'unicode-width', 'winapi-util', 'windows-console-colors']
 optional-deps = ['regex', 'unicode-width', 'winapi-util']
-
-[[target-package]]
-name = 'criterion-plot'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-channel'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-deque'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-epoch'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'csv'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'csv-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'difference'
@@ -436,25 +372,11 @@ status = 'transitive'
 features = ['std']
 
 [[target-package]]
-name = 'half'
-version = '1.6.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'hashbrown'
 version = '0.9.1'
 crates-io = true
 status = 'transitive'
 features = ['raw']
-
-[[target-package]]
-name = 'hermit-abi'
-version = '0.1.17'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'itertools'
@@ -466,13 +388,6 @@ features = ['default', 'use_std']
 [[target-package]]
 name = 'itoa'
 version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'js-sys'
-version = '0.3.45'
 crates-io = true
 status = 'transitive'
 features = []
@@ -499,25 +414,11 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'maybe-uninit'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'memchr'
 version = '2.3.3'
 crates-io = true
 status = 'transitive'
 features = ['std', 'use_std']
-
-[[target-package]]
-name = 'memoffset'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'num-integer'
@@ -531,21 +432,7 @@ name = 'num-traits'
 version = '0.2.12'
 crates-io = true
 status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'oorandom'
-version = '11.1.2'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['std']
 
 [[target-package]]
 name = 'output_vt100'
@@ -553,13 +440,6 @@ version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'plotters'
-version = '0.2.15'
-crates-io = true
-status = 'transitive'
-features = ['area_series', 'line_series', 'svg']
 
 [[target-package]]
 name = 'ppv-lite86'
@@ -581,7 +461,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
+optional-deps = ['getrandom_package']
 
 [[target-package]]
 name = 'rand_chacha'
@@ -599,36 +479,8 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[target-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'rand_xorshift'
 version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon-core'
-version = '1.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.1.57'
 crates-io = true
 status = 'transitive'
 features = []
@@ -639,13 +491,6 @@ version = '1.3.9'
 crates-io = true
 status = 'transitive'
 features = ['std']
-
-[[target-package]]
-name = 'regex-automata'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'regex-syntax'
@@ -677,32 +522,11 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'semver-parser'
 version = '0.7.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'serde_cbor'
-version = '0.11.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'smallvec'
@@ -733,13 +557,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'termios'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'textwrap'
 version = '0.11.0'
 crates-io = true
@@ -749,13 +566,6 @@ features = []
 [[target-package]]
 name = 'time'
 version = '0.1.44'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tinytemplate'
-version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -796,41 +606,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'wasi'
-version = '0.10.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'wasm-bindgen'
-version = '0.2.68'
-crates-io = true
-status = 'transitive'
-features = ['default', 'spans', 'std']
-
-[[target-package]]
-name = 'web-sys'
-version = '0.3.45'
-crates-io = true
-status = 'transitive'
-features = ['CanvasRenderingContext2d', 'Document', 'DomRect', 'DomRectReadOnly', 'Element', 'EventTarget', 'HtmlCanvasElement', 'HtmlElement', 'Node', 'Window']
-
-[[target-package]]
 name = 'winapi'
 version = '0.3.9'
 crates-io = true
@@ -838,22 +613,8 @@ status = 'transitive'
 features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'minwinbase', 'minwindef', 'ntdef', 'processenv', 'profileapi', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winuser']
 
 [[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'winapi-util'
 version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -873,20 +634,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'bumpalo'
-version = '3.4.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'cfg-if'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ctor'
 version = '0.1.16'
 crates-io = true
@@ -896,20 +643,6 @@ features = []
 [[host-package]]
 name = 'heck'
 version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'log'
-version = '0.4.11'
 crates-io = true
 status = 'transitive'
 features = []
@@ -956,27 +689,6 @@ version = '1.0.7'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'rustc_version'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'semver'
-version = '0.9.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'serde_derive'
@@ -1032,34 +744,6 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wasm-bindgen-backend'
-version = '0.2.68'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-macro'
-version = '0.2.68'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-macro-support'
-version = '0.2.68'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-shared'
-version = '0.2.68'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-7.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_guppy_c9b4f76
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'always'
@@ -28,21 +28,21 @@ workspace-path = 'guppy'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest010', 'summaries']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'cargo-compare'
 version = '0.1.0'
 workspace-path = 'internal-tools/cargo-compare'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'fixtures'
 version = '0.1.0'
 workspace-path = 'fixtures'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'guppy'
 version = '0.5.0'
 workspace-path = 'guppy'
@@ -50,7 +50,7 @@ status = 'initial'
 features = ['guppy-summaries', 'proptest', 'proptest-derive', 'proptest010', 'summaries']
 optional-deps = ['guppy-summaries', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'guppy-cmdlib'
 version = '0.1.0'
 workspace-path = 'guppy-cmdlib'
@@ -58,21 +58,21 @@ status = 'initial'
 features = ['proptest', 'proptest010']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'proptest-ext'
 version = '0.1.0'
 workspace-path = 'internal-tools/proptest-ext'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'guppy-summaries'
 version = '0.2.0'
 workspace-path = 'guppy-summaries'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'target-spec'
 version = '0.4.1'
 workspace-path = 'target-spec'
@@ -80,987 +80,104 @@ status = 'workspace'
 features = ['proptest', 'proptest010', 'serde', 'summaries']
 optional-deps = ['proptest', 'serde']
 
-[[target-package]]
+[[host-package]]
 name = 'anyhow'
 version = '1.0.33'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'cargo'
 version = '0.46.0'
 source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'cargo_metadata'
 version = '0.11.3'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'cfg-expr'
 version = '0.4.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'diffus'
 version = '0.9.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'either'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[target-package]]
+[[host-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'indexmap'
 version = '1.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'itertools'
 version = '0.9.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std']
 
-[[target-package]]
+[[host-package]]
 name = 'nested'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'once_cell'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'pathdiff'
 version = '0.2.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'pretty_assertions'
 version = '0.6.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'proptest'
 version = '0.10.1'
 crates-io = true
 status = 'direct'
 features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
 optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[target-package]]
-name = 'semver'
-version = '0.10.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'serde']
-optional-deps = ['serde']
-
-[[target-package]]
-name = 'serde'
-version = '1.0.116'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'serde_json'
-version = '1.0.58'
-crates-io = true
-status = 'direct'
-features = ['default', 'raw_value', 'std']
-
-[[target-package]]
-name = 'structopt'
-version = '0.3.19'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'supercow'
-version = '0.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'toml'
-version = '0.5.7'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'adler'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'aho-corasick'
-version = '0.7.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atty'
-version = '0.2.14'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit-set'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'bitmaps'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bstr'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bytesize'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cargo-platform'
-version = '0.1.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cfg-if'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clap'
-version = '2.33.3'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'commoncrypto'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'commoncrypto-sys'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'core-foundation'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[target-package]]
-name = 'core-foundation-sys'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['mac_os_10_7_support']
-
-[[target-package]]
-name = 'crates-io'
-version = '0.31.1'
-source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crc32fast'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crypto-hash'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'curl'
-version = '0.4.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[target-package]]
-name = 'curl-sys'
-version = '0.4.36+curl-7.71.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
-optional-deps = ['libnghttp2-sys', 'openssl-sys']
-
-[[target-package]]
-name = 'difference'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'env_logger'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
-optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
-
-[[target-package]]
-name = 'filetime'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'flate2'
-version = '1.0.18'
-crates-io = true
-status = 'transitive'
-features = ['any_zlib', 'libz-sys', 'zlib']
-optional-deps = ['libz-sys']
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'foreign-types'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'foreign-types-shared'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fwdansi'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'getrandom'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'git2'
-version = '0.13.11'
-crates-io = true
-status = 'transitive'
-features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['openssl-probe', 'openssl-sys']
-
-[[target-package]]
-name = 'git2-curl'
-version = '0.14.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'glob'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'globset'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hashbrown'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[target-package]]
-name = 'hermit-abi'
-version = '0.1.17'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hex'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'home'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '2.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'idna'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ignore'
-version = '0.4.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'im-rc'
-version = '15.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itertools'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'itoa'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'jobserver'
-version = '0.1.21'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lazycell'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'libgit2-sys'
-version = '0.12.13+1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
-optional-deps = ['libssh2-sys', 'openssl-sys']
-
-[[target-package]]
-name = 'libnghttp2-sys'
-version = '0.1.4+1.41.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libssh2-sys'
-version = '0.2.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libz-sys'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = ['libc']
-optional-deps = ['libc']
-
-[[target-package]]
-name = 'log'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'use_std']
-
-[[target-package]]
-name = 'miniz_oxide'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'miow'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'opener'
-version = '0.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl'
-version = '0.10.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-probe'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-sys'
-version = '0.9.58'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'output_vt100'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'percent-encoding'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ppv-lite86'
-version = '0.2.9'
-crates-io = true
-status = 'transitive'
-features = ['simd', 'std']
-
-[[target-package]]
-name = 'quick-error'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[target-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xorshift'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xoshiro'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex'
-version = '1.3.9'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustc-workspace-hack'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustfix'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rusty-fork'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[target-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'schannel'
-version = '0.1.19'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'semver-parser'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'serde_ignored'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'shell-escape'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'sized-chunks'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'smallvec'
-version = '1.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'socket2'
-version = '0.3.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'strip-ansi-escapes'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tar'
-version = '0.4.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'termcolor'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tinyvec'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default']
-
-[[target-package]]
-name = 'typenum'
-version = '1.12.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-normalization'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'unicode-width'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-xid'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'url'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'utf8parse'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vec_map'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vte'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['basetsd', 'consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'jobapi', 'jobapi2', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntstatus', 'processenv', 'processthreadsapi', 'psapi', 'schannel', 'securitybaseapi', 'shellapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'proptest-derive'
@@ -1070,9 +187,137 @@ status = 'direct'
 features = []
 
 [[host-package]]
+name = 'semver'
+version = '0.10.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.116'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.58'
+crates-io = true
+status = 'direct'
+features = ['default', 'raw_value', 'std']
+
+[[host-package]]
+name = 'structopt'
+version = '0.3.19'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'supercow'
+version = '0.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'toml'
+version = '0.5.7'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'aho-corasick'
+version = '0.7.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'autocfg'
 version = '1.0.1'
 crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bit-set'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'bitmaps'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bstr'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'bytesize'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cargo-platform'
+version = '0.1.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
 status = 'transitive'
 features = []
 
@@ -1085,15 +330,216 @@ features = ['jobserver', 'parallel']
 optional-deps = ['jobserver']
 
 [[host-package]]
-name = 'ctor'
-version = '0.1.16'
+name = 'cfg-if'
+version = '0.1.10'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'clap'
+version = '2.33.3'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
+
+[[host-package]]
+name = 'crates-io'
+version = '0.31.1'
+source = 'git+https://github.com/rust-lang/cargo.git?rev=0227f048fcb7c798026ede6cc20c92befc84c3a4#0227f048fcb7c798026ede6cc20c92befc84c3a4'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc32fast'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'crossbeam-utils'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crypto-hash'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'curl'
+version = '0.4.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'openssl-probe', 'openssl-sys', 'ssl']
+
+[[host-package]]
+name = 'curl-sys'
+version = '0.4.36+curl-7.71.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'http2', 'libnghttp2-sys', 'openssl-sys', 'ssl']
+optional-deps = ['libnghttp2-sys']
+
+[[host-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'env_logger'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
+optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
+
+[[host-package]]
+name = 'filetime'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'flate2'
+version = '1.0.18'
+crates-io = true
+status = 'transitive'
+features = ['any_zlib', 'libz-sys', 'zlib']
+optional-deps = ['libz-sys']
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'getrandom'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'git2'
+version = '0.13.11'
+crates-io = true
+status = 'transitive'
+features = ['default', 'https', 'openssl-probe', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+
+[[host-package]]
+name = 'git2-curl'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'glob'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'globset'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
 name = 'heck'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'home'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'humantime'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'humantime'
+version = '2.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ignore'
+version = '0.4.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'im-rc'
+version = '15.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itertools'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'itoa'
+version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1106,11 +552,118 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lazycell'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'libgit2-sys'
+version = '0.12.13+1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['https', 'libssh2-sys', 'openssl-sys', 'ssh', 'ssh_key_from_memory']
+optional-deps = ['libssh2-sys']
+
+[[host-package]]
+name = 'libnghttp2-sys'
+version = '0.1.4+1.41.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libssh2-sys'
+version = '0.2.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libz-sys'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = ['libc']
+optional-deps = ['libc']
+
+[[host-package]]
+name = 'log'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'num_cpus'
+version = '1.13.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'opener'
+version = '0.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'pkg-config'
 version = '0.3.18'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'ppv-lite86'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = ['simd']
 
 [[host-package]]
 name = 'proc-macro-error'
@@ -1142,6 +695,13 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -1156,11 +716,162 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package']
+
+[[host-package]]
+name = 'rand_chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[host-package]]
+name = 'rand_xorshift'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_xoshiro'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'regex'
+version = '1.3.9'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.6.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'remove_dir_all'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustc-workspace-hack'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rustfix'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'same-file'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'semver-parser'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'serde_derive'
 version = '1.0.116'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[host-package]]
+name = 'serde_ignored'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'shell-escape'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'sized-chunks'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'smallvec'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'socket2'
+version = '0.3.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strip-ansi-escapes'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'structopt-derive'
@@ -1186,11 +897,74 @@ features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', '
 optional-deps = ['quote']
 
 [[host-package]]
+name = 'tar'
+version = '0.4.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'thread_local'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tinyvec'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default']
+
+[[host-package]]
+name = 'typenum'
+version = '1.12.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'unicode-normalization'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'unicode-segmentation'
 version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -1207,8 +981,50 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'url'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vec_map'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.9.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vte'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'walkdir'
+version = '2.3.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
@@ -2,10 +2,10 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture hyper_util_7afb1ed
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
+# resolver = 'install'
 # unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '4'
+# dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['x86_64-apple-watchos-sim']
 # [[traversal-excludes.ids]]
@@ -14,65 +14,14 @@
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'regex'
-# version = '1.10.5'
+# name = 'tracing-core'
+# version = '0.1.32'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'smallvec'
-# version = '1.13.2'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'tokio-test'
-# version = '0.4.4'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'unicode-ident'
-# version = '1.0.12'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'winapi-util'
-# version = '0.1.8'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'winapi-x86_64-pc-windows-gnu'
-# version = '0.4.0'
-# crates-io = true
-# [[final-excludes.ids]]
-# name = 'adler'
-# version = '1.0.2'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'hyper'
-# version = '1.4.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'regex-syntax'
-# version = '0.8.4'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'termcolor'
-# version = '1.4.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'want'
-# version = '0.3.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'windows-targets'
-# version = '0.52.6'
-# crates-io = true
+# [final-excludes]
 
 [dependencies]
+async-stream = { version = "0.3", default-features = false }
 atomic-waker = { version = "1", default-features = false }
 bytes = { version = "1" }
 env_logger = { version = "0.10" }
@@ -85,34 +34,44 @@ futures-task = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false }
 h2 = { version = "0.4", default-features = false }
 hashbrown = { version = "0.14", default-features = false, features = ["raw"] }
-http = { version = "1" }
-http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
+http-body = { version = "1", default-features = false }
+http = { version = "1" }
 httparse = { version = "1" }
 httpdate = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
+hyper = { version = "1", features = ["full"] }
 indexmap = { version = "2" }
 is-terminal = { version = "0.4", default-features = false }
 itoa = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
+memchr = { version = "2", default-features = false, features = ["std"] }
 mio = { version = "1", default-features = false, features = ["net", "os-ext"] }
-once_cell = { version = "1" }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
 pretty_env_logger = { version = "0.5", default-features = false }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal"] }
+regex-syntax = { version = "0.8", default-features = false, features = ["std"] }
+regex = { version = "1", default-features = false, features = ["perf", "std"] }
 slab = { version = "0.4" }
-tokio = { version = "1", features = ["io-util", "macros", "net", "signal", "test-util"] }
+smallvec = { version = "1", default-features = false, features = ["const_new"] }
+termcolor = { version = "1", default-features = false }
+tokio-stream = { version = "0.1" }
+tokio-test = { version = "0.4", default-features = false }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "signal", "test-util"] }
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-tracing-core = { version = "0.1", default-features = false, features = ["std"] }
 try-lock = { version = "0.2", default-features = false }
+want = { version = "0.3", default-features = false }
 
 [build-dependencies]
+async-stream-impl = { version = "0.3", default-features = false }
 autocfg = { version = "1", default-features = false }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", features = ["full", "visit-mut"] }
 tokio-macros = { version = "2", default-features = false }
+unicode-ident = { version = "1", default-features = false }
 
 [target.x86_64-apple-watchos-sim.dependencies]
 libc = { version = "0.2" }

--- a/fixtures/large/hakari/hyper_util_7afb1ed-1.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-1.toml
@@ -2,58 +2,74 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture hyper_util_7afb1ed
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
+# resolver = '2'
 # unify-target-host = 'auto'
-# output-single-feature = false
-# dep-format-version = '2'
-# workspace-hack-line-style = 'workspace-dotted'
+# output-single-feature = true
+# dep-format-version = '3'
+# workspace-hack-line-style = 'full'
 # platforms = []
 # [[traversal-excludes.ids]]
-# name = 'regex-automata'
-# version = '0.4.7'
+# name = 'futures-util'
+# version = '0.3.30'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'serde'
-# version = '1.0.204'
+# name = 'hyper'
+# version = '1.4.1'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'slab'
-# version = '0.4.9'
+# name = 'pin-utils'
+# version = '0.1.0'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'tracing'
-# version = '0.1.40'
+# name = 'rustc-demangle'
+# version = '0.1.24'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'ipnetwork'
+# version = '0.20.0'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
+# [[final-excludes.ids]]
 # name = 'windows_aarch64_gnullvm'
 # version = '0.52.6'
 # crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'windows_aarch64_msvc'
-# version = '0.52.6'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'windows_i686_msvc'
-# version = '0.52.6'
-# crates-io = true
-#
-# [final-excludes]
 
 [dependencies]
-futures-core = { version = "0.3", features = ["alloc", "std"] }
-hyper = { version = "1", features = ["client", "full", "http1", "http2", "server"] }
-tokio = { version = "1", features = ["bytes", "io-util", "libc", "macros", "mio", "net", "rt", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros", "windows-sys"] }
+aho-corasick = { version = "1", default-features = false, features = ["perf-literal", "std"] }
+async-stream = { version = "0.3", default-features = false }
+bytes = { version = "1" }
+env_logger = { version = "0.10" }
+fnv = { version = "1" }
+futures-core = { version = "0.3" }
+http-body-util = { version = "0.1", default-features = false }
+http-body = { version = "1", default-features = false }
+http = { version = "1" }
+humantime = { version = "2", default-features = false }
+is-terminal = { version = "0.4", default-features = false }
+itoa = { version = "1", default-features = false }
+log = { version = "0.4", default-features = false, features = ["std"] }
+memchr = { version = "2", default-features = false, features = ["std"] }
+mio = { version = "1", default-features = false, features = ["net", "os-ext"] }
+pin-project-lite = { version = "0.2", default-features = false }
+pretty_env_logger = { version = "0.5", default-features = false }
+regex-automata = { version = "0.4", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal"] }
+regex-syntax = { version = "0.8", default-features = false, features = ["std"] }
+regex = { version = "1", default-features = false, features = ["perf", "std"] }
+termcolor = { version = "1", default-features = false }
+tokio-stream = { version = "0.1" }
+tokio-test = { version = "0.4", default-features = false }
+tokio = { version = "1", features = ["macros", "net", "signal", "test-util"] }
 
 [build-dependencies]
-proc-macro2 = { version = "1", features = ["proc-macro"] }
-quote = { version = "1", features = ["proc-macro"] }
-syn = { version = "2", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "visit-mut"] }
+async-stream-impl = { version = "0.3", default-features = false }
+proc-macro2 = { version = "1" }
+quote = { version = "1" }
+syn = { version = "2", features = ["full", "visit-mut"] }
+tokio-macros = { version = "2", default-features = false }
+unicode-ident = { version = "1", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
@@ -2,34 +2,44 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture hyper_util_7afb1ed
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
+# resolver = '3'
 # unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '4'
-# workspace-hack-line-style = 'version-only'
+# dep-format-version = '2'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['i686-unknown-netbsd', 'armv7-unknown-linux-uclibceabihf']
 # [[traversal-excludes.ids]]
-# name = 'async-stream-impl'
-# version = '0.3.5'
+# name = 'aho-corasick'
+# version = '1.1.3'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'cc'
-# version = '1.1.6'
+# name = 'futures-util'
+# version = '0.3.30'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'hyper'
-# version = '1.4.1'
+# name = 'slab'
+# version = '0.4.9'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'want'
-# version = '0.3.1'
+# name = 'tracing'
+# version = '0.1.40'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'windows_x86_64_gnullvm'
+# name = 'tracing-core'
+# version = '0.1.32'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'winapi-util'
+# version = '0.1.8'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'windows_aarch64_gnullvm'
 # version = '0.52.6'
 # crates-io = true
 # [[final-excludes.ids]]
@@ -38,32 +48,33 @@
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'regex-automata'
-# version = '0.4.7'
+# name = 'httparse'
+# version = '1.9.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'serde'
-# version = '1.0.204'
+# name = 'itoa'
+# version = '1.0.11'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'termcolor'
-# version = '1.4.1'
+# name = 'rustc-demangle'
+# version = '0.1.24'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'tracing'
-# version = '0.1.40'
+# name = 'windows_aarch64_msvc'
+# version = '0.52.6'
 # crates-io = true
 
 [dependencies]
-futures-core = { version = "0.3" }
-tokio = { version = "1", features = ["macros", "net", "signal", "test-util"] }
+hyper = { version = "1", features = ["client", "full", "http1", "http2", "server"] }
+tokio = { version = "1", features = ["bytes", "io-util", "libc", "macros", "mio", "net", "rt", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }
 
 [build-dependencies]
-futures-core = { version = "0.3" }
-tokio = { version = "1", features = ["macros", "net", "signal", "test-util"] }
+hyper = { version = "1", features = ["client", "full", "http1", "http2", "server"] }
+syn = { version = "2", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "visit-mut"] }
+tokio = { version = "1", features = ["bytes", "io-util", "libc", "macros", "mio", "net", "rt", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra-0.toml
+++ b/fixtures/large/hakari/metadata_libra-0.toml
@@ -2,55 +2,48 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '3'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
 # platforms = ['x86_64-unknown-fuchsia', 'arm64e-apple-darwin', 'armv7-unknown-linux-gnueabihf']
-# [[traversal-excludes.ids]]
-# name = 'netcore'
+#
+# [traversal-excludes]
+# [[final-excludes.ids]]
+# name = 'autocfg'
+# version = '0.1.6'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'client'
 # version = '0.1.0'
-# workspace-path = 'network/netcore'
+# workspace-path = 'client'
 #
-# [[traversal-excludes.ids]]
-# name = 'rental'
-# version = '0.5.4'
+# [[final-excludes.ids]]
+# name = 'lru-cache'
+# version = '0.1.2'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'vm-cache-map'
+# [[final-excludes.ids]]
+# name = 'memsocket'
 # version = '0.1.0'
-# workspace-path = 'language/vm/vm-runtime/vm-cache-map'
+# workspace-path = 'network/memsocket'
 #
-# [[traversal-excludes.ids]]
-# name = 'xml-rs'
-# version = '0.8.0'
-# crates-io = true
 # [[final-excludes.ids]]
-# name = 'chashmap'
-# version = '2.2.2'
+# name = 'parking_lot'
+# version = '0.6.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'filecheck'
-# version = '0.4.0'
+# name = 'slog'
+# version = '2.5.2'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'itoa'
-# version = '0.4.4'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'rand'
-# version = '0.3.23'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'tokio-codec'
-# version = '0.2.0-alpha.6'
-# crates-io = true
+# name = 'storage-service'
+# version = '0.1.0'
+# workspace-path = 'storage/storage-service'
 
 [dependencies]
 adler32 = { version = "1", default-features = false }
@@ -88,6 +81,7 @@ cached = { version = "0.9", default-features = false }
 cast = { version = "0.2", features = ["std"] }
 cfg-if = { version = "0.1", default-features = false }
 chacha20-poly1305-aead = { version = "0.1", default-features = false }
+chashmap = { version = "2", default-features = false }
 chrono = { version = "0.4", features = ["clock", "serde", "time"] }
 clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
@@ -130,6 +124,7 @@ errno = { version = "0.2", default-features = false }
 error-chain = { version = "0.12", features = ["backtrace", "example_generated"] }
 failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 fake-simd = { version = "0.1", default-features = false }
+filecheck = { version = "0.4", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
 flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
 fnv = { version = "1", default-features = false }
@@ -162,6 +157,7 @@ idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = 
 indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
 itertools = { version = "0.8", features = ["use_std"] }
+itoa = { version = "0.4", features = ["std"] }
 jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 keccak = { version = "0.1", default-features = false }
@@ -174,7 +170,6 @@ linked-hash-map = { version = "0.5", default-features = false }
 lock_api-c65f7effa3be6d31 = { package = "lock_api", version = "0.1", default-features = false, features = ["owning_ref"] }
 lock_api-468e82937335b1c9 = { package = "lock_api", version = "0.3", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-lru-cache = { version = "0.1", default-features = false }
 lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
 matches = { version = "0.1", default-features = false }
 md5 = { version = "0.6", default-features = false }
@@ -189,6 +184,7 @@ mirai-annotations = { version = "1", default-features = false }
 net2 = { version = "0.2", features = ["duration"] }
 nibble_vec = { version = "0.0.4", default-features = false }
 nodrop = { version = "0.1", default-features = false }
+nohash-hasher = { version = "0.1", default-features = false }
 num = { version = "0.2", features = ["num-bigint", "std"] }
 num-bigint = { version = "0.2", default-features = false, features = ["std"] }
 num-complex = { version = "0.2", default-features = false, features = ["std"] }
@@ -202,12 +198,16 @@ numtoa = { version = "0.1", default-features = false, features = ["std"] }
 once_cell = { version = "0.1", features = ["parking_lot"] }
 opaque-debug = { version = "0.2", default-features = false }
 ordermap = { version = "0.3", default-features = false }
-owning_ref = { version = "0.4", default-features = false }
+owning_ref-468e82937335b1c9 = { package = "owning_ref", version = "0.3", default-features = false }
+owning_ref-9fbad63c4bcf4a8f = { package = "owning_ref", version = "0.4", default-features = false }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.5", default-features = false }
 parity-multihash = { version = "0.1", default-features = false }
+parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4", features = ["owning_ref"] }
 parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7", features = ["owning_ref"] }
 parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
+parking_lot_core-468e82937335b1c9 = { package = "parking_lot_core", version = "0.3", default-features = false }
 parking_lot_core-9fbad63c4bcf4a8f = { package = "parking_lot_core", version = "0.4", default-features = false }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
@@ -221,15 +221,18 @@ proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", 
 prost = { version = "0.5", features = ["prost-derive"] }
 protobuf = { version = "2", default-features = false }
 publicsuffix = { version = "1", default-features = false }
-quick-error = { version = "1", default-features = false }
+quick-error-c65f7effa3be6d31 = { package = "quick-error", version = "0.1", default-features = false }
+quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
+rand-468e82937335b1c9 = { package = "rand", version = "0.3", default-features = false }
 rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
 rand04_compat = { version = "0.1", features = ["std"] }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
-rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_hc = { version = "0.1", default-features = false }
@@ -246,6 +249,7 @@ regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cac
 regex-automata = { version = "0.1", default-features = false }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
+rental = { version = "0.5", features = ["std"] }
 reqwest = { version = "0.9", default-features = false, features = ["hyper-rustls", "rustls", "rustls-tls", "tls", "tokio-rustls", "webpki-roots"] }
 retry = { version = "0.5", default-features = false }
 ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
@@ -283,7 +287,6 @@ signal-hook = { version = "0.1", default-features = false }
 signal-hook-registry = { version = "1", default-features = false }
 siphasher = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
-slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
 slog-async = { version = "2" }
 slog-envlogger = { version = "2", features = ["regex"] }
 slog-scope = { version = "4", default-features = false }
@@ -318,7 +321,8 @@ tinytemplate = { version = "1", default-features = false }
 tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
 tokio-1048d4db57848387 = { package = "tokio", version = "0.2.0-alpha.6", features = ["bytes", "codec", "fs", "io", "macros", "net", "num_cpus", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-executor", "tokio-fs", "tokio-io", "tokio-macros", "tokio-net", "tokio-sync", "tokio-timer", "tracing-core", "udp", "uds"] }
 tokio-buf = { version = "0.1", features = ["either", "util"] }
-tokio-codec = { version = "0.1", default-features = false }
+tokio-codec-c65f7effa3be6d31 = { package = "tokio-codec", version = "0.1", default-features = false }
+tokio-codec-1048d4db57848387 = { package = "tokio-codec", version = "0.2.0-alpha.6", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor-c65f7effa3be6d31 = { package = "tokio-executor", version = "0.1", default-features = false }
 tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "crossbeam-utils", "current-thread", "futures-core-preview", "lazy_static", "num_cpus", "slab", "threadpool", "tokio-sync"] }
@@ -343,6 +347,7 @@ tracing-core = { version = "0.1", features = ["std"] }
 try-lock = { version = "0.2", default-features = false }
 try_from = { version = "0.3", default-features = false }
 ttl_cache = { version = "0.4" }
+typed-arena = { version = "1", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
 unicode-bidi = { version = "0.3" }
@@ -362,373 +367,108 @@ webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
 webpki-roots = { version = "0.17", default-features = false }
 x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
+xml-rs = { version = "0.8", default-features = false }
+yamux = { version = "0.2", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [build-dependencies]
-adler32 = { version = "1", default-features = false }
 aho-corasick = { version = "0.7", features = ["std"] }
-anyhow = { version = "1", features = ["std"] }
-arc-swap = { version = "0.4", default-features = false }
-arrayref = { version = "0.3", default-features = false }
-arrayvec = { version = "0.4", default-features = false }
-assert_approx_eq = { version = "1", default-features = false }
-assert_matches = { version = "1", default-features = false }
-atty = { version = "0.2", default-features = false }
-autocfg = { version = "0.1", default-features = false }
-backoff = { version = "0.1", default-features = false }
 backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
 backtrace-sys = { version = "0.1", default-features = false }
-base64 = { version = "0.10", default-features = false }
-bech32 = { version = "0.6", default-features = false }
-bincode = { version = "1", default-features = false }
 bindgen = { version = "0.51", default-features = false }
-bit-set = { version = "0.5", features = ["std"] }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
-bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
 bitflags = { version = "1" }
-bitvec = { version = "0.10", features = ["alloc", "std"] }
-blake2 = { version = "0.8", default-features = false }
-blake2-rfc = { version = "0.2", features = ["std"] }
-block-buffer = { version = "0.7", default-features = false }
-block-padding = { version = "0.1", default-features = false }
-bs58 = { version = "0.2" }
-bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 build_const = { version = "0.2", features = ["std"] }
-byte-tools = { version = "0.3", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
 bytes = { version = "0.4", default-features = false, features = ["either"] }
-bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
-c_linked_list = { version = "1", default-features = false }
-cached = { version = "0.9", default-features = false }
-cast = { version = "0.2", features = ["std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "num_cpus", "parallel"] }
 cexpr = { version = "0.3", default-features = false }
 cfg-if = { version = "0.1", default-features = false }
-chacha20-poly1305-aead = { version = "0.1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "serde", "time"] }
 clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
 cmake = { version = "0.1", default-features = false }
-codespan = { version = "0.2", default-features = false, features = ["serde", "serde_derive", "serialization"] }
-codespan-reporting = { version = "0.2", default-features = false }
-constant_time_eq = { version = "0.1", default-features = false }
-cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
-cookie_store = { version = "0.7", default-features = false }
-crc = { version = "1", features = ["std"] }
-crc32fast = { version = "1", features = ["std"] }
-criterion = { version = "0.3" }
-criterion-plot = { version = "0.4", default-features = false }
-crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
-crossbeam-channel = { version = "0.3", default-features = false }
-crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.7", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.1", default-features = false }
-crossbeam-utils = { version = "0.6", features = ["lazy_static", "std"] }
-crunchy = { version = "0.2", features = ["limit_128"] }
-crypto-mac = { version = "0.7", default-features = false }
-csv = { version = "1", default-features = false }
-csv-core = { version = "0.1", features = ["libc"] }
-ct-logs = { version = "0.6", default-features = false }
-ctrlc = { version = "3", default-features = false }
-curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
-curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["alloc", "std", "u64_backend"] }
-data-encoding = { version = "2", default-features = false }
 derivative = { version = "1", default-features = false, features = ["use_core"] }
 derive-new = { version = "0.5", features = ["std"] }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
-dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
-dirs-sys = { version = "0.3", default-features = false }
-dtoa = { version = "0.4", default-features = false }
-ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1", features = ["std", "u64_backend"] }
 either = { version = "1", features = ["use_std"] }
-encoding_rs = { version = "0.8", default-features = false }
-endian-type = { version = "0.1", default-features = false }
-env_logger = { version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
-errno = { version = "0.2", default-features = false }
-error-chain = { version = "0.12", features = ["backtrace", "example_generated"] }
 failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 failure_derive = { version = "0.1", default-features = false }
-fake-simd = { version = "0.1", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
-fnv = { version = "1", default-features = false }
 fs_extra = { version = "1", default-features = false }
-futures = { version = "0.1", features = ["use_std", "with-deprecated"] }
-futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["alloc", "futures-sink-preview", "sink", "std"] }
-futures-core-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
-futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
-futures-executor-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["num_cpus", "std"] }
-futures-io-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["std"] }
 futures-join-macro-preview = { version = "0.3.0-alpha.19", default-features = false }
-futures-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "compat", "io-compat", "std"] }
 futures-select-macro-preview = { version = "0.3.0-alpha.19", default-features = false }
-futures-sink-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
-futures-util-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "channel", "compat", "futures-channel-preview", "futures-io-preview", "futures-join-macro-preview", "futures-select-macro-preview", "futures-sink-preview", "futures_01", "io", "io-compat", "join-macro", "memchr", "proc-macro-hack", "proc-macro-nested", "select-macro", "sink", "slab", "std", "tokio-io"] }
 gcc = { version = "0.3", default-features = false }
 generic-array = { version = "0.12", default-features = false }
-get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
-grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["bytes", "prost", "prost-codec", "protobuf", "protobuf-codec"] }
 grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost", "prost-build", "prost-codec", "prost-types"] }
-grpcio-sys = { version = "0.5.0-alpha.4" }
-h2 = { version = "0.1", default-features = false }
 heck = { version = "0.3", default-features = false }
-hex = { version = "0.3", default-features = false }
-hex_fmt = { version = "0.3", default-features = false }
-hmac = { version = "0.7", default-features = false }
-http = { version = "0.1", default-features = false }
-http-body = { version = "0.1", default-features = false }
-httparse = { version = "1", features = ["std"] }
-humantime = { version = "1", default-features = false }
-hyper = { version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
-hyper-rustls = { version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
-idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
 itertools = { version = "0.8", features = ["use_std"] }
-jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
-jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jobserver = { version = "0.1", default-features = false }
-keccak = { version = "0.1", default-features = false }
 lazy_static = { version = "1", default-features = false }
 libc = { version = "0.2", features = ["std"] }
 libloading = { version = "0.5", default-features = false }
-librocksdb_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
-libtitan_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
-libz-sys = { version = "1", default-features = false, features = ["static"] }
-linked-hash-map = { version = "0.5", default-features = false }
-lock_api-c65f7effa3be6d31 = { package = "lock_api", version = "0.1", default-features = false, features = ["owning_ref"] }
-lock_api-468e82937335b1c9 = { package = "lock_api", version = "0.3", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-lru-cache = { version = "0.1", default-features = false }
-lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
-matches = { version = "0.1", default-features = false }
-md5 = { version = "0.6", default-features = false }
 memchr = { version = "2", features = ["libc", "use_std"] }
-memoffset = { version = "0.5", default-features = false }
-memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
-mime = { version = "0.3", default-features = false }
-mime_guess = { version = "2", features = ["rev-mappings"] }
-miniz_oxide = { version = "0.3", default-features = false }
-mio = { version = "0.6", features = ["with-deprecated"] }
-mirai-annotations = { version = "1", default-features = false }
 multimap = { version = "0.4", default-features = false }
-net2 = { version = "0.2", features = ["duration"] }
-nibble_vec = { version = "0.0.4", default-features = false }
-nodrop = { version = "0.1", default-features = false }
 nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
-num = { version = "0.2", features = ["num-bigint", "std"] }
-num-bigint = { version = "0.2", default-features = false, features = ["std"] }
-num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-derive = { version = "0.2", default-features = false }
-num-integer = { version = "0.1", default-features = false, features = ["std"] }
-num-iter = { version = "0.1", default-features = false, features = ["std"] }
-num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
-num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
-num_enum = { version = "0.4", features = ["std"] }
 num_enum_derive = { version = "0.4", default-features = false, features = ["std"] }
-numtoa = { version = "0.1", default-features = false, features = ["std"] }
-once_cell = { version = "0.1", features = ["parking_lot"] }
-opaque-debug = { version = "0.2", default-features = false }
-ordermap = { version = "0.3", default-features = false }
-owning_ref = { version = "0.4", default-features = false }
-pairing = { version = "0.14", features = ["u128-support"] }
-parity-multiaddr = { version = "0.5", default-features = false }
-parity-multihash = { version = "0.1", default-features = false }
-parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7", features = ["owning_ref"] }
-parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
-parking_lot_core-9fbad63c4bcf4a8f = { package = "parking_lot_core", version = "0.4", default-features = false }
-parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
-percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
-percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
 petgraph = { version = "0.4", features = ["graphmap", "ordermap", "stable_graph"] }
-pin-project = { version = "0.4", default-features = false }
 pin-project-internal = { version = "0.4", default-features = false }
-pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
 proc-macro-crate = { version = "0.1", default-features = false }
 proc-macro-error = { version = "0.2", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro-nested = { version = "0.1", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
 proc-quote = { version = "0.2", default-features = false }
 proc-quote-impl = { version = "0.2", default-features = false }
-prometheus = { version = "0.7", default-features = false }
-proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 proptest-derive = { version = "0.1", default-features = false }
 prost = { version = "0.5", features = ["prost-derive"] }
 prost-build = { version = "0.5", default-features = false }
 prost-derive = { version = "0.5", default-features = false }
 prost-types = { version = "0.5", default-features = false }
 protobuf = { version = "2", default-features = false }
-publicsuffix = { version = "1", default-features = false }
-quick-error = { version = "1", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
-radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
-rand04 = { version = "0.1", default-features = false, features = ["std"] }
-rand04_compat = { version = "0.1", features = ["std"] }
-rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
-rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
-rand_hc = { version = "0.1", default-features = false }
-rand_isaac = { version = "0.1", default-features = false }
-rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
-rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
-rand_os-6f8ce4dd05d13bba = { package = "rand_os", version = "0.2", default-features = false }
-rand_pcg = { version = "0.1", default-features = false }
-rand_xorshift = { version = "0.1", default-features = false }
-rand_xoshiro = { version = "0.3", default-features = false }
-rayon = { version = "1", default-features = false }
-rayon-core = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-automata = { version = "0.1", default-features = false }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
-reqwest = { version = "0.9", default-features = false, features = ["hyper-rustls", "rustls", "rustls-tls", "tls", "tokio-rustls", "webpki-roots"] }
-retry = { version = "0.5", default-features = false }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
-ripemd160 = { version = "0.8", features = ["std"] }
-rmp = { version = "0.8", default-features = false }
-rmp-serde = { version = "0.13", default-features = false }
-rocksdb = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
-rusoto_core = { version = "0.41", default-features = false, features = ["hyper-rustls", "rustls"] }
-rusoto_credential = { version = "0.41", default-features = false }
-rusoto_ec2 = { version = "0.41", default-features = false, features = ["rustls"] }
-rusoto_ecr = { version = "0.41", default-features = false, features = ["rustls"] }
-rusoto_ecs = { version = "0.41", default-features = false, features = ["rustls"] }
-rusoto_kinesis = { version = "0.41", default-features = false, features = ["rustls"] }
-rusoto_logs = { version = "0.41", default-features = false, features = ["rustls"] }
-rust-crypto = { version = "0.2", default-features = false }
-rust_decimal = { version = "1", features = ["serde"] }
+rental-impl = { version = "0.5", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", default-features = false }
-rustc-serialize = { version = "0.3", default-features = false }
 rustc_version = { version = "0.2", default-features = false }
-rustls = { version = "0.16", features = ["dangerous_configuration", "log", "logging"] }
-rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
-rustyline = { version = "5", features = ["dirs", "with-dirs"] }
-ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
-scopeguard-468e82937335b1c9 = { package = "scopeguard", version = "0.3", default-features = false }
-scopeguard-dff4ba8e3ae991db = { package = "scopeguard", version = "1", default-features = false }
-sct = { version = "0.6", default-features = false }
 semver = { version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
 serde_derive = { version = "1" }
-serde_json = { version = "1" }
-serde_urlencoded = { version = "0.5", default-features = false }
-sha-1 = { version = "0.8", default-features = false }
-sha2 = { version = "0.8", features = ["std"] }
-sha3 = { version = "0.8", features = ["std"] }
 shlex = { version = "0.1", default-features = false }
-signal-hook = { version = "0.1", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
-siphasher = { version = "0.3", default-features = false }
-slab = { version = "0.4", default-features = false }
-slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
-slog-async = { version = "2" }
-slog-envlogger = { version = "2", features = ["regex"] }
-slog-scope = { version = "4", default-features = false }
-slog-stdlog = { version = "4", default-features = false }
-slog-term = { version = "2", default-features = false }
-smallvec = { version = "0.6", features = ["std"] }
-snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
-snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
-spin = { version = "0.5", default-features = false }
-stable_deref_trait = { version = "1", features = ["std"] }
-statistical = { version = "1", default-features = false }
-stats_alloc = { version = "0.1" }
-string = { version = "0.2", features = ["bytes"] }
-strsim = { version = "0.8", default-features = false }
-structopt = { version = "0.3" }
 structopt-derive = { version = "0.3", default-features = false }
-strum = { version = "0.15", default-features = false }
 strum_macros = { version = "0.15", default-features = false }
-subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
 subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 synstructure = { version = "0.10", default-features = false }
-take_mut = { version = "0.2", default-features = false }
 tempfile = { version = "3", default-features = false }
-term = { version = "0.5" }
-termcolor = { version = "1", default-features = false }
-termion = { version = "1", default-features = false }
-textwrap = { version = "0.11", default-features = false }
-thread-id = { version = "3", default-features = false }
 thread_local = { version = "0.3", default-features = false }
-threadpool = { version = "1", default-features = false }
-threshold_crypto = { version = "0.3", default-features = false }
-time = { version = "0.1", default-features = false }
-tiny-keccak = { version = "1", features = ["keccak"] }
-tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
-tokio-1048d4db57848387 = { package = "tokio", version = "0.2.0-alpha.6", features = ["bytes", "codec", "fs", "io", "macros", "net", "num_cpus", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-executor", "tokio-fs", "tokio-io", "tokio-macros", "tokio-net", "tokio-sync", "tokio-timer", "tracing-core", "udp", "uds"] }
-tokio-buf = { version = "0.1", features = ["either", "util"] }
-tokio-codec = { version = "0.1", default-features = false }
-tokio-current-thread = { version = "0.1", default-features = false }
-tokio-executor-c65f7effa3be6d31 = { package = "tokio-executor", version = "0.1", default-features = false }
-tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "crossbeam-utils", "current-thread", "futures-core-preview", "lazy_static", "num_cpus", "slab", "threadpool", "tokio-sync"] }
-tokio-fs-c65f7effa3be6d31 = { package = "tokio-fs", version = "0.1", default-features = false }
-tokio-fs-1048d4db57848387 = { package = "tokio-fs", version = "0.2.0-alpha.6", default-features = false }
-tokio-io-c65f7effa3be6d31 = { package = "tokio-io", version = "0.1", default-features = false }
-tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["memchr", "pin-project", "util"] }
 tokio-macros = { version = "0.2.0-alpha.6", default-features = false }
-tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "bytes", "futures-sink-preview", "iovec", "libc", "mio-uds", "tcp", "udp", "uds"] }
-tokio-process = { version = "0.2", default-features = false }
-tokio-reactor = { version = "0.1", default-features = false }
-tokio-retry = { version = "0.2", default-features = false }
-tokio-rustls = { version = "0.10", default-features = false }
-tokio-sync-c65f7effa3be6d31 = { package = "tokio-sync", version = "0.1", default-features = false }
-tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "futures-sink-preview"] }
-tokio-tcp = { version = "0.1", default-features = false }
-tokio-threadpool = { version = "0.1", default-features = false }
-tokio-timer-6f8ce4dd05d13bba = { package = "tokio-timer", version = "0.2", default-features = false }
-tokio-timer-411ef6e417c0d908 = { package = "tokio-timer", version = "0.3.0-alpha.6", default-features = false, features = ["async-traits"] }
-tokio-udp = { version = "0.1", default-features = false }
 toml = { version = "0.5" }
-tracing-core = { version = "0.1", features = ["std"] }
-try-lock = { version = "0.2", default-features = false }
-try_from = { version = "0.3", default-features = false }
-ttl_cache = { version = "0.4" }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
-unicode-width = { version = "0.1" }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
-unsigned-varint = { version = "0.2", default-features = false }
-untrusted = { version = "0.7", default-features = false }
-url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
-url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
-uuid = { version = "0.7", features = ["rand", "std", "v4"] }
-vec_map = { version = "0.8", default-features = false }
 version_check = { version = "0.1", default-features = false }
-wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
-want = { version = "0.2", default-features = false }
-webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
-webpki-roots = { version = "0.17", default-features = false }
 which = { version = "2", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
-x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
-zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [target.x86_64-unknown-fuchsia.dependencies]
 ansi_term = { version = "0.11", default-features = false }
@@ -747,20 +487,10 @@ utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
 [target.x86_64-unknown-fuchsia.build-dependencies]
-ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
-fuchsia-cprng = { version = "0.1", default-features = false }
-fuchsia-zircon = { version = "0.3", default-features = false }
-fuchsia-zircon-sys = { version = "0.3", default-features = false }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-mio-uds = { version = "0.6", default-features = false }
-nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
 [target.arm64e-apple-darwin.dependencies]
 ansi_term = { version = "0.11", default-features = false }
@@ -777,18 +507,10 @@ utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
 [target.arm64e-apple-darwin.build-dependencies]
-ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-mach_o_sys = { version = "0.1", default-features = false }
-mio-uds = { version = "0.6", default-features = false }
-nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
 [target.armv7-unknown-linux-gnueabihf.dependencies]
 ansi_term = { version = "0.11", default-features = false }
@@ -804,17 +526,10 @@ utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
 [target.armv7-unknown-linux-gnueabihf.build-dependencies]
-ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
-mio-uds = { version = "0.6", default-features = false }
-nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra-3.toml
+++ b/fixtures/large/hakari/metadata_libra-3.toml
@@ -2,118 +2,108 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'none'
+# resolver = '2'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '3'
-# workspace-hack-line-style = 'workspace-dotted'
+# dep-format-version = '1'
+# workspace-hack-line-style = 'full'
 # platforms = []
 # [[traversal-excludes.ids]]
-# name = 'atty'
-# version = '0.2.13'
+# name = 'byteorder'
+# version = '1.3.2'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'futures-executor-preview'
-# version = '0.3.0-alpha.19'
+# name = 'tempfile'
+# version = '3.1.0'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'filecheck'
+# version = '0.4.0'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'libradb'
+# [[final-excludes.ids]]
+# name = 'memsocket'
 # version = '0.1.0'
-# workspace-path = 'storage/libradb'
+# workspace-path = 'network/memsocket'
 #
-# [[traversal-excludes.ids]]
-# name = 'rustls'
-# version = '0.16.0'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'socket-bench-server'
-# version = '0.1.0'
-# workspace-path = 'network/socket-bench-server'
 # [[final-excludes.ids]]
-# name = 'autocfg'
-# version = '0.1.6'
+# name = 'num'
+# version = '0.2.0'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'rusty-fork'
-# version = '0.2.2'
+# name = 'percent-encoding'
+# version = '2.1.0'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'snow'
-# version = '0.6.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'unicode-width'
-# version = '0.1.6'
+# name = 'tokio'
+# version = '0.1.22'
 # crates-io = true
 
 [dependencies]
 adler32 = { version = "1", default-features = false }
-aho-corasick = { version = "0.7" }
-anyhow = { version = "1" }
+aho-corasick = { version = "0.7", features = ["std"] }
+anyhow = { version = "1", features = ["std"] }
 arc-swap = { version = "0.4", default-features = false }
 arrayref = { version = "0.3", default-features = false }
 arrayvec = { version = "0.4", default-features = false }
 assert_approx_eq = { version = "1", default-features = false }
 assert_matches = { version = "1", default-features = false }
+atty = { version = "0.2", default-features = false }
 backoff = { version = "0.1", default-features = false }
-backtrace = { version = "0.3", features = ["serialize-serde"] }
+backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
 backtrace-sys = { version = "0.1", default-features = false }
 base64 = { version = "0.10", default-features = false }
 bech32 = { version = "0.6", default-features = false }
 bincode = { version = "1", default-features = false }
-bit-set = { version = "0.5" }
+bit-set = { version = "0.5", features = ["std"] }
 bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
-bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6" }
+bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
 bitflags = { version = "1" }
-bitvec = { version = "0.10" }
+bitvec = { version = "0.10", features = ["alloc", "std"] }
 blake2 = { version = "0.8", default-features = false }
-blake2-rfc = { version = "0.2" }
+blake2-rfc = { version = "0.2", features = ["std"] }
 block-buffer = { version = "0.7", default-features = false }
 block-padding = { version = "0.1", default-features = false }
 bs58 = { version = "0.2" }
-bstr = { version = "0.2", features = ["serde1"] }
+bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
 byte-tools = { version = "0.3", default-features = false }
-byteorder = { version = "1", features = ["i128"] }
 bytes = { version = "0.4", default-features = false, features = ["either"] }
 bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
 c_linked_list = { version = "1", default-features = false }
 cached = { version = "0.9", default-features = false }
-cast = { version = "0.2" }
+cast = { version = "0.2", features = ["std"] }
 cfg-if = { version = "0.1", default-features = false }
 chacha20-poly1305-aead = { version = "0.1", default-features = false }
 chashmap = { version = "2", default-features = false }
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "2" }
+chrono = { version = "0.4", features = ["clock", "serde", "time"] }
+clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
-codespan = { version = "0.2", default-features = false, features = ["serialization"] }
+codespan = { version = "0.2", default-features = false, features = ["serde", "serde_derive", "serialization"] }
 codespan-reporting = { version = "0.2", default-features = false }
 constant_time_eq = { version = "0.1", default-features = false }
-cookie = { version = "0.12", default-features = false, features = ["percent-encode"] }
+cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
 cookie_store = { version = "0.7", default-features = false }
-crc = { version = "1" }
-crc32fast = { version = "1" }
+crc = { version = "1", features = ["std"] }
+crc32fast = { version = "1", features = ["std"] }
 criterion = { version = "0.3" }
 criterion-plot = { version = "0.4", default-features = false }
-crossbeam = { version = "0.7" }
+crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
 crossbeam-channel = { version = "0.3", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.7" }
+crossbeam-epoch = { version = "0.7", features = ["lazy_static", "std"] }
 crossbeam-queue = { version = "0.1", default-features = false }
-crossbeam-utils = { version = "0.6" }
-crunchy = { version = "0.2" }
+crossbeam-utils = { version = "0.6", features = ["lazy_static", "std"] }
+crunchy = { version = "0.2", features = ["limit_128"] }
 crypto-mac = { version = "0.7", default-features = false }
 csv = { version = "1", default-features = false }
-csv-core = { version = "0.1" }
+csv-core = { version = "0.1", features = ["libc"] }
 ct-logs = { version = "0.6", default-features = false }
 ctrlc = { version = "3", default-features = false }
-curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
-curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["std", "u64_backend"] }
+curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["alloc", "std", "u64_backend"] }
 data-encoding = { version = "2", default-features = false }
 digest = { version = "0.8", default-features = false, features = ["std"] }
 dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
@@ -121,31 +111,31 @@ dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = fa
 dirs-sys = { version = "0.3", default-features = false }
 dtoa = { version = "0.4", default-features = false }
 ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1" }
-either = { version = "1" }
+ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1", features = ["std", "u64_backend"] }
+either = { version = "1", features = ["use_std"] }
 encoding_rs = { version = "0.8", default-features = false }
 endian-type = { version = "0.1", default-features = false }
-env_logger = { version = "0.6" }
+env_logger = { version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
 errno = { version = "0.2", default-features = false }
-error-chain = { version = "0.12" }
-failure = { version = "0.1" }
+error-chain = { version = "0.12", features = ["backtrace", "example_generated"] }
+failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 fake-simd = { version = "0.1", default-features = false }
-filecheck = { version = "0.4", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
 fnv = { version = "1", default-features = false }
-futures = { version = "0.1" }
-futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["sink", "std"] }
-futures-core-preview = { version = "0.3.0-alpha.19" }
-futures-cpupool = { version = "0.1" }
+futures = { version = "0.1", features = ["use_std", "with-deprecated"] }
+futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["alloc", "futures-sink-preview", "sink", "std"] }
+futures-core-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
+futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
+futures-executor-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["num_cpus", "std"] }
 futures-io-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["std"] }
-futures-preview = { version = "0.3.0-alpha.19", features = ["async-await", "io-compat"] }
-futures-sink-preview = { version = "0.3.0-alpha.19" }
-futures-util-preview = { version = "0.3.0-alpha.19", features = ["channel", "io-compat", "join-macro", "select-macro", "sink"] }
+futures-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "compat", "io-compat", "std"] }
+futures-sink-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
+futures-util-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "channel", "compat", "futures-channel-preview", "futures-io-preview", "futures-join-macro-preview", "futures-select-macro-preview", "futures-sink-preview", "futures_01", "io", "io-compat", "join-macro", "memchr", "proc-macro-hack", "proc-macro-nested", "select-macro", "sink", "slab", "std", "tokio-io"] }
 generic-array = { version = "0.12", default-features = false }
 get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["prost-codec", "protobuf-codec"] }
+grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["bytes", "prost", "prost-codec", "protobuf", "protobuf-codec"] }
 grpcio-sys = { version = "0.5.0-alpha.4" }
 h2 = { version = "0.1", default-features = false }
 hex = { version = "0.3", default-features = false }
@@ -153,21 +143,21 @@ hex_fmt = { version = "0.3", default-features = false }
 hmac = { version = "0.7", default-features = false }
 http = { version = "0.1", default-features = false }
 http-body = { version = "0.1", default-features = false }
-httparse = { version = "1" }
+httparse = { version = "1", features = ["std"] }
 humantime = { version = "1", default-features = false }
-hyper = { version = "0.12" }
-hyper-rustls = { version = "0.17" }
+hyper = { version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
+hyper-rustls = { version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
 idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools = { version = "0.8" }
-itoa = { version = "0.4" }
+itertools = { version = "0.8", features = ["use_std"] }
+itoa = { version = "0.4", features = ["std"] }
 jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
-jemallocator = { version = "0.3", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 keccak = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
-libc = { version = "0.2" }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["std"] }
 librocksdb_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
 libtitan_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
 libz-sys = { version = "1", default-features = false, features = ["static"] }
@@ -179,29 +169,28 @@ lru-cache = { version = "0.1", default-features = false }
 lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
 matches = { version = "0.1", default-features = false }
 md5 = { version = "0.6", default-features = false }
-memchr = { version = "2", features = ["libc"] }
+memchr = { version = "2", features = ["libc", "use_std"] }
 memoffset = { version = "0.5", default-features = false }
-memsec = { version = "0.5" }
+memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
 mime = { version = "0.3", default-features = false }
-mime_guess = { version = "2" }
+mime_guess = { version = "2", features = ["rev-mappings"] }
 miniz_oxide = { version = "0.3", default-features = false }
-mio = { version = "0.6" }
+mio = { version = "0.6", features = ["with-deprecated"] }
 mirai-annotations = { version = "1", default-features = false }
-net2 = { version = "0.2" }
+net2 = { version = "0.2", features = ["duration"] }
 nibble_vec = { version = "0.0.4", default-features = false }
 nodrop = { version = "0.1", default-features = false }
 nohash-hasher = { version = "0.1", default-features = false }
-num = { version = "0.2" }
 num-bigint = { version = "0.2", default-features = false, features = ["std"] }
 num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-integer = { version = "0.1", default-features = false, features = ["std"] }
 num-iter = { version = "0.1", default-features = false, features = ["std"] }
-num-rational = { version = "0.2", default-features = false, features = ["bigint", "std"] }
-num-traits = { version = "0.2" }
+num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
+num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
-num_enum = { version = "0.4" }
+num_enum = { version = "0.4", features = ["std"] }
 numtoa = { version = "0.1", default-features = false, features = ["std"] }
-once_cell = { version = "0.1" }
+once_cell = { version = "0.1", features = ["parking_lot"] }
 opaque-debug = { version = "0.2", default-features = false }
 ordermap = { version = "0.3", default-features = false }
 owning_ref-468e82937335b1c9 = { package = "owning_ref", version = "0.3", default-features = false }
@@ -209,39 +198,38 @@ owning_ref-9fbad63c4bcf4a8f = { package = "owning_ref", version = "0.4", default
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.5", default-features = false }
 parity-multihash = { version = "0.1", default-features = false }
-parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4" }
-parking_lot-3b31131e45eafb45 = { package = "parking_lot", version = "0.6" }
-parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7" }
+parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4", features = ["owning_ref"] }
+parking_lot-3b31131e45eafb45 = { package = "parking_lot", version = "0.6", features = ["owning_ref"] }
+parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7", features = ["owning_ref"] }
 parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
 parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
 parking_lot_core-468e82937335b1c9 = { package = "parking_lot_core", version = "0.3", default-features = false }
 parking_lot_core-9fbad63c4bcf4a8f = { package = "parking_lot_core", version = "0.4", default-features = false }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
-percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
-percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
-petgraph = { version = "0.4" }
+percent-encoding = { version = "1", default-features = false }
+petgraph = { version = "0.4", features = ["graphmap", "ordermap", "stable_graph"] }
 pin-project = { version = "0.4", default-features = false }
 pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 proc-macro-nested = { version = "0.1", default-features = false }
 prometheus = { version = "0.7", default-features = false }
-proptest = { version = "0.9" }
-prost = { version = "0.5" }
+proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+prost = { version = "0.5", features = ["prost-derive"] }
 protobuf = { version = "2", default-features = false }
 publicsuffix = { version = "1", default-features = false }
 quick-error-c65f7effa3be6d31 = { package = "quick-error", version = "0.1", default-features = false }
 quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
 rand-468e82937335b1c9 = { package = "rand", version = "0.3", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4" }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5" }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
-rand04_compat = { version = "0.1" }
+rand04_compat = { version = "0.1", features = ["std"] }
 rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
@@ -252,19 +240,18 @@ rand_xorshift = { version = "0.1", default-features = false }
 rand_xoshiro = { version = "0.3", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1" }
+regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", default-features = false }
-regex-syntax = { version = "0.6" }
-remove_dir_all = { version = "0.5", default-features = false }
-rental = { version = "0.5" }
-reqwest = { version = "0.9", default-features = false, features = ["rustls-tls"] }
+regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+rental = { version = "0.5", features = ["std"] }
+reqwest = { version = "0.9", default-features = false, features = ["hyper-rustls", "rustls", "rustls-tls", "tls", "tokio-rustls", "webpki-roots"] }
 retry = { version = "0.5", default-features = false }
-ring = { version = "0.16", features = ["std"] }
-ripemd160 = { version = "0.8" }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
+ripemd160 = { version = "0.8", features = ["std"] }
 rmp = { version = "0.8", default-features = false }
 rmp-serde = { version = "0.13", default-features = false }
 rocksdb = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
-rusoto_core = { version = "0.41", default-features = false, features = ["rustls"] }
+rusoto_core = { version = "0.41", default-features = false, features = ["hyper-rustls", "rustls"] }
 rusoto_credential = { version = "0.41", default-features = false }
 rusoto_ec2 = { version = "0.41", default-features = false, features = ["rustls"] }
 rusoto_ecr = { version = "0.41", default-features = false, features = ["rustls"] }
@@ -272,45 +259,48 @@ rusoto_ecs = { version = "0.41", default-features = false, features = ["rustls"]
 rusoto_kinesis = { version = "0.41", default-features = false, features = ["rustls"] }
 rusoto_logs = { version = "0.41", default-features = false, features = ["rustls"] }
 rust-crypto = { version = "0.2", default-features = false }
-rust_decimal = { version = "1" }
+rust_decimal = { version = "1", features = ["serde"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", default-features = false }
-rustyline = { version = "5" }
+rustls = { version = "0.16", features = ["dangerous_configuration", "log", "logging"] }
+rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
+rustyline = { version = "5", features = ["dirs", "with-dirs"] }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scopeguard-468e82937335b1c9 = { package = "scopeguard", version = "0.3", default-features = false }
 scopeguard-dff4ba8e3ae991db = { package = "scopeguard", version = "1", default-features = false }
 sct = { version = "0.6", default-features = false }
-serde = { version = "1", features = ["derive", "rc"] }
+serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1" }
 serde_urlencoded = { version = "0.5", default-features = false }
 sha-1 = { version = "0.8", default-features = false }
-sha2 = { version = "0.8" }
-sha3 = { version = "0.8" }
+sha2 = { version = "0.8", features = ["std"] }
+sha3 = { version = "0.8", features = ["std"] }
 shlex = { version = "0.1", default-features = false }
 signal-hook = { version = "0.1", default-features = false }
 signal-hook-registry = { version = "1", default-features = false }
 siphasher = { version = "0.3", default-features = false }
 slab = { version = "0.4", default-features = false }
-slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug"] }
+slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
 slog-async = { version = "2" }
-slog-envlogger = { version = "2" }
+slog-envlogger = { version = "2", features = ["regex"] }
 slog-scope = { version = "4", default-features = false }
 slog-stdlog = { version = "4", default-features = false }
 slog-term = { version = "2", default-features = false }
-smallvec = { version = "0.6" }
+smallvec = { version = "0.6", features = ["std"] }
 snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
+snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
 spin = { version = "0.5", default-features = false }
-stable_deref_trait = { version = "1" }
+stable_deref_trait = { version = "1", features = ["std"] }
 statistical = { version = "1", default-features = false }
 stats_alloc = { version = "0.1" }
-string = { version = "0.2" }
+string = { version = "0.2", features = ["bytes"] }
 strsim = { version = "0.8", default-features = false }
 structopt = { version = "0.3" }
+strum = { version = "0.15", default-features = false }
 subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
-subtle-f595c2ba2a3f28df = { package = "subtle", version = "2" }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
 take_mut = { version = "0.2", default-features = false }
-tempfile = { version = "3", default-features = false }
 term = { version = "0.5" }
 termcolor = { version = "1", default-features = false }
 termion = { version = "1", default-features = false }
@@ -320,161 +310,436 @@ thread_local = { version = "0.3", default-features = false }
 threadpool = { version = "1", default-features = false }
 threshold_crypto = { version = "0.3", default-features = false }
 time = { version = "0.1", default-features = false }
-tiny-keccak = { version = "1" }
+tiny-keccak = { version = "1", features = ["keccak"] }
 tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1" }
-tokio-1048d4db57848387 = { package = "tokio", version = "0.2.0-alpha.6" }
-tokio-buf = { version = "0.1" }
+tokio = { version = "0.2.0-alpha.6", features = ["bytes", "codec", "fs", "io", "macros", "net", "num_cpus", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-executor", "tokio-fs", "tokio-io", "tokio-macros", "tokio-net", "tokio-sync", "tokio-timer", "tracing-core", "udp", "uds"] }
+tokio-buf = { version = "0.1", features = ["either", "util"] }
 tokio-codec-c65f7effa3be6d31 = { package = "tokio-codec", version = "0.1", default-features = false }
 tokio-codec-1048d4db57848387 = { package = "tokio-codec", version = "0.2.0-alpha.6", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
 tokio-executor-c65f7effa3be6d31 = { package = "tokio-executor", version = "0.1", default-features = false }
-tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "current-thread", "threadpool", "tracing"] }
+tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "crossbeam-utils", "current-thread", "futures-core-preview", "lazy_static", "num_cpus", "slab", "threadpool", "tokio-sync"] }
 tokio-fs-c65f7effa3be6d31 = { package = "tokio-fs", version = "0.1", default-features = false }
 tokio-fs-1048d4db57848387 = { package = "tokio-fs", version = "0.2.0-alpha.6", default-features = false }
 tokio-io-c65f7effa3be6d31 = { package = "tokio-io", version = "0.1", default-features = false }
-tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["util"] }
-tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "tcp", "tracing", "udp", "uds"] }
+tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["memchr", "pin-project", "util"] }
+tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "bytes", "futures-sink-preview", "iovec", "libc", "mio-uds", "tcp", "udp", "uds"] }
 tokio-process = { version = "0.2", default-features = false }
 tokio-reactor = { version = "0.1", default-features = false }
 tokio-retry = { version = "0.2", default-features = false }
 tokio-rustls = { version = "0.10", default-features = false }
 tokio-sync-c65f7effa3be6d31 = { package = "tokio-sync", version = "0.1", default-features = false }
-tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits"] }
+tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "futures-sink-preview"] }
 tokio-tcp = { version = "0.1", default-features = false }
 tokio-threadpool = { version = "0.1", default-features = false }
 tokio-timer-6f8ce4dd05d13bba = { package = "tokio-timer", version = "0.2", default-features = false }
 tokio-timer-411ef6e417c0d908 = { package = "tokio-timer", version = "0.3.0-alpha.6", default-features = false, features = ["async-traits"] }
 tokio-udp = { version = "0.1", default-features = false }
 toml = { version = "0.5" }
-tracing = { version = "0.1", features = ["log"] }
-tracing-core = { version = "0.1" }
+tracing-core = { version = "0.1", features = ["std"] }
 try-lock = { version = "0.2", default-features = false }
 try_from = { version = "0.3", default-features = false }
 ttl_cache = { version = "0.4" }
-typed-arena = { version = "1" }
+typed-arena = { version = "1", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
 unicode-bidi = { version = "0.3" }
 unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
 unsigned-varint = { version = "0.2", default-features = false }
 untrusted = { version = "0.7", default-features = false }
 url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
 url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
-uuid = { version = "0.7", features = ["v4"] }
+uuid = { version = "0.7", features = ["rand", "std", "v4"] }
 vec_map = { version = "0.8", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.2", default-features = false }
-webpki = { version = "0.21" }
+webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
 webpki-roots = { version = "0.17", default-features = false }
 x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
-x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5" }
+x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yamux = { version = "0.2", default-features = false }
-zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git" }
+zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [build-dependencies]
-aho-corasick = { version = "0.7" }
-backtrace = { version = "0.3", features = ["serialize-serde"] }
+adler32 = { version = "1", default-features = false }
+aho-corasick = { version = "0.7", features = ["std"] }
+anyhow = { version = "1", features = ["std"] }
+arc-swap = { version = "0.4", default-features = false }
+arrayref = { version = "0.3", default-features = false }
+arrayvec = { version = "0.4", default-features = false }
+assert_approx_eq = { version = "1", default-features = false }
+assert_matches = { version = "1", default-features = false }
+atty = { version = "0.2", default-features = false }
+autocfg = { version = "0.1", default-features = false }
+backoff = { version = "0.1", default-features = false }
+backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
 backtrace-sys = { version = "0.1", default-features = false }
+base64 = { version = "0.10", default-features = false }
+bech32 = { version = "0.6", default-features = false }
+bincode = { version = "1", default-features = false }
 bindgen = { version = "0.51", default-features = false }
+bit-set = { version = "0.5", features = ["std"] }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
+bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
 bitflags = { version = "1" }
-build_const = { version = "0.2" }
-byteorder = { version = "1", features = ["i128"] }
+bitvec = { version = "0.10", features = ["alloc", "std"] }
+blake2 = { version = "0.8", default-features = false }
+blake2-rfc = { version = "0.2", features = ["std"] }
+block-buffer = { version = "0.7", default-features = false }
+block-padding = { version = "0.1", default-features = false }
+bs58 = { version = "0.2" }
+bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+build_const = { version = "0.2", features = ["std"] }
+byte-tools = { version = "0.3", default-features = false }
 bytes = { version = "0.4", default-features = false, features = ["either"] }
-cc = { version = "1", default-features = false, features = ["parallel"] }
+bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
+c_linked_list = { version = "1", default-features = false }
+cached = { version = "0.9", default-features = false }
+cast = { version = "0.2", features = ["std"] }
+cc = { version = "1", default-features = false, features = ["jobserver", "num_cpus", "parallel"] }
 cexpr = { version = "0.3", default-features = false }
 cfg-if = { version = "0.1", default-features = false }
-clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "runtime"] }
+chacha20-poly1305-aead = { version = "0.1", default-features = false }
+chashmap = { version = "2", default-features = false }
+chrono = { version = "0.4", features = ["clock", "serde", "time"] }
+clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
+clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
 cmake = { version = "0.1", default-features = false }
+codespan = { version = "0.2", default-features = false, features = ["serde", "serde_derive", "serialization"] }
+codespan-reporting = { version = "0.2", default-features = false }
+constant_time_eq = { version = "0.1", default-features = false }
+cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
+cookie_store = { version = "0.7", default-features = false }
+crc = { version = "1", features = ["std"] }
+crc32fast = { version = "1", features = ["std"] }
+criterion = { version = "0.3" }
+criterion-plot = { version = "0.4", default-features = false }
+crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
+crossbeam-channel = { version = "0.3", default-features = false }
+crossbeam-deque = { version = "0.7", default-features = false }
+crossbeam-epoch = { version = "0.7", features = ["lazy_static", "std"] }
+crossbeam-queue = { version = "0.1", default-features = false }
+crossbeam-utils = { version = "0.6", features = ["lazy_static", "std"] }
+crunchy = { version = "0.2", features = ["limit_128"] }
+crypto-mac = { version = "0.7", default-features = false }
+csv = { version = "1", default-features = false }
+csv-core = { version = "0.1", features = ["libc"] }
+ct-logs = { version = "0.6", default-features = false }
+ctrlc = { version = "3", default-features = false }
+curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+curve25519-dalek-dff4ba8e3ae991db = { package = "curve25519-dalek", version = "1", default-features = false, features = ["alloc", "std", "u64_backend"] }
+data-encoding = { version = "2", default-features = false }
 derivative = { version = "1", default-features = false, features = ["use_core"] }
-derive-new = { version = "0.5" }
+derive-new = { version = "0.5", features = ["std"] }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-either = { version = "1" }
-failure = { version = "0.1" }
+dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
+dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
+dirs-sys = { version = "0.3", default-features = false }
+dtoa = { version = "0.4", default-features = false }
+ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
+ed25519-dalek-21bb1c62648f302a = { package = "ed25519-dalek", version = "1.0.0-pre.1", features = ["std", "u64_backend"] }
+either = { version = "1", features = ["use_std"] }
+encoding_rs = { version = "0.8", default-features = false }
+endian-type = { version = "0.1", default-features = false }
+env_logger = { version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
+errno = { version = "0.2", default-features = false }
+error-chain = { version = "0.12", features = ["backtrace", "example_generated"] }
+failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 failure_derive = { version = "0.1", default-features = false }
+fake-simd = { version = "0.1", default-features = false }
 fixedbitset = { version = "0.1", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
+fnv = { version = "1", default-features = false }
 fs_extra = { version = "1", default-features = false }
+futures = { version = "0.1", features = ["use_std", "with-deprecated"] }
+futures-channel-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["alloc", "futures-sink-preview", "sink", "std"] }
+futures-core-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
+futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
+futures-executor-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["num_cpus", "std"] }
+futures-io-preview = { version = "0.3.0-alpha.19", default-features = false, features = ["std"] }
 futures-join-macro-preview = { version = "0.3.0-alpha.19", default-features = false }
+futures-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "compat", "io-compat", "std"] }
 futures-select-macro-preview = { version = "0.3.0-alpha.19", default-features = false }
+futures-sink-preview = { version = "0.3.0-alpha.19", features = ["alloc", "std"] }
+futures-util-preview = { version = "0.3.0-alpha.19", features = ["alloc", "async-await", "channel", "compat", "futures-channel-preview", "futures-io-preview", "futures-join-macro-preview", "futures-select-macro-preview", "futures-sink-preview", "futures_01", "io", "io-compat", "join-macro", "memchr", "proc-macro-hack", "proc-macro-nested", "select-macro", "sink", "slab", "std", "tokio-io"] }
 gcc = { version = "0.3", default-features = false }
 generic-array = { version = "0.12", default-features = false }
+get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
-grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost-codec"] }
+grpcio = { version = "0.5.0-alpha.4", default-features = false, features = ["bytes", "prost", "prost-codec", "protobuf", "protobuf-codec"] }
+grpcio-compiler = { version = "0.5.0-alpha.2", default-features = false, features = ["prost", "prost-build", "prost-codec", "prost-types"] }
+grpcio-sys = { version = "0.5.0-alpha.4" }
+h2 = { version = "0.1", default-features = false }
 heck = { version = "0.3", default-features = false }
+hex = { version = "0.3", default-features = false }
+hex_fmt = { version = "0.3", default-features = false }
+hmac = { version = "0.7", default-features = false }
+http = { version = "0.1", default-features = false }
+http-body = { version = "0.1", default-features = false }
+httparse = { version = "1", features = ["std"] }
+humantime = { version = "1", default-features = false }
+hyper = { version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
+hyper-rustls = { version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+indexmap = { version = "1", default-features = false }
 iovec = { version = "0.1", default-features = false }
-itertools = { version = "0.8" }
+itertools = { version = "0.8", features = ["use_std"] }
+itoa = { version = "0.4", features = ["std"] }
+jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jobserver = { version = "0.1", default-features = false }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
-libc = { version = "0.2" }
+keccak = { version = "0.1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["std"] }
 libloading = { version = "0.5", default-features = false }
+librocksdb_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+libtitan_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+libz-sys = { version = "1", default-features = false, features = ["static"] }
+linked-hash-map = { version = "0.5", default-features = false }
+lock_api-c65f7effa3be6d31 = { package = "lock_api", version = "0.1", default-features = false, features = ["owning_ref"] }
+lock_api-468e82937335b1c9 = { package = "lock_api", version = "0.3", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["libc"] }
+lru-cache = { version = "0.1", default-features = false }
+lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
+matches = { version = "0.1", default-features = false }
+md5 = { version = "0.6", default-features = false }
+memchr = { version = "2", features = ["libc", "use_std"] }
+memoffset = { version = "0.5", default-features = false }
+memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", features = ["rev-mappings"] }
+miniz_oxide = { version = "0.3", default-features = false }
+mio = { version = "0.6", features = ["with-deprecated"] }
+mirai-annotations = { version = "1", default-features = false }
 multimap = { version = "0.4", default-features = false }
-nom = { version = "4", features = ["verbose-errors"] }
+net2 = { version = "0.2", features = ["duration"] }
+nibble_vec = { version = "0.0.4", default-features = false }
+nodrop = { version = "0.1", default-features = false }
+nohash-hasher = { version = "0.1", default-features = false }
+nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
+num-bigint = { version = "0.2", default-features = false, features = ["std"] }
+num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-derive = { version = "0.2", default-features = false }
+num-integer = { version = "0.1", default-features = false, features = ["std"] }
+num-iter = { version = "0.1", default-features = false, features = ["std"] }
+num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
+num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
+num_enum = { version = "0.4", features = ["std"] }
 num_enum_derive = { version = "0.4", default-features = false, features = ["std"] }
+numtoa = { version = "0.1", default-features = false, features = ["std"] }
+once_cell = { version = "0.1", features = ["parking_lot"] }
+opaque-debug = { version = "0.2", default-features = false }
 ordermap = { version = "0.3", default-features = false }
+owning_ref-468e82937335b1c9 = { package = "owning_ref", version = "0.3", default-features = false }
+owning_ref-9fbad63c4bcf4a8f = { package = "owning_ref", version = "0.4", default-features = false }
+pairing = { version = "0.14", features = ["u128-support"] }
+parity-multiaddr = { version = "0.5", default-features = false }
+parity-multihash = { version = "0.1", default-features = false }
+parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4", features = ["owning_ref"] }
+parking_lot-3b31131e45eafb45 = { package = "parking_lot", version = "0.6", features = ["owning_ref"] }
+parking_lot-ca01ad9e24f5d932 = { package = "parking_lot", version = "0.7", features = ["owning_ref"] }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
+parking_lot_core-468e82937335b1c9 = { package = "parking_lot_core", version = "0.3", default-features = false }
+parking_lot_core-9fbad63c4bcf4a8f = { package = "parking_lot_core", version = "0.4", default-features = false }
+parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 peeking_take_while = { version = "0.1", default-features = false }
-petgraph = { version = "0.4" }
+percent-encoding = { version = "1", default-features = false }
+petgraph = { version = "0.4", features = ["graphmap", "ordermap", "stable_graph"] }
+pin-project = { version = "0.4", default-features = false }
 pin-project-internal = { version = "0.4", default-features = false }
+pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
 proc-macro-crate = { version = "0.1", default-features = false }
 proc-macro-error = { version = "0.2", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4" }
-proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1" }
+proc-macro-nested = { version = "0.1", default-features = false }
+proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
+proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
 proc-quote = { version = "0.2", default-features = false }
 proc-quote-impl = { version = "0.2", default-features = false }
+prometheus = { version = "0.7", default-features = false }
+proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 proptest-derive = { version = "0.1", default-features = false }
-prost = { version = "0.5" }
+prost = { version = "0.5", features = ["prost-derive"] }
 prost-build = { version = "0.5", default-features = false }
 prost-derive = { version = "0.5", default-features = false }
 prost-types = { version = "0.5", default-features = false }
 protobuf = { version = "2", default-features = false }
-quote-3b31131e45eafb45 = { package = "quote", version = "0.6" }
-quote-dff4ba8e3ae991db = { package = "quote", version = "1" }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7" }
+publicsuffix = { version = "1", default-features = false }
+quick-error-c65f7effa3be6d31 = { package = "quick-error", version = "0.1", default-features = false }
+quick-error-dff4ba8e3ae991db = { package = "quick-error", version = "1", default-features = false }
+quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
+quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+radix_trie = { version = "0.1", default-features = false }
+rand-468e82937335b1c9 = { package = "rand", version = "0.3", default-features = false }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "std"] }
+rand04 = { version = "0.1", default-features = false, features = ["std"] }
+rand04_compat = { version = "0.1", features = ["std"] }
+rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
-regex = { version = "1" }
-regex-syntax = { version = "0.6" }
-remove_dir_all = { version = "0.5", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
+rand_os-6f8ce4dd05d13bba = { package = "rand_os", version = "0.2", default-features = false }
+rand_pcg = { version = "0.1", default-features = false }
+rand_xorshift = { version = "0.1", default-features = false }
+rand_xoshiro = { version = "0.3", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1", default-features = false }
+regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+rental = { version = "0.5", features = ["std"] }
 rental-impl = { version = "0.5", default-features = false }
+reqwest = { version = "0.9", default-features = false, features = ["hyper-rustls", "rustls", "rustls-tls", "tls", "tokio-rustls", "webpki-roots"] }
+retry = { version = "0.5", default-features = false }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
+ripemd160 = { version = "0.8", features = ["std"] }
+rmp = { version = "0.8", default-features = false }
+rmp-serde = { version = "0.13", default-features = false }
+rocksdb = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+rusoto_core = { version = "0.41", default-features = false, features = ["hyper-rustls", "rustls"] }
+rusoto_credential = { version = "0.41", default-features = false }
+rusoto_ec2 = { version = "0.41", default-features = false, features = ["rustls"] }
+rusoto_ecr = { version = "0.41", default-features = false, features = ["rustls"] }
+rusoto_ecs = { version = "0.41", default-features = false, features = ["rustls"] }
+rusoto_kinesis = { version = "0.41", default-features = false, features = ["rustls"] }
+rusoto_logs = { version = "0.41", default-features = false, features = ["rustls"] }
+rust-crypto = { version = "0.2", default-features = false }
+rust_decimal = { version = "1", features = ["serde"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", default-features = false }
+rustc-serialize = { version = "0.3", default-features = false }
 rustc_version = { version = "0.2", default-features = false }
+rustls = { version = "0.16", features = ["dangerous_configuration", "log", "logging"] }
+rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
+rustyline = { version = "5", features = ["dirs", "with-dirs"] }
+ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
+scopeguard-468e82937335b1c9 = { package = "scopeguard", version = "0.3", default-features = false }
+scopeguard-dff4ba8e3ae991db = { package = "scopeguard", version = "1", default-features = false }
+sct = { version = "0.6", default-features = false }
 semver = { version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
-serde = { version = "1", features = ["derive", "rc"] }
+serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
 serde_derive = { version = "1" }
+serde_json = { version = "1" }
+serde_urlencoded = { version = "0.5", default-features = false }
+sha-1 = { version = "0.8", default-features = false }
+sha2 = { version = "0.8", features = ["std"] }
+sha3 = { version = "0.8", features = ["std"] }
 shlex = { version = "0.1", default-features = false }
+signal-hook = { version = "0.1", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
+siphasher = { version = "0.3", default-features = false }
+slab = { version = "0.4", default-features = false }
+slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
+slog-async = { version = "2" }
+slog-envlogger = { version = "2", features = ["regex"] }
+slog-scope = { version = "4", default-features = false }
+slog-stdlog = { version = "4", default-features = false }
+slog-term = { version = "2", default-features = false }
+smallvec = { version = "0.6", features = ["std"] }
+snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
+snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
 spin = { version = "0.5", default-features = false }
+stable_deref_trait = { version = "1", features = ["std"] }
+statistical = { version = "1", default-features = false }
+stats_alloc = { version = "0.1" }
+string = { version = "0.2", features = ["bytes"] }
+strsim = { version = "0.8", default-features = false }
+structopt = { version = "0.3" }
 structopt-derive = { version = "0.3", default-features = false }
-subtle-f595c2ba2a3f28df = { package = "subtle", version = "2" }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "fold", "full", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full", "visit", "visit-mut"] }
+strum = { version = "0.15", default-features = false }
+strum_macros = { version = "0.15", default-features = false }
+subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 synstructure = { version = "0.10", default-features = false }
-tempfile = { version = "3", default-features = false }
+take_mut = { version = "0.2", default-features = false }
+term = { version = "0.5" }
+termcolor = { version = "1", default-features = false }
+termion = { version = "1", default-features = false }
+textwrap = { version = "0.11", default-features = false }
+thread-id = { version = "3", default-features = false }
 thread_local = { version = "0.3", default-features = false }
+threadpool = { version = "1", default-features = false }
+threshold_crypto = { version = "0.3", default-features = false }
+time = { version = "0.1", default-features = false }
+tiny-keccak = { version = "1", features = ["keccak"] }
+tinytemplate = { version = "1", default-features = false }
+tokio = { version = "0.2.0-alpha.6", features = ["bytes", "codec", "fs", "io", "macros", "net", "num_cpus", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-executor", "tokio-fs", "tokio-io", "tokio-macros", "tokio-net", "tokio-sync", "tokio-timer", "tracing-core", "udp", "uds"] }
+tokio-buf = { version = "0.1", features = ["either", "util"] }
+tokio-codec-c65f7effa3be6d31 = { package = "tokio-codec", version = "0.1", default-features = false }
+tokio-codec-1048d4db57848387 = { package = "tokio-codec", version = "0.2.0-alpha.6", default-features = false }
+tokio-current-thread = { version = "0.1", default-features = false }
+tokio-executor-c65f7effa3be6d31 = { package = "tokio-executor", version = "0.1", default-features = false }
+tokio-executor-1048d4db57848387 = { package = "tokio-executor", version = "0.2.0-alpha.6", default-features = false, features = ["blocking", "crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "crossbeam-utils", "current-thread", "futures-core-preview", "lazy_static", "num_cpus", "slab", "threadpool", "tokio-sync"] }
+tokio-fs-c65f7effa3be6d31 = { package = "tokio-fs", version = "0.1", default-features = false }
+tokio-fs-1048d4db57848387 = { package = "tokio-fs", version = "0.2.0-alpha.6", default-features = false }
+tokio-io-c65f7effa3be6d31 = { package = "tokio-io", version = "0.1", default-features = false }
+tokio-io-1048d4db57848387 = { package = "tokio-io", version = "0.2.0-alpha.6", default-features = false, features = ["memchr", "pin-project", "util"] }
 tokio-macros = { version = "0.2.0-alpha.6", default-features = false }
+tokio-net = { version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "bytes", "futures-sink-preview", "iovec", "libc", "mio-uds", "tcp", "udp", "uds"] }
+tokio-process = { version = "0.2", default-features = false }
+tokio-reactor = { version = "0.1", default-features = false }
+tokio-retry = { version = "0.2", default-features = false }
+tokio-rustls = { version = "0.10", default-features = false }
+tokio-sync-c65f7effa3be6d31 = { package = "tokio-sync", version = "0.1", default-features = false }
+tokio-sync-1048d4db57848387 = { package = "tokio-sync", version = "0.2.0-alpha.6", default-features = false, features = ["async-traits", "futures-sink-preview"] }
+tokio-tcp = { version = "0.1", default-features = false }
+tokio-threadpool = { version = "0.1", default-features = false }
+tokio-timer-6f8ce4dd05d13bba = { package = "tokio-timer", version = "0.2", default-features = false }
+tokio-timer-411ef6e417c0d908 = { package = "tokio-timer", version = "0.3.0-alpha.6", default-features = false, features = ["async-traits"] }
+tokio-udp = { version = "0.1", default-features = false }
 toml = { version = "0.5" }
-tracing-attributes = { version = "0.1", default-features = false }
+tracing-core = { version = "0.1", features = ["std"] }
+try-lock = { version = "0.2", default-features = false }
+try_from = { version = "0.3", default-features = false }
+ttl_cache = { version = "0.4" }
+typed-arena = { version = "1", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unsigned-varint = { version = "0.2", default-features = false }
+untrusted = { version = "0.7", default-features = false }
+url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
+url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
+uuid = { version = "0.7", features = ["rand", "std", "v4"] }
+vec_map = { version = "0.8", default-features = false }
 version_check = { version = "0.1", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
 walkdir = { version = "2", default-features = false }
+want = { version = "0.2", default-features = false }
+webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
+webpki-roots = { version = "0.17", default-features = false }
 which = { version = "2", default-features = false }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+x25519-dalek-d8f496e17d97b5cb = { package = "x25519-dalek", version = "0.5", features = ["std", "u64_backend"] }
+xml-rs = { version = "0.8", default-features = false }
+yamux = { version = "0.2", default-features = false }
+zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
@@ -2,186 +2,144 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra_9ffd93b
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
+# resolver = '3'
 # unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '1'
+# dep-format-version = '4'
 # workspace-hack-line-style = 'full'
 # platforms = ['aarch64-nintendo-switch-freestanding', 'x86_64-fortanix-unknown-sgx']
-# [[traversal-excludes.ids]]
-# name = 'c_linked_list'
-# version = '1.1.1'
-# crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'encoding_rs'
-# version = '0.8.22'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'lock_api'
-# version = '0.3.3'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'phf_generator'
-# version = '0.7.24'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'pin-project-lite'
-# version = '0.1.4'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'strum'
-# version = '0.18.0'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'xml-rs'
-# version = '0.8.0'
-# crates-io = true
+# [traversal-excludes]
 # [[final-excludes.ids]]
-# name = 'backtrace-sys'
-# version = '0.1.33'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'codespan'
-# version = '0.8.0'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'executor'
+# name = 'consensus-types'
 # version = '0.1.0'
-# workspace-path = 'execution/executor'
+# workspace-path = 'consensus/consensus-types'
 #
 # [[final-excludes.ids]]
-# name = 'rusoto_ecs'
-# version = '0.42.0'
+# name = 'futures-sink'
+# version = '0.3.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'serde'
-# version = '1.0.104'
+# name = 'oorandom'
+# version = '11.1.0'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'stats_alloc'
-# version = '0.1.8'
+# name = 'tower-retry'
+# version = '0.3.0'
 # crates-io = true
 
 [dependencies]
-backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
-byteorder = { version = "1", features = ["i128", "std"] }
-bytes = { version = "0.5", features = ["serde", "std"] }
-chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
-curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+backtrace = { version = "0.3", features = ["serialize-serde"] }
+byteorder = { version = "1", features = ["i128"] }
+bytes = { version = "0.5", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "2" }
+curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 digest = { version = "0.8", default-features = false, features = ["std"] }
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-either = { version = "1", features = ["use_std"] }
-env_logger = { version = "0.7", features = ["atty", "humantime", "regex", "termcolor"] }
-failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3", features = ["alloc", "std"] }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+either = { version = "1" }
+env_logger = { version = "0.7" }
+failure = { version = "0.1" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
-libc = { version = "0.2", features = ["std"] }
+itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
+itoa = { version = "0.4" }
+libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
-memchr = { version = "2", features = ["std", "use_std"] }
+memchr = { version = "2", features = ["use_std"] }
 num-integer = { version = "0.1", default-features = false, features = ["std"] }
-num-traits = { version = "0.2", features = ["std"] }
-petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
-proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+num-traits = { version = "0.2" }
+petgraph = { version = "0.5" }
+proptest = { version = "0.9" }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-reqwest = { version = "0.10", default-features = false, features = ["__tls", "async-compression", "blocking", "default-tls", "gzip", "hyper-rustls", "hyper-tls", "json", "native-tls", "native-tls-crate", "rustls", "rustls-tls", "serde_json", "stream", "tokio-rustls", "tokio-tls", "webpki-roots"] }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
-rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
-sha-1 = { version = "0.8", features = ["std"] }
-sha2 = { version = "0.8", features = ["std"] }
-sha3 = { version = "0.8", features = ["std"] }
-subtle = { version = "2", features = ["i128", "std"] }
-tokio = { version = "0.2", features = ["blocking", "dns", "fnv", "fs", "full", "futures-core", "io-driver", "io-std", "io-util", "iovec", "lazy_static", "libc", "macros", "memchr", "mio", "mio-named-pipes", "mio-uds", "net", "num_cpus", "process", "rt-core", "rt-threaded", "rt-util", "signal", "signal-hook-registry", "slab", "stream", "sync", "tcp", "time", "tokio-macros", "udp", "uds"] }
+regex = { version = "1" }
+regex-syntax = { version = "0.6" }
+reqwest = { version = "0.10", default-features = false, features = ["blocking", "gzip", "json", "native-tls", "rustls-tls", "stream"] }
+ring = { version = "0.16", features = ["std"] }
+rusty-fork = { version = "0.2" }
+serde = { version = "1", features = ["derive", "rc"] }
+sha-1 = { version = "0.8" }
+sha2 = { version = "0.8" }
+sha3 = { version = "0.8" }
+subtle = { version = "2" }
+tokio = { version = "0.2", features = ["full"] }
 toml = { version = "0.5" }
-ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
+ureq = { version = "0.11", features = ["json"] }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 
 [build-dependencies]
-backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
-byteorder = { version = "1", features = ["i128", "std"] }
-bytes = { version = "0.5", features = ["serde", "std"] }
-cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
-chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
-clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
-curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+backtrace = { version = "0.3", features = ["serialize-serde"] }
+byteorder = { version = "1", features = ["i128"] }
+bytes = { version = "0.5", features = ["serde"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "2" }
+curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 digest = { version = "0.8", default-features = false, features = ["std"] }
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-either = { version = "1", features = ["use_std"] }
-env_logger = { version = "0.7", features = ["atty", "humantime", "regex", "termcolor"] }
-failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3", features = ["alloc", "std"] }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
+either = { version = "1" }
+env_logger = { version = "0.7" }
+failure = { version = "0.1" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
-libc = { version = "0.2", features = ["std"] }
+itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9" }
+itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8" }
+itoa = { version = "0.4" }
+libc = { version = "0.2" }
 log = { version = "0.4", default-features = false, features = ["serde", "std"] }
-memchr = { version = "2", features = ["std", "use_std"] }
+memchr = { version = "2", features = ["use_std"] }
 num-integer = { version = "0.1", default-features = false, features = ["std"] }
-num-traits = { version = "0.2", features = ["std"] }
-petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
-proc-macro2 = { version = "0.4", features = ["proc-macro"] }
-proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
-quote = { version = "0.6", features = ["proc-macro"] }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+num-traits = { version = "0.2" }
+petgraph = { version = "0.5" }
+proc-macro2 = { version = "0.4" }
+proptest = { version = "0.9" }
+quote = { version = "0.6" }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
-regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-reqwest = { version = "0.10", default-features = false, features = ["__tls", "async-compression", "blocking", "default-tls", "gzip", "hyper-rustls", "hyper-tls", "json", "native-tls", "native-tls-crate", "rustls", "rustls-tls", "serde_json", "stream", "tokio-rustls", "tokio-tls", "webpki-roots"] }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
-rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
-sha-1 = { version = "0.8", features = ["std"] }
-sha2 = { version = "0.8", features = ["std"] }
-sha3 = { version = "0.8", features = ["std"] }
-subtle = { version = "2", features = ["i128", "std"] }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
-tokio = { version = "0.2", features = ["blocking", "dns", "fnv", "fs", "full", "futures-core", "io-driver", "io-std", "io-util", "iovec", "lazy_static", "libc", "macros", "memchr", "mio", "mio-named-pipes", "mio-uds", "net", "num_cpus", "process", "rt-core", "rt-threaded", "rt-util", "signal", "signal-hook-registry", "slab", "stream", "sync", "tcp", "time", "tokio-macros", "udp", "uds"] }
+regex = { version = "1" }
+regex-syntax = { version = "0.6" }
+reqwest = { version = "0.10", default-features = false, features = ["blocking", "gzip", "json", "native-tls", "rustls-tls", "stream"] }
+ring = { version = "0.16", features = ["std"] }
+rusty-fork = { version = "0.2" }
+serde = { version = "1", features = ["derive", "rc"] }
+sha-1 = { version = "0.8" }
+sha2 = { version = "0.8" }
+sha3 = { version = "0.8" }
+subtle = { version = "2" }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+tokio = { version = "0.2", features = ["full"] }
 toml = { version = "0.5" }
-ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
+ureq = { version = "0.11", features = ["json"] }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 
 [target.aarch64-nintendo-switch-freestanding.dependencies]
-hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper = { version = "0.13" }
 
 [target.aarch64-nintendo-switch-freestanding.build-dependencies]
-hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper = { version = "0.13" }
 
 [target.x86_64-fortanix-unknown-sgx.dependencies]
-hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper = { version = "0.13" }
 
 [target.x86_64-fortanix-unknown-sgx.build-dependencies]
-hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper = { version = "0.13" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-1.toml
@@ -2,62 +2,38 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra_9ffd93b
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = 'install'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = true
-# dep-format-version = '1'
+# dep-format-version = '2'
 # workspace-hack-line-style = 'full'
 # platforms = ['riscv64gc-unknown-hermit']
 # [[traversal-excludes.ids]]
-# name = 'hmac'
-# version = '0.7.1'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'rayon'
-# version = '1.3.0'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'thread_local'
-# version = '1.0.1'
-# crates-io = true
-# [[final-excludes.ids]]
-# name = 'Inflector'
-# version = '0.11.4'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'cfg-if'
-# version = '0.1.10'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'libra-metrics'
+# name = 'libra-wallet'
 # version = '0.1.0'
-# workspace-path = 'common/metrics'
+# workspace-path = 'client/libra_wallet'
 #
-# [[final-excludes.ids]]
-# name = 'oorandom'
-# version = '11.1.0'
+# [[traversal-excludes.ids]]
+# name = 'proc-macro-nested'
+# version = '0.1.3'
 # crates-io = true
 #
-# [[final-excludes.ids]]
-# name = 'tokio-executor'
-# version = '0.1.10'
+# [[traversal-excludes.ids]]
+# name = 'rustversion'
+# version = '1.0.2'
 # crates-io = true
 #
-# [[final-excludes.ids]]
-# name = 'tokio-tcp'
-# version = '0.1.4'
+# [[traversal-excludes.ids]]
+# name = 'tonic-build'
+# version = '0.1.1'
 # crates-io = true
-#
 # [[final-excludes.ids]]
-# name = 'vcpkg'
-# version = '0.2.8'
+# name = 'dirs'
+# version = '2.0.2'
 # crates-io = true
 
 [dependencies]
+Inflector = { version = "0.11", features = ["heavyweight", "lazy_static", "regex"] }
 adler32 = { version = "1", default-features = false }
 aho-corasick = { version = "0.7", features = ["std"] }
 ansi_term-274715c4dabd11b0 = { package = "ansi_term", version = "0.9", default-features = false }
@@ -76,7 +52,6 @@ backtrace-sys = { version = "0.1", default-features = false, features = ["backtr
 base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
 base64-a6292c17cd707f01 = { package = "base64", version = "0.11", features = ["std"] }
 base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12", features = ["std"] }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
 bincode = { version = "1", default-features = false }
 bit-set = { version = "0.5", features = ["std"] }
 bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
@@ -98,6 +73,7 @@ bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-feat
 c_linked_list = { version = "1", default-features = false }
 cached = { version = "0.11", default-features = false }
 cast = { version = "0.2", features = ["std"] }
+cfg-if = { version = "0.1", default-features = false }
 chacha20-poly1305-aead = { version = "0.1", default-features = false }
 chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
 chunked_transfer = { version = "1", default-features = false }
@@ -127,8 +103,7 @@ curve25519-dalek-f595c2ba2a3f28df = { package = "curve25519-dalek", version = "2
 data-encoding = { version = "2", features = ["alloc", "std"] }
 difference = { version = "2" }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
-dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
+dirs = { version = "1", default-features = false }
 dirs-sys = { version = "0.3", default-features = false }
 dtoa = { version = "0.4", default-features = false }
 ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
@@ -166,6 +141,7 @@ headers = { version = "0.3", default-features = false }
 headers-core = { version = "0.2", default-features = false }
 hex = { version = "0.4", features = ["std"] }
 hex_fmt = { version = "0.3", default-features = false }
+hmac = { version = "0.7", default-features = false }
 http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
 http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
 http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
@@ -229,6 +205,7 @@ num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
 numtoa = { version = "0.1", default-features = false, features = ["std"] }
 once_cell = { version = "1", features = ["std"] }
+oorandom = { version = "11", default-features = false }
 opaque-debug = { version = "0.2", default-features = false }
 openssl = { version = "0.10", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
@@ -241,7 +218,6 @@ parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
 parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
 parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 paste = { version = "0.1", default-features = false }
-pbkdf2 = { version = "0.3", features = ["base64", "hmac", "include_simple", "rand", "sha2", "subtle"] }
 percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
 percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
 petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
@@ -254,7 +230,6 @@ plotters = { version = "0.2", default-features = false, features = ["area_series
 pretty = { version = "0.9", default-features = false }
 prettydiff = { version = "0.3", default-features = false }
 prettytable-rs = { version = "0.8", features = ["csv", "win_crlf"] }
-proc-macro-nested = { version = "0.1", default-features = false }
 prometheus = { version = "0.8", default-features = false }
 proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 prost = { version = "0.6", features = ["prost-derive"] }
@@ -263,13 +238,12 @@ quick-error = { version = "1", default-features = false }
 radium = { version = "0.3", default-features = false }
 radix_trie = { version = "0.1", default-features = false }
 rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
 rand04 = { version = "0.1", default-features = false, features = ["std"] }
 rand04_compat = { version = "0.1", features = ["std"] }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
-rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_hc = { version = "0.1", default-features = false }
@@ -279,6 +253,8 @@ rand_os = { version = "0.1", default-features = false }
 rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
 ref-cast = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-automata = { version = "0.1", default-features = false }
@@ -342,6 +318,7 @@ termcolor = { version = "1", default-features = false }
 termion = { version = "1", default-features = false }
 textwrap = { version = "0.11", default-features = false }
 thiserror = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
 threshold_crypto = { version = "0.3", default-features = false }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
 time-6f8ce4dd05d13bba = { package = "time", version = "0.2", features = ["deprecated", "libc", "std", "winapi"] }
@@ -354,6 +331,7 @@ tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["bloc
 tokio-buf = { version = "0.1", features = ["either", "util"] }
 tokio-codec = { version = "0.1", default-features = false }
 tokio-current-thread = { version = "0.1", default-features = false }
+tokio-executor = { version = "0.1", default-features = false }
 tokio-fs = { version = "0.1", default-features = false }
 tokio-io = { version = "0.1", default-features = false }
 tokio-process = { version = "0.2", default-features = false }
@@ -361,6 +339,7 @@ tokio-reactor = { version = "0.1", default-features = false }
 tokio-retry = { version = "0.2", default-features = false }
 tokio-rustls-93f6ce9d446188ac = { package = "tokio-rustls", version = "0.10", default-features = false }
 tokio-sync = { version = "0.1", default-features = false }
+tokio-tcp = { version = "0.1", default-features = false }
 tokio-threadpool = { version = "0.1", default-features = false }
 tokio-timer = { version = "0.2", default-features = false }
 tokio-tungstenite = { version = "0.10", default-features = false }
@@ -423,18 +402,8 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [build-dependencies]
-adler32 = { version = "1", default-features = false }
 aho-corasick = { version = "0.7", features = ["std"] }
-ansi_term-274715c4dabd11b0 = { package = "ansi_term", version = "0.9", default-features = false }
 anyhow = { version = "1", features = ["std"] }
-arbitrary = { version = "0.4", default-features = false }
-arc-swap = { version = "0.4", default-features = false }
-arrayref = { version = "0.3", default-features = false }
-arrayvec-9fbad63c4bcf4a8f = { package = "arrayvec", version = "0.4", default-features = false }
-arrayvec-d8f496e17d97b5cb = { package = "arrayvec", version = "0.5", features = ["std"] }
-assert_approx_eq = { version = "1", default-features = false }
-assert_matches = { version = "1", default-features = false }
-async-stream = { version = "0.2", default-features = false }
 async-stream-impl = { version = "0.2", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 atty = { version = "0.2", default-features = false }
@@ -442,238 +411,71 @@ autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-featu
 autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
 backtrace-sys = { version = "0.1", default-features = false, features = ["backtrace-sys"] }
-base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
-base64-a6292c17cd707f01 = { package = "base64", version = "0.11", features = ["std"] }
-base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12", features = ["std"] }
-base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
-bincode = { version = "1", default-features = false }
 bindgen-8d8b32fa686af104 = { package = "bindgen", version = "0.51", features = ["clap", "env_logger", "log", "logging", "which", "which-rustfmt"] }
 bindgen-c1a53b25704bd5ca = { package = "bindgen", version = "0.53", features = ["clap", "env_logger", "log", "logging", "runtime", "which", "which-rustfmt"] }
-bit-set = { version = "0.5", features = ["std"] }
-bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
-bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
 bitflags = { version = "1" }
-bitvec = { version = "0.17", features = ["alloc", "atomic", "std"] }
-blake2 = { version = "0.8", default-features = false }
-blake2-rfc = { version = "0.2", features = ["std"] }
-block-buffer = { version = "0.7", default-features = false }
-block-padding = { version = "0.1", default-features = false }
-bs58 = { version = "0.3", features = ["alloc", "std"] }
-bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
-buf_redux = { version = "0.8", default-features = false }
-byte-tools = { version = "0.3", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
-bytes-9fbad63c4bcf4a8f = { package = "bytes", version = "0.4", default-features = false, features = ["either"] }
 bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["serde", "std"] }
-bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
-c_linked_list = { version = "1", default-features = false }
-cached = { version = "0.11", default-features = false }
-cast = { version = "0.2", features = ["std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 cexpr = { version = "0.3", default-features = false }
-chacha20-poly1305-aead = { version = "0.1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
-chunked_transfer = { version = "1", default-features = false }
+cfg-if = { version = "0.1", default-features = false }
 clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
 clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
 cmake = { version = "0.1", default-features = false }
-codespan = { version = "0.8", default-features = false, features = ["serde", "serialization"] }
-codespan-reporting = { version = "0.8", default-features = false }
-constant_time_eq = { version = "0.1", default-features = false }
-cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
-crc32fast = { version = "1", features = ["std"] }
-criterion = { version = "0.3" }
-criterion-plot = { version = "0.4", default-features = false }
-crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
-crossbeam-channel = { version = "0.4", default-features = false }
-crossbeam-deque = { version = "0.7", default-features = false }
-crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.2", features = ["std"] }
-crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
-crunchy = { version = "0.2", features = ["limit_128"] }
-crypto-mac = { version = "0.7", default-features = false }
-csv = { version = "1", default-features = false }
-csv-core = { version = "0.1" }
-ct-logs = { version = "0.6", default-features = false }
-ctrlc = { version = "3", default-features = false }
-curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
-curve25519-dalek-f595c2ba2a3f28df = { package = "curve25519-dalek", version = "2", default-features = false, features = ["alloc", "std", "u64_backend"] }
-data-encoding = { version = "2", features = ["alloc", "std"] }
-difference = { version = "2" }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
-dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
-dirs-sys = { version = "0.3", default-features = false }
-dtoa = { version = "0.4", default-features = false }
-ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 either = { version = "1", features = ["use_std"] }
-encode_unicode = { version = "0.3", features = ["std"] }
-endian-type = { version = "0.1", default-features = false }
 env_logger-3b31131e45eafb45 = { package = "env_logger", version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
 env_logger-ca01ad9e24f5d932 = { package = "env_logger", version = "0.7", features = ["atty", "humantime", "regex", "termcolor"] }
-errno = { version = "0.2", default-features = false }
 failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 failure_derive = { version = "0.1", default-features = false }
-fake-simd = { version = "0.1", default-features = false }
 fixedbitset = { version = "0.2", default-features = false }
-flate2 = { version = "1", features = ["miniz_oxide", "rust_backend"] }
-fnv = { version = "1", default-features = false }
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
 fs_extra = { version = "1", default-features = false }
-futures-c65f7effa3be6d31 = { package = "futures", version = "0.1", features = ["use_std", "with-deprecated"] }
-futures-468e82937335b1c9 = { package = "futures", version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3", features = ["alloc", "std"] }
-futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
-futures-executor = { version = "0.3", default-features = false, features = ["std"] }
-futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-macro = { version = "0.3", default-features = false }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-timer = { version = "3", default-features = false }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.12", default-features = false }
-get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
-goldenfile = { version = "1", default-features = false }
-h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
-h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
-headers = { version = "0.3", default-features = false }
-headers-core = { version = "0.2", default-features = false }
 heck = { version = "0.3", default-features = false }
-hex = { version = "0.4", features = ["std"] }
-hex_fmt = { version = "0.3", default-features = false }
-http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
-http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
-http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
-http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
-httparse = { version = "1", features = ["std"] }
 humantime = { version = "1", default-features = false }
-hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
-hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
-hyper-rustls-9067fe90e8c1f593 = { package = "hyper-rustls", version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
-idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
-idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-include_dir = { version = "0.5" }
 include_dir_impl = { version = "0.5", default-features = false }
 indexmap = { version = "1", default-features = false }
-input_buffer = { version = "0.3", default-features = false }
-iovec = { version = "0.1", default-features = false }
 itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
-itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
-itoa = { version = "0.4", features = ["std"] }
-jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
-jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jobserver = { version = "0.1", default-features = false }
-k8s-openapi = { version = "0.7", default-features = false, features = ["v1_15"] }
-keccak = { version = "0.1", default-features = false }
-kube = { version = "0.27", features = ["k8s-openapi", "native-tls", "openapi", "openssl"] }
 lazy_static = { version = "1", default-features = false }
 lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", features = ["extra_traits", "std"] }
-libfuzzer-sys = { version = "0.3", default-features = false }
 libloading = { version = "0.5", default-features = false }
-librocksdb_sys = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
-libtitan_sys = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
-libz-sys = { version = "1", default-features = false, features = ["static"] }
-linked-hash-map = { version = "0.5", default-features = false }
-lock_api = { version = "0.3", default-features = false }
-log-468e82937335b1c9 = { package = "log", version = "0.3", features = ["use_std"] }
 log-9fbad63c4bcf4a8f = { package = "log", version = "0.4", default-features = false, features = ["serde", "std"] }
-lru-cache = { version = "0.1", default-features = false }
-lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
-matches = { version = "0.1", default-features = false }
-maybe-uninit = { version = "2", default-features = false }
-md5 = { version = "0.7", features = ["std"] }
 memchr = { version = "2", features = ["std", "use_std"] }
-memoffset = { version = "0.5", default-features = false }
-memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
-mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
-mime-468e82937335b1c9 = { package = "mime", version = "0.3", default-features = false }
-mime_guess-dff4ba8e3ae991db = { package = "mime_guess", version = "1", default-features = false }
-mime_guess-f595c2ba2a3f28df = { package = "mime_guess", version = "2", features = ["rev-mappings"] }
-miniz_oxide = { version = "0.3", default-features = false }
-mio = { version = "0.6", features = ["with-deprecated"] }
-mirai-annotations = { version = "1", default-features = false }
 multimap = { version = "0.8", default-features = false }
-multipart = { version = "0.16", default-features = false, features = ["buf_redux", "httparse", "quick-error", "safemem", "server", "twoway"] }
-net2 = { version = "0.2", features = ["duration"] }
-nibble_vec = { version = "0.0.4", default-features = false }
-nodrop = { version = "0.1", default-features = false }
-nohash-hasher = { version = "0.2", features = ["std"] }
 nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
-num = { version = "0.2", features = ["num-bigint", "std"] }
-num-bigint = { version = "0.2", default-features = false, features = ["std"] }
-num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-derive = { version = "0.3", default-features = false }
-num-integer = { version = "0.1", default-features = false, features = ["std"] }
-num-iter = { version = "0.1", default-features = false, features = ["std"] }
-num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
-num-traits = { version = "0.2", features = ["std"] }
-num_cpus = { version = "1", default-features = false }
-numtoa = { version = "0.1", default-features = false, features = ["std"] }
-once_cell = { version = "1", features = ["std"] }
-opaque-debug = { version = "0.2", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-ordered-float = { version = "1", features = ["std"] }
-pairing = { version = "0.14", features = ["u128-support"] }
-parity-multiaddr = { version = "0.7", default-features = false }
-parity-multihash = { version = "0.2", default-features = false }
-parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
-parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
-parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
-parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
-paste = { version = "0.1", default-features = false }
 paste-impl = { version = "0.1", default-features = false }
-pbkdf2 = { version = "0.3", features = ["base64", "hmac", "include_simple", "rand", "sha2", "subtle"] }
 peeking_take_while = { version = "0.1", default-features = false }
-percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
-percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
 petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
 phf = { version = "0.7", default-features = false, features = ["unicase"] }
 phf_codegen = { version = "0.7", default-features = false }
 phf_generator = { version = "0.7", default-features = false }
 phf_shared = { version = "0.7", default-features = false, features = ["unicase"] }
-pin-project = { version = "0.4", default-features = false }
 pin-project-internal = { version = "0.4", default-features = false }
-pin-project-lite = { version = "0.1", default-features = false }
-pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
-plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
-pretty = { version = "0.9", default-features = false }
-prettydiff = { version = "0.3", default-features = false }
-prettytable-rs = { version = "0.8", features = ["csv", "win_crlf"] }
 proc-macro-error = { version = "0.4", default-features = false }
 proc-macro-error-attr = { version = "0.4", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro-nested = { version = "0.1", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
-prometheus = { version = "0.8", default-features = false }
-proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 proptest-derive = { version = "0.1", default-features = false }
 prost = { version = "0.6", features = ["prost-derive"] }
 prost-build = { version = "0.6", default-features = false }
 prost-derive = { version = "0.6", default-features = false }
 prost-types = { version = "0.6", default-features = false }
-qstring = { version = "0.7", default-features = false }
 quick-error = { version = "1", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
-radium = { version = "0.3", default-features = false }
-radix_trie = { version = "0.1", default-features = false }
-rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
-rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-rand04 = { version = "0.1", default-features = false, features = ["std"] }
-rand04_compat = { version = "0.1", features = ["std"] }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
-rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
 rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_hc = { version = "0.1", default-features = false }
@@ -683,174 +485,49 @@ rand_os = { version = "0.1", default-features = false }
 rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
-ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-automata = { version = "0.1", default-features = false }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
-rental = { version = "0.5", features = ["std"] }
 rental-impl = { version = "0.5", default-features = false }
-reqwest = { version = "0.10", default-features = false, features = ["__tls", "async-compression", "blocking", "default-tls", "gzip", "hyper-rustls", "hyper-tls", "json", "native-tls", "native-tls-crate", "rustls", "rustls-tls", "serde_json", "stream", "tokio-rustls", "tokio-tls", "webpki-roots"] }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
-ripemd160 = { version = "0.8", features = ["std"] }
-rocksdb = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
-rusoto_core = { version = "0.42", default-features = false, features = ["hyper-rustls", "rustls"] }
-rusoto_credential = { version = "0.42", default-features = false }
-rusoto_ec2 = { version = "0.42", default-features = false, features = ["rustls"] }
-rusoto_ecr = { version = "0.42", default-features = false, features = ["rustls"] }
-rusoto_ecs = { version = "0.42", default-features = false, features = ["rustls"] }
-rusoto_s3 = { version = "0.42", default-features = false, features = ["rustls"] }
-rusoto_signature = { version = "0.42", default-features = false }
-rust_decimal = { version = "1", features = ["serde"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", features = ["std"] }
 rustc_version = { version = "0.2", default-features = false }
-rustls-986da7b5efc2b80e = { package = "rustls", version = "0.16", features = ["log", "logging"] }
-rustversion = { version = "1", default-features = false }
-rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
-rustyline = { version = "6", features = ["dirs", "with-dirs"] }
-ryu = { version = "1", default-features = false }
-safemem = { version = "0.3", features = ["std"] }
-same-file = { version = "1", default-features = false }
-scoped-tls = { version = "1", default-features = false }
-scopeguard = { version = "1", default-features = false }
-sct = { version = "0.6", default-features = false }
 semver = { version = "0.9" }
 semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
-serde-value = { version = "0.6", default-features = false }
 serde_derive = { version = "1" }
-serde_json = { version = "1", features = ["std"] }
-serde_urlencoded = { version = "0.6", default-features = false }
-serde_yaml = { version = "0.8", default-features = false }
-sha-1 = { version = "0.8", features = ["std"] }
-sha2 = { version = "0.8", features = ["std"] }
-sha3 = { version = "0.8", features = ["std"] }
 shlex = { version = "0.1", default-features = false }
-simplelog = { version = "0.7", features = ["term"] }
 siphasher = { version = "0.2", default-features = false }
-slab = { version = "0.4", default-features = false }
-smallvec-3b31131e45eafb45 = { package = "smallvec", version = "0.6", features = ["std"] }
-smallvec-dff4ba8e3ae991db = { package = "smallvec", version = "1", default-features = false }
-snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
-snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
-spin = { version = "0.5", default-features = false }
-stable_deref_trait = { version = "1", default-features = false, features = ["std"] }
-static_assertions = { version = "1", default-features = false }
-statistical = { version = "1", default-features = false }
-stats_alloc = { version = "0.1" }
-string = { version = "0.2", features = ["bytes"] }
 strsim = { version = "0.8", default-features = false }
-structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
-structopt-468e82937335b1c9 = { package = "structopt", version = "0.3" }
 structopt-derive-6f8ce4dd05d13bba = { package = "structopt-derive", version = "0.2", default-features = false }
 structopt-derive-9fbad63c4bcf4a8f = { package = "structopt-derive", version = "0.4", default-features = false }
-strum = { version = "0.18", default-features = false }
 strum_macros = { version = "0.18", default-features = false }
-subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
 subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 syn-mid = { version = "0.5", default-features = false }
 synstructure = { version = "0.12", features = ["proc-macro"] }
 tempfile = { version = "3", default-features = false }
-term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
-term-3b31131e45eafb45 = { package = "term", version = "0.6" }
 termcolor = { version = "1", default-features = false }
-termion = { version = "1", default-features = false }
 textwrap = { version = "0.11", default-features = false }
-thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
-threshold_crypto = { version = "0.3", default-features = false }
-time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
-time-6f8ce4dd05d13bba = { package = "time", version = "0.2", features = ["deprecated", "libc", "std", "winapi"] }
-time-macros = { version = "0.1", default-features = false }
+thread_local = { version = "1", default-features = false }
 time-macros-impl = { version = "0.1", default-features = false }
-tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1", features = ["keccak"] }
-tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
-tinytemplate = { version = "1", default-features = false }
-tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
-tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["blocking", "dns", "fnv", "fs", "full", "futures-core", "io-driver", "io-std", "io-util", "iovec", "lazy_static", "libc", "macros", "memchr", "mio", "mio-named-pipes", "mio-uds", "net", "num_cpus", "process", "rt-core", "rt-threaded", "rt-util", "signal", "signal-hook-registry", "slab", "stream", "sync", "tcp", "time", "tokio-macros", "udp", "uds", "winapi"] }
-tokio-buf = { version = "0.1", features = ["either", "util"] }
-tokio-codec = { version = "0.1", default-features = false }
-tokio-current-thread = { version = "0.1", default-features = false }
-tokio-fs = { version = "0.1", default-features = false }
-tokio-io = { version = "0.1", default-features = false }
 tokio-macros = { version = "0.2", default-features = false }
-tokio-process = { version = "0.2", default-features = false }
-tokio-reactor = { version = "0.1", default-features = false }
-tokio-retry = { version = "0.2", default-features = false }
-tokio-rustls-93f6ce9d446188ac = { package = "tokio-rustls", version = "0.10", default-features = false }
-tokio-sync = { version = "0.1", default-features = false }
-tokio-threadpool = { version = "0.1", default-features = false }
-tokio-timer = { version = "0.2", default-features = false }
-tokio-tungstenite = { version = "0.10", default-features = false }
-tokio-udp = { version = "0.1", default-features = false }
-tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
-tokio-util-468e82937335b1c9 = { package = "tokio-util", version = "0.3", features = ["codec"] }
-toml = { version = "0.5" }
-tonic = { version = "0.1", features = ["async-trait", "codegen", "hyper", "prost", "prost-derive", "tokio", "tower", "tower-balance", "tower-load", "tracing-futures", "transport"] }
-tonic-build = { version = "0.1", features = ["rustfmt", "transport"] }
-tower = { version = "0.3", features = ["full", "log"] }
-tower-balance = { version = "0.3", features = ["log"] }
-tower-buffer = { version = "0.3", default-features = false, features = ["log"] }
-tower-discover = { version = "0.3", default-features = false }
-tower-layer = { version = "0.3", default-features = false }
-tower-limit = { version = "0.3", default-features = false }
-tower-load = { version = "0.3", default-features = false }
-tower-load-shed = { version = "0.3", default-features = false }
-tower-make = { version = "0.3", default-features = false, features = ["connect", "tokio"] }
-tower-ready-cache = { version = "0.3", default-features = false }
-tower-retry = { version = "0.3", default-features = false }
-tower-service = { version = "0.3", default-features = false }
-tower-timeout = { version = "0.3", default-features = false }
-tower-util = { version = "0.3", features = ["call-all", "futures-util"] }
-tracing = { version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-attributes = { version = "0.1", default-features = false }
-tracing-core = { version = "0.1", default-features = false, features = ["lazy_static", "std"] }
-tracing-futures = { version = "0.2", features = ["pin-project", "std", "std-future"] }
-try-lock = { version = "0.2", default-features = false }
-ttl_cache = { version = "0.5" }
-tungstenite = { version = "0.10", default-features = false }
-twoway = { version = "0.1", features = ["use_std"] }
-typed-arena = { version = "2", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase-dff4ba8e3ae991db = { package = "unicase", version = "1", default-features = false }
 unicase-f595c2ba2a3f28df = { package = "unicase", version = "2", default-features = false }
-unicode-bidi = { version = "0.3" }
-unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
-unsigned-varint = { version = "0.3", default-features = false }
-untrusted = { version = "0.7", default-features = false }
-ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
-url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
-url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
-urlencoding = { version = "1", default-features = false }
-utf-8 = { version = "0.7", default-features = false }
 vec_map = { version = "0.8", default-features = false }
 version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", default-features = false }
 version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
-wait-timeout = { version = "0.2", default-features = false }
-walkdir = { version = "2", default-features = false }
-want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
-want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
-warp = { version = "0.2", features = ["multipart", "tokio-tungstenite", "websocket"] }
-webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
-webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
-webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
 which = { version = "3", default-features = false }
-x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
-x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6", features = ["std", "u64_backend"] }
-xml-rs = { version = "0.8", default-features = false }
-yaml-rust = { version = "0.4", default-features = false }
-yamux = { version = "0.4", default-features = false }
-zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 zeroize_derive = { version = "1", default-features = false }
-zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [target.riscv64gc-unknown-hermit.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
@@ -871,20 +548,10 @@ tokio-tls = { version = "0.3", default-features = false }
 
 [target.riscv64gc-unknown-hermit.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
-async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-encoding_rs = { version = "0.8", default-features = false }
 hermit-abi = { version = "0.1" }
-hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
-hyper-tls = { version = "0.4", default-features = false }
-native-tls = { version = "0.2", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration", "log", "logging"] }
-rustls-native-certs = { version = "0.3", default-features = false }
-tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
-tokio-tls = { version = "0.3", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
@@ -2,41 +2,14 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra_9ffd93b
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'unify-if-both'
+# resolver = 'install'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = true
-# dep-format-version = '1'
+# dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = []
-# [[traversal-excludes.ids]]
-# name = 'chunked_transfer'
-# version = '1.0.0'
-# crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'get_if_addrs-sys'
-# version = '0.1.1'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'language_benchmarks'
-# version = '0.1.0'
-# workspace-path = 'language/benchmarks'
-#
-# [[traversal-excludes.ids]]
-# name = 'rdrand'
-# version = '0.4.0'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'semver-parser'
-# version = '0.7.0'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'yamux'
-# version = '0.4.4'
-# crates-io = true
+# [traversal-excludes]
 #
 # [final-excludes]
 
@@ -85,6 +58,7 @@ cast = { version = "0.2", features = ["std"] }
 cfg-if = { version = "0.1", default-features = false }
 chacha20-poly1305-aead = { version = "0.1", default-features = false }
 chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
+chunked_transfer = { version = "1", default-features = false }
 clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
 codespan = { version = "0.8", default-features = false, features = ["serde", "serialization"] }
@@ -203,6 +177,7 @@ multipart = { version = "0.16", default-features = false, features = ["buf_redux
 net2 = { version = "0.2", features = ["duration"] }
 nibble_vec = { version = "0.0.4", default-features = false }
 nodrop = { version = "0.1", default-features = false }
+nohash-hasher = { version = "0.2", features = ["std"] }
 num = { version = "0.2", features = ["num-bigint", "std"] }
 num-bigint = { version = "0.2", default-features = false, features = ["std"] }
 num-complex = { version = "0.2", default-features = false, features = ["std"] }
@@ -221,8 +196,10 @@ ordered-float = { version = "1", features = ["std"] }
 pairing = { version = "0.14", features = ["u128-support"] }
 parity-multiaddr = { version = "0.7", default-features = false }
 parity-multihash = { version = "0.2", default-features = false }
-parking_lot = { version = "0.9" }
-parking_lot_core = { version = "0.6", default-features = false }
+parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
+parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
 paste = { version = "0.1", default-features = false }
 pbkdf2 = { version = "0.3", features = ["base64", "hmac", "include_simple", "rand", "sha2", "subtle"] }
 percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
@@ -406,12 +383,24 @@ x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://githu
 x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6", features = ["std", "u64_backend"] }
 xml-rs = { version = "0.8", default-features = false }
 yaml-rust = { version = "0.4", default-features = false }
+yamux = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [build-dependencies]
+Inflector = { version = "0.11", features = ["heavyweight", "lazy_static", "regex"] }
+adler32 = { version = "1", default-features = false }
 aho-corasick = { version = "0.7", features = ["std"] }
+ansi_term = { version = "0.9", default-features = false }
 anyhow = { version = "1", features = ["std"] }
+arbitrary = { version = "0.4", default-features = false }
+arc-swap = { version = "0.4", default-features = false }
+arrayref = { version = "0.3", default-features = false }
+arrayvec-9fbad63c4bcf4a8f = { package = "arrayvec", version = "0.4", default-features = false }
+arrayvec-d8f496e17d97b5cb = { package = "arrayvec", version = "0.5", features = ["std"] }
+assert_approx_eq = { version = "1", default-features = false }
+assert_matches = { version = "1", default-features = false }
+async-stream = { version = "0.2", default-features = false }
 async-stream-impl = { version = "0.2", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 atty = { version = "0.2", default-features = false }
@@ -419,69 +408,239 @@ autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-featu
 autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
 backtrace-sys = { version = "0.1", default-features = false, features = ["backtrace-sys"] }
+base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
+base64-a6292c17cd707f01 = { package = "base64", version = "0.11", features = ["std"] }
+base64-5ef9efb8ec2df382 = { package = "base64", version = "0.12", features = ["std"] }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
+bincode = { version = "1", default-features = false }
 bindgen-8d8b32fa686af104 = { package = "bindgen", version = "0.51", features = ["clap", "env_logger", "log", "logging", "which", "which-rustfmt"] }
 bindgen-c1a53b25704bd5ca = { package = "bindgen", version = "0.53", features = ["clap", "env_logger", "log", "logging", "runtime", "which", "which-rustfmt"] }
+bit-set = { version = "0.5", features = ["std"] }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
+bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
 bitflags = { version = "1" }
+bitvec = { version = "0.17", features = ["alloc", "atomic", "std"] }
+blake2 = { version = "0.8", default-features = false }
+blake2-rfc = { version = "0.2", features = ["std"] }
+block-buffer = { version = "0.7", default-features = false }
+block-padding = { version = "0.1", default-features = false }
+bs58 = { version = "0.3", features = ["alloc", "std"] }
+bstr = { version = "0.2", features = ["lazy_static", "regex-automata", "serde", "serde1", "serde1-nostd", "std", "unicode"] }
+buf_redux = { version = "0.8", default-features = false }
+byte-tools = { version = "0.3", default-features = false }
 byteorder = { version = "1", features = ["i128", "std"] }
+bytes-9fbad63c4bcf4a8f = { package = "bytes", version = "0.4", default-features = false, features = ["either"] }
 bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["serde", "std"] }
+bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
+c_linked_list = { version = "1", default-features = false }
+cached = { version = "0.11", default-features = false }
+cast = { version = "0.2", features = ["std"] }
 cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
 cexpr = { version = "0.3", default-features = false }
 cfg-if = { version = "0.1", default-features = false }
+chacha20-poly1305-aead = { version = "0.1", default-features = false }
+chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
+chunked_transfer = { version = "1", default-features = false }
 clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
 clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
 clear_on_drop = { version = "0.2", default-features = false }
 cmake = { version = "0.1", default-features = false }
+codespan = { version = "0.8", default-features = false, features = ["serde", "serialization"] }
+codespan-reporting = { version = "0.8", default-features = false }
+constant_time_eq = { version = "0.1", default-features = false }
+cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
+crc32fast = { version = "1", features = ["std"] }
+criterion = { version = "0.3" }
+criterion-plot = { version = "0.4", default-features = false }
+crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
+crossbeam-channel = { version = "0.4", default-features = false }
+crossbeam-deque = { version = "0.7", default-features = false }
+crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
+crossbeam-queue = { version = "0.2", features = ["std"] }
+crossbeam-utils = { version = "0.7", features = ["lazy_static", "std"] }
+crunchy = { version = "0.2", features = ["limit_128"] }
+crypto-mac = { version = "0.7", default-features = false }
+csv = { version = "1", default-features = false }
+csv-core = { version = "0.1" }
+ct-logs = { version = "0.6", default-features = false }
+ctrlc = { version = "3", default-features = false }
+curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+curve25519-dalek-f595c2ba2a3f28df = { package = "curve25519-dalek", version = "2", default-features = false, features = ["alloc", "std", "u64_backend"] }
+data-encoding = { version = "2", features = ["alloc", "std"] }
+difference = { version = "2" }
 digest = { version = "0.8", default-features = false, features = ["std"] }
+dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
+dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
+dirs-sys = { version = "0.3", default-features = false }
+dtoa = { version = "0.4", default-features = false }
+ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
 either = { version = "1", features = ["use_std"] }
+encode_unicode = { version = "0.3", features = ["std"] }
+endian-type = { version = "0.1", default-features = false }
 env_logger-3b31131e45eafb45 = { package = "env_logger", version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
 env_logger-ca01ad9e24f5d932 = { package = "env_logger", version = "0.7", features = ["atty", "humantime", "regex", "termcolor"] }
+errno = { version = "0.2", default-features = false }
 failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 failure_derive = { version = "0.1", default-features = false }
+fake-simd = { version = "0.1", default-features = false }
 fixedbitset = { version = "0.2", default-features = false }
+flate2 = { version = "1", features = ["miniz_oxide", "rust_backend"] }
+fnv = { version = "1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
 fs_extra = { version = "1", default-features = false }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1", features = ["use_std", "with-deprecated"] }
+futures-468e82937335b1c9 = { package = "futures", version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3", default-features = false, features = ["std"] }
 futures-macro = { version = "0.3", default-features = false }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-timer = { version = "3", default-features = false }
+futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.12", default-features = false }
+get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
 glob = { version = "0.3", default-features = false }
+goldenfile = { version = "1", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
+h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+headers = { version = "0.3", default-features = false }
+headers-core = { version = "0.2", default-features = false }
 heck = { version = "0.3", default-features = false }
+hex = { version = "0.4", features = ["std"] }
+hex_fmt = { version = "0.3", default-features = false }
+hmac = { version = "0.7", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
+http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+httparse = { version = "1", features = ["std"] }
 humantime = { version = "1", default-features = false }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
+hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper-rustls = { version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+include_dir = { version = "0.5" }
 include_dir_impl = { version = "0.5", default-features = false }
 indexmap = { version = "1", default-features = false }
+input_buffer = { version = "0.3", default-features = false }
+iovec = { version = "0.1", default-features = false }
 itertools-c38e5c1d305a1b54 = { package = "itertools", version = "0.8", features = ["use_std"] }
+itertools-274715c4dabd11b0 = { package = "itertools", version = "0.9", features = ["use_std"] }
+itoa = { version = "0.4", features = ["std"] }
+jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
 jobserver = { version = "0.1", default-features = false }
+k8s-openapi = { version = "0.7", default-features = false, features = ["v1_15"] }
+keccak = { version = "0.1", default-features = false }
+kube = { version = "0.27", features = ["k8s-openapi", "native-tls", "openapi", "openssl"] }
 lazy_static = { version = "1", default-features = false }
 lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", features = ["extra_traits", "std"] }
+libfuzzer-sys = { version = "0.3", default-features = false }
 libloading = { version = "0.5", default-features = false }
+librocksdb_sys = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
+libtitan_sys = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
+libz-sys = { version = "1", default-features = false, features = ["static"] }
+linked-hash-map = { version = "0.5", default-features = false }
+lock_api = { version = "0.3", default-features = false }
+log-468e82937335b1c9 = { package = "log", version = "0.3", features = ["use_std"] }
 log-9fbad63c4bcf4a8f = { package = "log", version = "0.4", default-features = false, features = ["serde", "std"] }
+lru-cache = { version = "0.1", default-features = false }
+lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
+matches = { version = "0.1", default-features = false }
+maybe-uninit = { version = "2", default-features = false }
+md5 = { version = "0.7", features = ["std"] }
 memchr = { version = "2", features = ["std", "use_std"] }
+memoffset = { version = "0.5", default-features = false }
+memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
+mime-6f8ce4dd05d13bba = { package = "mime", version = "0.2", default-features = false }
+mime-468e82937335b1c9 = { package = "mime", version = "0.3", default-features = false }
+mime_guess-dff4ba8e3ae991db = { package = "mime_guess", version = "1", default-features = false }
+mime_guess-f595c2ba2a3f28df = { package = "mime_guess", version = "2", features = ["rev-mappings"] }
+miniz_oxide = { version = "0.3", default-features = false }
+mio = { version = "0.6", features = ["with-deprecated"] }
+mirai-annotations = { version = "1", default-features = false }
 multimap = { version = "0.8", default-features = false }
+multipart = { version = "0.16", default-features = false, features = ["buf_redux", "httparse", "quick-error", "safemem", "server", "twoway"] }
+net2 = { version = "0.2", features = ["duration"] }
+nibble_vec = { version = "0.0.4", default-features = false }
+nodrop = { version = "0.1", default-features = false }
+nohash-hasher = { version = "0.2", features = ["std"] }
 nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
+num = { version = "0.2", features = ["num-bigint", "std"] }
+num-bigint = { version = "0.2", default-features = false, features = ["std"] }
+num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-derive = { version = "0.3", default-features = false }
+num-integer = { version = "0.1", default-features = false, features = ["std"] }
+num-iter = { version = "0.1", default-features = false, features = ["std"] }
+num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
+num-traits = { version = "0.2", features = ["std"] }
+num_cpus = { version = "1", default-features = false }
+numtoa = { version = "0.1", default-features = false, features = ["std"] }
+once_cell = { version = "1", features = ["std"] }
+oorandom = { version = "11", default-features = false }
+opaque-debug = { version = "0.2", default-features = false }
+openssl = { version = "0.10", default-features = false }
+openssl-sys = { version = "0.9", default-features = false }
+ordered-float = { version = "1", features = ["std"] }
+pairing = { version = "0.14", features = ["u128-support"] }
+parity-multiaddr = { version = "0.7", default-features = false }
+parity-multihash = { version = "0.2", default-features = false }
+parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
+parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
+paste = { version = "0.1", default-features = false }
 paste-impl = { version = "0.1", default-features = false }
+pbkdf2 = { version = "0.3", features = ["base64", "hmac", "include_simple", "rand", "sha2", "subtle"] }
 peeking_take_while = { version = "0.1", default-features = false }
+percent-encoding-dff4ba8e3ae991db = { package = "percent-encoding", version = "1", default-features = false }
+percent-encoding-f595c2ba2a3f28df = { package = "percent-encoding", version = "2", default-features = false }
 petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
 phf = { version = "0.7", default-features = false, features = ["unicase"] }
 phf_codegen = { version = "0.7", default-features = false }
 phf_generator = { version = "0.7", default-features = false }
 phf_shared = { version = "0.7", default-features = false, features = ["unicase"] }
+pin-project = { version = "0.4", default-features = false }
 pin-project-internal = { version = "0.4", default-features = false }
+pin-project-lite = { version = "0.1", default-features = false }
+pin-utils = { version = "0.1.0-alpha.4", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
+plotters = { version = "0.2", default-features = false, features = ["area_series", "line_series", "svg"] }
+pretty = { version = "0.9", default-features = false }
+prettydiff = { version = "0.3", default-features = false }
+prettytable-rs = { version = "0.8", features = ["csv", "win_crlf"] }
 proc-macro-error = { version = "0.4", default-features = false }
 proc-macro-error-attr = { version = "0.4", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
+proc-macro-nested = { version = "0.1", default-features = false }
 proc-macro2-9fbad63c4bcf4a8f = { package = "proc-macro2", version = "0.4", features = ["proc-macro"] }
 proc-macro2-dff4ba8e3ae991db = { package = "proc-macro2", version = "1", features = ["proc-macro"] }
+prometheus = { version = "0.8", default-features = false }
+proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
 proptest-derive = { version = "0.1", default-features = false }
 prost = { version = "0.6", features = ["prost-derive"] }
 prost-build = { version = "0.6", default-features = false }
 prost-derive = { version = "0.6", default-features = false }
 prost-types = { version = "0.6", default-features = false }
+qstring = { version = "0.7", default-features = false }
 quick-error = { version = "1", default-features = false }
 quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
 quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+radium = { version = "0.3", default-features = false }
+radix_trie = { version = "0.1", default-features = false }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
 rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
 rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+rand04 = { version = "0.1", default-features = false, features = ["std"] }
+rand04_compat = { version = "0.1", features = ["std"] }
 rand_chacha = { version = "0.1", default-features = false }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
 rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
@@ -493,50 +652,179 @@ rand_os = { version = "0.1", default-features = false }
 rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
 rand_xorshift = { version = "0.1", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+ref-cast = { version = "1", default-features = false }
 ref-cast-impl = { version = "1", default-features = false }
 regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata = { version = "0.1", default-features = false }
 regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.5", default-features = false }
+rental = { version = "0.5", features = ["std"] }
 rental-impl = { version = "0.5", default-features = false }
+reqwest = { version = "0.10", default-features = false, features = ["__tls", "async-compression", "blocking", "default-tls", "gzip", "hyper-rustls", "hyper-tls", "json", "native-tls", "native-tls-crate", "rustls", "rustls-tls", "serde_json", "stream", "tokio-rustls", "tokio-tls", "webpki-roots"] }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
+ripemd160 = { version = "0.8", features = ["std"] }
+rocksdb = { git = "https://github.com/tikv/rust-rocksdb.git", rev = "72e45c3f3283302c825d53c3cd7154f4cd9e8f5b" }
+rusoto_core = { version = "0.42", default-features = false, features = ["hyper-rustls", "rustls"] }
+rusoto_credential = { version = "0.42", default-features = false }
+rusoto_ec2 = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_ecr = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_ecs = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_s3 = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_signature = { version = "0.42", default-features = false }
+rust_decimal = { version = "1", features = ["serde"] }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc-hash = { version = "1", features = ["std"] }
 rustc_version = { version = "0.2", default-features = false }
+rustls = { version = "0.16", features = ["log", "logging"] }
 rustversion = { version = "1", default-features = false }
+rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
+rustyline = { version = "6", features = ["dirs", "with-dirs"] }
+ryu = { version = "1", default-features = false }
+safemem = { version = "0.3", features = ["std"] }
+same-file = { version = "1", default-features = false }
+scoped-tls = { version = "1", default-features = false }
+scopeguard = { version = "1", default-features = false }
+sct = { version = "0.6", default-features = false }
 semver = { version = "0.9" }
+semver-parser = { version = "0.7", default-features = false }
 serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
+serde-value = { version = "0.6", default-features = false }
 serde_derive = { version = "1" }
+serde_json = { version = "1", features = ["std"] }
+serde_urlencoded = { version = "0.6", default-features = false }
+serde_yaml = { version = "0.8", default-features = false }
+sha-1 = { version = "0.8", features = ["std"] }
+sha2 = { version = "0.8", features = ["std"] }
+sha3 = { version = "0.8", features = ["std"] }
 shlex = { version = "0.1", default-features = false }
+simplelog = { version = "0.7", features = ["term"] }
 siphasher = { version = "0.2", default-features = false }
+slab = { version = "0.4", default-features = false }
+smallvec-3b31131e45eafb45 = { package = "smallvec", version = "0.6", features = ["std"] }
+smallvec-dff4ba8e3ae991db = { package = "smallvec", version = "1", default-features = false }
+snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
+snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
+spin = { version = "0.5", default-features = false }
+stable_deref_trait = { version = "1", default-features = false, features = ["std"] }
+static_assertions = { version = "1", default-features = false }
+statistical = { version = "1", default-features = false }
+stats_alloc = { version = "0.1" }
+string = { version = "0.2", features = ["bytes"] }
 strsim = { version = "0.8", default-features = false }
+structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
+structopt-468e82937335b1c9 = { package = "structopt", version = "0.3" }
 structopt-derive-6f8ce4dd05d13bba = { package = "structopt-derive", version = "0.2", default-features = false }
 structopt-derive-9fbad63c4bcf4a8f = { package = "structopt-derive", version = "0.4", default-features = false }
+strum = { version = "0.18", default-features = false }
 strum_macros = { version = "0.18", default-features = false }
+subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
 subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 syn-mid = { version = "0.5", default-features = false }
 synstructure = { version = "0.12", features = ["proc-macro"] }
 tempfile = { version = "3", default-features = false }
+term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
+term-3b31131e45eafb45 = { package = "term", version = "0.6" }
 termcolor = { version = "1", default-features = false }
+termion = { version = "1", default-features = false }
 textwrap = { version = "0.11", default-features = false }
+thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
+threshold_crypto = { version = "0.3", default-features = false }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+time-6f8ce4dd05d13bba = { package = "time", version = "0.2", features = ["deprecated", "libc", "std", "winapi"] }
+time-macros = { version = "0.1", default-features = false }
 time-macros-impl = { version = "0.1", default-features = false }
+tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1", features = ["keccak"] }
+tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
+tinytemplate = { version = "1", default-features = false }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
+tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["blocking", "dns", "fnv", "fs", "full", "futures-core", "io-driver", "io-std", "io-util", "iovec", "lazy_static", "libc", "macros", "memchr", "mio", "mio-named-pipes", "mio-uds", "net", "num_cpus", "process", "rt-core", "rt-threaded", "rt-util", "signal", "signal-hook-registry", "slab", "stream", "sync", "tcp", "time", "tokio-macros", "udp", "uds", "winapi"] }
+tokio-buf = { version = "0.1", features = ["either", "util"] }
+tokio-codec = { version = "0.1", default-features = false }
+tokio-current-thread = { version = "0.1", default-features = false }
+tokio-executor = { version = "0.1", default-features = false }
+tokio-fs = { version = "0.1", default-features = false }
+tokio-io = { version = "0.1", default-features = false }
 tokio-macros = { version = "0.2", default-features = false }
+tokio-process = { version = "0.2", default-features = false }
+tokio-reactor = { version = "0.1", default-features = false }
+tokio-retry = { version = "0.2", default-features = false }
+tokio-rustls = { version = "0.10", default-features = false }
+tokio-sync = { version = "0.1", default-features = false }
+tokio-tcp = { version = "0.1", default-features = false }
+tokio-threadpool = { version = "0.1", default-features = false }
+tokio-timer = { version = "0.2", default-features = false }
+tokio-tungstenite = { version = "0.10", default-features = false }
+tokio-udp = { version = "0.1", default-features = false }
+tokio-util-6f8ce4dd05d13bba = { package = "tokio-util", version = "0.2", features = ["codec"] }
+tokio-util-468e82937335b1c9 = { package = "tokio-util", version = "0.3", features = ["codec"] }
+toml = { version = "0.5" }
+tonic = { version = "0.1", features = ["async-trait", "codegen", "hyper", "prost", "prost-derive", "tokio", "tower", "tower-balance", "tower-load", "tracing-futures", "transport"] }
 tonic-build = { version = "0.1", features = ["rustfmt", "transport"] }
+tower = { version = "0.3", features = ["full", "log"] }
+tower-balance = { version = "0.3", features = ["log"] }
+tower-buffer = { version = "0.3", default-features = false, features = ["log"] }
+tower-discover = { version = "0.3", default-features = false }
+tower-layer = { version = "0.3", default-features = false }
+tower-limit = { version = "0.3", default-features = false }
+tower-load = { version = "0.3", default-features = false }
+tower-load-shed = { version = "0.3", default-features = false }
+tower-make = { version = "0.3", default-features = false, features = ["connect", "tokio"] }
+tower-ready-cache = { version = "0.3", default-features = false }
+tower-retry = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tower-timeout = { version = "0.3", default-features = false }
+tower-util = { version = "0.3", features = ["call-all", "futures-util"] }
+tracing = { version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-attributes = { version = "0.1", default-features = false }
+tracing-core = { version = "0.1", default-features = false, features = ["lazy_static", "std"] }
+tracing-futures = { version = "0.2", features = ["pin-project", "std", "std-future"] }
+try-lock = { version = "0.2", default-features = false }
+ttl_cache = { version = "0.5" }
+tungstenite = { version = "0.10", default-features = false }
+twoway = { version = "0.1", features = ["use_std"] }
+typed-arena = { version = "2", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase-dff4ba8e3ae991db = { package = "unicase", version = "1", default-features = false }
 unicase-f595c2ba2a3f28df = { package = "unicase", version = "2", default-features = false }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1", default-features = false }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+unsigned-varint = { version = "0.3", default-features = false }
+untrusted = { version = "0.7", default-features = false }
+ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
+url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
+url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
+urlencoding = { version = "1", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
 vec_map = { version = "0.8", default-features = false }
 version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", default-features = false }
 version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
+walkdir = { version = "2", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
+want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+warp = { version = "0.2", features = ["multipart", "tokio-tungstenite", "websocket"] }
+webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
+webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
+webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
 which = { version = "3", default-features = false }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6", features = ["std", "u64_backend"] }
+xml-rs = { version = "0.8", default-features = false }
+yaml-rust = { version = "0.4", default-features = false }
+yamux = { version = "0.4", default-features = false }
+zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 zeroize_derive = { version = "1", default-features = false }
+zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
@@ -2,142 +2,558 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_libra_f0091a4
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'none'
-# output-single-feature = false
-# dep-format-version = '3'
-# workspace-hack-line-style = 'version-only'
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = true
+# dep-format-version = '1'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['powerpc64-wrs-vxworks', 'thumbv6m-none-eabi']
 # [[traversal-excludes.ids]]
-# name = 'crypto-mac'
-# version = '0.7.0'
+# name = 'csv'
+# version = '1.1.3'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'errno'
-# version = '0.2.4'
+# name = 'thiserror-impl'
+# version = '1.0.11'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'fuchsia-zircon-sys'
-# version = '0.3.3'
+# name = 'xml-rs'
+# version = '0.8.0'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'libra-node'
+# version = '0.1.0'
+# workspace-path = 'libra-node'
+#
+# [[final-excludes.ids]]
+# name = 'nibble_vec'
+# version = '0.0.4'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'hex_fmt'
-# version = '0.3.0'
+# [[final-excludes.ids]]
+# name = 'parity-multiaddr'
+# version = '0.7.2'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'libz-sys'
-# version = '1.0.25'
+# [[final-excludes.ids]]
+# name = 'percent-encoding'
+# version = '2.1.0'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
+# [[final-excludes.ids]]
 # name = 'proc-macro2'
 # version = '1.0.8'
 # crates-io = true
-# [[final-excludes.ids]]
-# name = 'linked-hash-map'
-# version = '0.5.2'
-# crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'net2'
-# version = '0.2.33'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'num'
-# version = '0.2.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'rand_os'
-# version = '0.1.3'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'stable_deref_trait'
-# version = '1.1.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'tokio-uds'
-# version = '0.2.6'
+# name = 'tower-load'
+# version = '0.3.0'
 # crates-io = true
 
 [dependencies]
-backtrace = { version = "0.3", features = ["serialize-serde"] }
-byteorder = { version = "1", features = ["i128"] }
-bytes = { version = "0.4", default-features = false, features = ["either"] }
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "2" }
-curve25519-dalek = { git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+adler32 = { version = "1", default-features = false }
+aho-corasick = { version = "0.7", features = ["std"] }
+ansi_term-274715c4dabd11b0 = { package = "ansi_term", version = "0.9", default-features = false }
+anyhow = { version = "1", features = ["std"] }
+arbitrary = { version = "0.4", default-features = false }
+arc-swap = { version = "0.4", default-features = false }
+arrayref = { version = "0.3", default-features = false }
+arrayvec-9fbad63c4bcf4a8f = { package = "arrayvec", version = "0.4", default-features = false }
+arrayvec-d8f496e17d97b5cb = { package = "arrayvec", version = "0.5", features = ["std"] }
+assert_approx_eq = { version = "1", default-features = false }
+assert_matches = { version = "1", default-features = false }
+async-stream = { version = "0.2", default-features = false }
+atty = { version = "0.2", default-features = false }
+backtrace = { version = "0.3", features = ["backtrace-sys", "dbghelp", "dladdr", "libbacktrace", "libunwind", "serde", "serialize-serde", "std"] }
+backtrace-sys = { version = "0.1", default-features = false }
+base64-93f6ce9d446188ac = { package = "base64", version = "0.10", default-features = false }
+base64-a6292c17cd707f01 = { package = "base64", version = "0.11", features = ["std"] }
+base64-274715c4dabd11b0 = { package = "base64", version = "0.9", default-features = false }
+bincode = { version = "1", default-features = false }
+bit-set = { version = "0.5", features = ["std"] }
+bit-vec-d8f496e17d97b5cb = { package = "bit-vec", version = "0.5", default-features = false, features = ["std"] }
+bit-vec-3b31131e45eafb45 = { package = "bit-vec", version = "0.6", features = ["std"] }
+bitflags = { version = "1" }
+bitvec = { version = "0.10", features = ["alloc", "std"] }
+blake2 = { version = "0.8", default-features = false }
+blake2-rfc = { version = "0.2", features = ["std"] }
+block-buffer = { version = "0.7", default-features = false }
+block-padding = { version = "0.1", default-features = false }
+bs58 = { version = "0.3", features = ["alloc", "std"] }
+byte-tools = { version = "0.3", default-features = false }
+byteorder = { version = "1", features = ["i128", "std"] }
+bytes-9fbad63c4bcf4a8f = { package = "bytes", version = "0.4", default-features = false, features = ["either"] }
+bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["std"] }
+bzip2-sys = { git = "https://github.com/alexcrichton/bzip2-rs.git", default-features = false }
+c_linked_list = { version = "1", default-features = false }
+cached = { version = "0.11", default-features = false }
+cast = { version = "0.2", features = ["std"] }
+cfg-if = { version = "0.1", default-features = false }
+chacha20-poly1305-aead = { version = "0.1", default-features = false }
+chashmap = { version = "2", default-features = false }
+chrono = { version = "0.4", features = ["clock", "serde", "std", "time"] }
+chunked_transfer = { version = "1", default-features = false }
+clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
+clear_on_drop = { version = "0.2", default-features = false }
+codespan-6f8ce4dd05d13bba = { package = "codespan", version = "0.2", default-features = false, features = ["serde", "serde_derive", "serialization"] }
+codespan-d8f496e17d97b5cb = { package = "codespan", version = "0.5", default-features = false }
+codespan-reporting-6f8ce4dd05d13bba = { package = "codespan-reporting", version = "0.2", default-features = false }
+codespan-reporting-d8f496e17d97b5cb = { package = "codespan-reporting", version = "0.5", default-features = false }
+constant_time_eq = { version = "0.1", default-features = false }
+cookie = { version = "0.12", default-features = false, features = ["percent-encode", "url"] }
+crc = { version = "1", features = ["std"] }
+crc32fast = { version = "1", features = ["std"] }
+criterion = { version = "0.3" }
+criterion-plot = { version = "0.4", default-features = false }
+crossbeam = { version = "0.7", features = ["crossbeam-channel", "crossbeam-deque", "crossbeam-queue", "std"] }
+crossbeam-channel-468e82937335b1c9 = { package = "crossbeam-channel", version = "0.3", default-features = false }
+crossbeam-channel-9fbad63c4bcf4a8f = { package = "crossbeam-channel", version = "0.4", default-features = false }
+crossbeam-deque = { version = "0.7", default-features = false }
+crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
+crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
+crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
+crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
+crunchy = { version = "0.2", features = ["limit_128"] }
+crypto-mac = { version = "0.7", default-features = false }
+ct-logs = { version = "0.6", default-features = false }
+ctrlc = { version = "3", default-features = false }
+curve25519-dalek-14725356451c5601 = { package = "curve25519-dalek", git = "https://github.com/calibra/curve25519-dalek.git", branch = "fiat", default-features = false, features = ["alloc", "curve25519-fiat", "fiat_u64_backend", "std", "u64_backend"] }
+curve25519-dalek-f595c2ba2a3f28df = { package = "curve25519-dalek", version = "2", default-features = false, features = ["alloc", "std", "u64_backend"] }
+data-encoding = { version = "2", default-features = false }
+difference = { version = "2" }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-ed25519-dalek = { git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
-either = { version = "1" }
-failure = { version = "0.1" }
-futures = { version = "0.3", features = ["io-compat"] }
-futures-channel = { version = "0.3", features = ["sink"] }
-futures-core = { version = "0.3" }
-futures-sink = { version = "0.3" }
-futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io-compat", "sink"] }
+dirs-dff4ba8e3ae991db = { package = "dirs", version = "1", default-features = false }
+dirs-f595c2ba2a3f28df = { package = "dirs", version = "2", default-features = false }
+dirs-sys = { version = "0.3", default-features = false }
+dtoa = { version = "0.4", default-features = false }
+ed25519-dalek-903978446b7dd55b = { package = "ed25519-dalek", git = "https://github.com/calibra/ed25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "serde", "std", "u64_backend"] }
+ed25519-dalek-64d47c1a8d1e1aed = { package = "ed25519-dalek", version = "1.0.0-pre.3", features = ["rand", "std", "u64_backend"] }
+either = { version = "1", features = ["use_std"] }
+encode_unicode = { version = "0.3", features = ["std"] }
+endian-type = { version = "0.1", default-features = false }
+errno = { version = "0.2", default-features = false }
+failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
+fake-simd = { version = "0.1", default-features = false }
+filecheck = { version = "0.4", default-features = false }
+fixedbitset = { version = "0.2", default-features = false }
+flate2 = { version = "1", default-features = false, features = ["miniz_oxide", "rust_backend"] }
+fnv = { version = "1", default-features = false }
+futures-c65f7effa3be6d31 = { package = "futures", version = "0.1", features = ["use_std", "with-deprecated"] }
+futures-468e82937335b1c9 = { package = "futures", version = "0.3", features = ["alloc", "async-await", "compat", "executor", "futures-executor", "io-compat", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures-cpupool = { version = "0.1", features = ["with-deprecated"] }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = { version = "0.3", default-features = false, features = ["std"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await", "async-await-macro", "channel", "compat", "futures-channel", "futures-io", "futures-macro", "futures-sink", "futures_01", "io", "io-compat", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std", "tokio-io"] }
+generic-array = { version = "0.12", default-features = false }
+get_if_addrs = { version = "0.5", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-itoa = { version = "0.4" }
-libc = { version = "0.2", features = ["extra_traits"] }
+goldenfile = { version = "1", default-features = false }
+h2-c65f7effa3be6d31 = { package = "h2", version = "0.1", default-features = false }
+h2-6f8ce4dd05d13bba = { package = "h2", version = "0.2", default-features = false }
+hex = { version = "0.4", features = ["std"] }
+hex_fmt = { version = "0.3", default-features = false }
+hmac = { version = "0.7", default-features = false }
+http-c65f7effa3be6d31 = { package = "http", version = "0.1", default-features = false }
+http-6f8ce4dd05d13bba = { package = "http", version = "0.2", default-features = false }
+http-body-c65f7effa3be6d31 = { package = "http-body", version = "0.1", default-features = false }
+http-body-468e82937335b1c9 = { package = "http-body", version = "0.3", default-features = false }
+httparse = { version = "1", features = ["std"] }
+hyper-5ef9efb8ec2df382 = { package = "hyper", version = "0.12", features = ["__internal_flaky_tests", "futures-cpupool", "net2", "runtime", "tokio", "tokio-executor", "tokio-reactor", "tokio-tcp", "tokio-threadpool", "tokio-timer"] }
+hyper-594e8ee84c453af0 = { package = "hyper", version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
+hyper-rustls-9067fe90e8c1f593 = { package = "hyper-rustls", version = "0.17", features = ["ct-logs", "tokio-runtime", "webpki-roots"] }
+idna-c65f7effa3be6d31 = { package = "idna", version = "0.1", default-features = false }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+indexmap = { version = "1", default-features = false }
+iovec = { version = "0.1", default-features = false }
+itertools = { version = "0.8", features = ["use_std"] }
+itoa = { version = "0.4", features = ["std"] }
+jemalloc-sys = { version = "0.3", default-features = false, features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
+jemallocator = { version = "0.3", features = ["background_threads_runtime_support", "profiling", "unprefixed_malloc_on_supported_platforms"] }
+keccak = { version = "0.1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["std"] }
+libfuzzer-sys = { version = "0.3", default-features = false }
+librocksdb_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+libtitan_sys = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+libz-sys = { version = "1", default-features = false, features = ["static"] }
+linked-hash-map = { version = "0.5", default-features = false }
+lock_api = { version = "0.3", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["libc", "use_std"] }
+lru-cache = { version = "0.1", default-features = false }
+lz4-sys = { git = "https://github.com/busyjay/lz4-rs.git", branch = "adjust-build", default-features = false }
+matches = { version = "0.1", default-features = false }
+maybe-uninit = { version = "2", default-features = false }
+md5 = { version = "0.7", features = ["std"] }
+memchr = { version = "2", features = ["std", "use_std"] }
+memoffset = { version = "0.5", default-features = false }
+memsec = { version = "0.5", features = ["alloc", "getrandom", "libc", "mach_o_sys", "use_os", "winapi"] }
+miniz_oxide = { version = "0.3", default-features = false }
+mio = { version = "0.6", features = ["with-deprecated"] }
+mirai-annotations = { version = "1", default-features = false }
+net2 = { version = "0.2", features = ["duration"] }
+nodrop = { version = "0.1", default-features = false }
+nohash-hasher = { version = "0.2", features = ["std"] }
+num = { version = "0.2", features = ["num-bigint", "std"] }
+num-bigint = { version = "0.2", default-features = false, features = ["std"] }
+num-complex = { version = "0.2", default-features = false, features = ["std"] }
 num-integer = { version = "0.1", default-features = false, features = ["std"] }
-num-traits = { version = "0.2" }
-petgraph = { version = "0.5" }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["i128_support"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
-rand_core = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-regex-syntax = { version = "0.6" }
-reqwest = { version = "0.10", default-features = false, features = ["blocking", "json", "rustls-tls"] }
-ring = { version = "0.16", features = ["std"] }
-rustls = { version = "0.16", features = ["dangerous_configuration"] }
-rusty-fork = { version = "0.2" }
-serde = { version = "1", features = ["derive", "rc"] }
-sha2 = { version = "0.8" }
-sha3 = { version = "0.8" }
-slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug"] }
-subtle = { version = "2" }
-tokio = { version = "0.2", features = ["full"] }
+num-iter = { version = "0.1", default-features = false, features = ["std"] }
+num-rational = { version = "0.2", default-features = false, features = ["bigint", "num-bigint", "std"] }
+num-traits = { version = "0.2", features = ["std"] }
+num_cpus = { version = "1", default-features = false }
+num_enum = { version = "0.4", features = ["std"] }
+numtoa = { version = "0.1", default-features = false, features = ["std"] }
+once_cell = { version = "1", features = ["std"] }
+opaque-debug = { version = "0.2", default-features = false }
+owning_ref = { version = "0.3", default-features = false }
+pairing = { version = "0.14", features = ["u128-support"] }
+parity-multihash = { version = "0.2", default-features = false }
+parking_lot-93f6ce9d446188ac = { package = "parking_lot", version = "0.10" }
+parking_lot-9fbad63c4bcf4a8f = { package = "parking_lot", version = "0.4", features = ["owning_ref"] }
+parking_lot-274715c4dabd11b0 = { package = "parking_lot", version = "0.9" }
+parking_lot_core-6f8ce4dd05d13bba = { package = "parking_lot_core", version = "0.2", default-features = false }
+parking_lot_core-3b31131e45eafb45 = { package = "parking_lot_core", version = "0.6", default-features = false }
+parking_lot_core-ca01ad9e24f5d932 = { package = "parking_lot_core", version = "0.7", default-features = false }
+pbkdf2 = { version = "0.3", features = ["base64", "hmac", "include_simple", "rand", "sha2", "subtle"] }
+percent-encoding = { version = "1", default-features = false }
+petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
+pin-project = { version = "0.4", default-features = false }
+pin-project-lite = { version = "0.1", default-features = false }
+pin-utils = { version = "0.1.0-alpha.4", default-features = false }
+pretty = { version = "0.9", default-features = false }
+prettydiff = { version = "0.3", default-features = false }
+prettytable-rs = { version = "0.8", features = ["csv", "win_crlf"] }
+proc-macro-nested = { version = "0.1", default-features = false }
+prometheus = { version = "0.7", default-features = false }
+proptest = { version = "0.9", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "quick-error", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+prost = { version = "0.6", features = ["prost-derive"] }
+qstring = { version = "0.7", default-features = false }
+quick-error = { version = "1", default-features = false }
+radix_trie = { version = "0.1", default-features = false }
+rand-9fbad63c4bcf4a8f = { package = "rand", version = "0.4", features = ["libc", "std"] }
+rand-d8f496e17d97b5cb = { package = "rand", version = "0.5", features = ["alloc", "cloudabi", "fuchsia-cprng", "libc", "std", "winapi"] }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "i128_support", "rand_os", "std"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+rand04 = { version = "0.1", default-features = false, features = ["std"] }
+rand04_compat = { version = "0.1", features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os-c65f7effa3be6d31 = { package = "rand_os", version = "0.1", default-features = false }
+rand_os-6f8ce4dd05d13bba = { package = "rand_os", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_xorshift = { version = "0.1", default-features = false }
+rand_xoshiro = { version = "0.3", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+ref-cast = { version = "1", default-features = false }
+regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+remove_dir_all = { version = "0.5", default-features = false }
+rental = { version = "0.5", features = ["std"] }
+reqwest = { version = "0.10", default-features = false, features = ["__tls", "blocking", "hyper-rustls", "json", "rustls", "rustls-tls", "serde_json", "tokio-rustls", "webpki-roots"] }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "lazy_static", "std"] }
+ripemd160 = { version = "0.8", features = ["std"] }
+rocksdb = { git = "https://github.com/pingcap/rust-rocksdb.git", rev = "3cd18c44d160a3cdba586d6502d51b7cc67efc59" }
+rusoto_core = { version = "0.42", default-features = false, features = ["hyper-rustls", "rustls"] }
+rusoto_credential = { version = "0.42", default-features = false }
+rusoto_ec2 = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_ecr = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_ecs = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_s3 = { version = "0.42", default-features = false, features = ["rustls"] }
+rusoto_signature = { version = "0.42", default-features = false }
+rust_decimal = { version = "1", features = ["serde"] }
+rustc-demangle = { version = "0.1", default-features = false }
+rustls = { version = "0.16", features = ["log", "logging"] }
+rusty-fork = { version = "0.2", features = ["timeout", "wait-timeout"] }
+rustyline = { version = "6", features = ["dirs", "with-dirs"] }
+ryu = { version = "1", default-features = false }
+safemem = { version = "0.3", features = ["std"] }
+same-file = { version = "1", default-features = false }
+scopeguard = { version = "1", default-features = false }
+sct = { version = "0.6", default-features = false }
+serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1", features = ["std"] }
+serde_urlencoded = { version = "0.6", default-features = false }
+sha-1 = { version = "0.8", default-features = false }
+sha2 = { version = "0.8", features = ["std"] }
+sha3 = { version = "0.8", features = ["std"] }
+shlex = { version = "0.1", default-features = false }
+simplelog = { version = "0.7", features = ["term"] }
+slab = { version = "0.4", default-features = false }
+slog = { version = "2", features = ["max_level_debug", "max_level_trace", "release_max_level_debug", "std"] }
+slog-async = { version = "2" }
+slog-envlogger = { version = "2", features = ["regex"] }
+slog-scope = { version = "4", default-features = false }
+slog-stdlog = { version = "4", default-features = false }
+slog-term = { version = "2", default-features = false }
+smallvec-3b31131e45eafb45 = { package = "smallvec", version = "0.6", features = ["std"] }
+smallvec-dff4ba8e3ae991db = { package = "smallvec", version = "1", default-features = false }
+snappy-sys = { git = "https://github.com/busyjay/rust-snappy.git", branch = "static-link", default-features = false }
+snow = { version = "0.6", features = ["blake2-rfc", "chacha20-poly1305-aead", "default-resolver", "rand", "ring", "ring-accelerated", "ring-resolver", "sha2", "x25519-dalek"] }
+spin = { version = "0.5", default-features = false }
+stable_deref_trait = { version = "1", features = ["std"] }
+static_assertions = { version = "1", default-features = false }
+statistical = { version = "1", default-features = false }
+stats_alloc = { version = "0.1" }
+string = { version = "0.2", features = ["bytes"] }
+strsim = { version = "0.8", default-features = false }
+structopt-6f8ce4dd05d13bba = { package = "structopt", version = "0.2" }
+structopt-468e82937335b1c9 = { package = "structopt", version = "0.3" }
+strum = { version = "0.17", default-features = false }
+subtle-dff4ba8e3ae991db = { package = "subtle", version = "1", default-features = false }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
+take_mut = { version = "0.2", default-features = false }
+tempfile = { version = "3", default-features = false }
+term-d8f496e17d97b5cb = { package = "term", version = "0.5" }
+term-3b31131e45eafb45 = { package = "term", version = "0.6" }
+termcolor = { version = "1", default-features = false }
+termion = { version = "1", default-features = false }
+textwrap = { version = "0.11", default-features = false }
+thiserror = { version = "1", default-features = false }
+thread-id = { version = "3", default-features = false }
+thread_local = { version = "1", default-features = false }
+threshold_crypto = { version = "0.3", default-features = false }
+time = { version = "0.1", default-features = false }
+tiny-keccak-dff4ba8e3ae991db = { package = "tiny-keccak", version = "1", features = ["keccak"] }
+tiny-keccak-f595c2ba2a3f28df = { package = "tiny-keccak", version = "2", features = ["sha3"] }
+tinytemplate = { version = "1", default-features = false }
+tokio-c65f7effa3be6d31 = { package = "tokio", version = "0.1", features = ["bytes", "codec", "fs", "io", "mio", "num_cpus", "reactor", "rt-full", "sync", "tcp", "timer", "tokio-codec", "tokio-current-thread", "tokio-executor", "tokio-fs", "tokio-io", "tokio-reactor", "tokio-sync", "tokio-tcp", "tokio-threadpool", "tokio-timer", "tokio-udp", "tokio-uds", "udp", "uds"] }
+tokio-6f8ce4dd05d13bba = { package = "tokio", version = "0.2", features = ["blocking", "dns", "fnv", "fs", "full", "futures-core", "io-driver", "io-std", "io-util", "iovec", "lazy_static", "libc", "macros", "memchr", "mio", "mio-named-pipes", "mio-uds", "net", "num_cpus", "process", "rt-core", "rt-threaded", "rt-util", "signal", "signal-hook-registry", "slab", "stream", "sync", "tcp", "time", "tokio-macros", "udp", "uds"] }
+tokio-buf = { version = "0.1", features = ["either", "util"] }
+tokio-codec = { version = "0.1", default-features = false }
+tokio-current-thread = { version = "0.1", default-features = false }
+tokio-executor = { version = "0.1", default-features = false }
+tokio-fs = { version = "0.1", default-features = false }
+tokio-io = { version = "0.1", default-features = false }
+tokio-process = { version = "0.2", default-features = false }
+tokio-reactor = { version = "0.1", default-features = false }
+tokio-retry = { version = "0.2", default-features = false }
+tokio-rustls-93f6ce9d446188ac = { package = "tokio-rustls", version = "0.10", default-features = false }
+tokio-sync = { version = "0.1", default-features = false }
+tokio-tcp = { version = "0.1", default-features = false }
+tokio-threadpool = { version = "0.1", default-features = false }
+tokio-timer = { version = "0.2", default-features = false }
+tokio-udp = { version = "0.1", default-features = false }
+tokio-util = { version = "0.2", features = ["codec"] }
 toml = { version = "0.5" }
-ureq = { version = "0.11", features = ["json"] }
-x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+tonic = { version = "0.1", features = ["async-trait", "codegen", "hyper", "prost", "prost-derive", "tokio", "tower", "tower-balance", "tower-load", "tracing-futures", "transport"] }
+tower = { version = "0.3", features = ["full", "log"] }
+tower-balance = { version = "0.3", features = ["log"] }
+tower-buffer = { version = "0.3", default-features = false, features = ["log"] }
+tower-discover = { version = "0.3", default-features = false }
+tower-layer = { version = "0.3", default-features = false }
+tower-limit = { version = "0.3", default-features = false }
+tower-load-shed = { version = "0.3", default-features = false }
+tower-make = { version = "0.3", default-features = false, features = ["connect", "tokio"] }
+tower-ready-cache = { version = "0.3", default-features = false }
+tower-retry = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tower-timeout = { version = "0.3", default-features = false }
+tower-util = { version = "0.3", features = ["call-all", "futures-util"] }
+tracing = { version = "0.1", features = ["log", "std"] }
+tracing-core = { version = "0.1", default-features = false, features = ["lazy_static", "std"] }
+tracing-futures = { version = "0.2", features = ["pin-project", "std", "std-future"] }
+try-lock = { version = "0.2", default-features = false }
+ttl_cache = { version = "0.5" }
+typed-arena = { version = "2", features = ["std"] }
+typenum = { version = "1", default-features = false }
+unicode-bidi = { version = "0.3" }
+unicode-normalization = { version = "0.1", default-features = false }
+unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
+unsigned-varint = { version = "0.3", default-features = false }
+untrusted = { version = "0.7", default-features = false }
+ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
+url-dff4ba8e3ae991db = { package = "url", version = "1", default-features = false }
+url-f595c2ba2a3f28df = { package = "url", version = "2", default-features = false }
+vec_map = { version = "0.8", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
+walkdir = { version = "2", default-features = false }
+want-6f8ce4dd05d13bba = { package = "want", version = "0.2", default-features = false }
+want-468e82937335b1c9 = { package = "want", version = "0.3", default-features = false }
+webpki = { version = "0.21", features = ["std", "trust_anchor_util"] }
+webpki-roots-9067fe90e8c1f593 = { package = "webpki-roots", version = "0.17", default-features = false }
+webpki-roots-954333c9f9249c96 = { package = "webpki-roots", version = "0.18", default-features = false }
+x25519-dalek-e7fe84ab14e05bdb = { package = "x25519-dalek", git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
+x25519-dalek-3b31131e45eafb45 = { package = "x25519-dalek", version = "0.6", features = ["std", "u64_backend"] }
+yamux = { version = "0.4", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
+zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
 [build-dependencies]
-byteorder = { version = "1", features = ["i128"] }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-clap = { version = "2" }
+aho-corasick = { version = "0.7", features = ["std"] }
+anyhow = { version = "1", features = ["std"] }
+async-stream-impl = { version = "0.2", default-features = false }
+async-trait = { version = "0.1", default-features = false }
+atty = { version = "0.2", default-features = false }
+autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
+autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
+bindgen = { version = "0.51", features = ["clap", "env_logger", "log", "logging", "which", "which-rustfmt"] }
+bitflags = { version = "1" }
+build_const = { version = "0.2", features = ["std"] }
+byteorder = { version = "1", features = ["i128", "std"] }
+bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["std"] }
+cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
+cexpr = { version = "0.3", default-features = false }
+cfg-if = { version = "0.1", default-features = false }
+clang-sys = { version = "0.28", default-features = false, features = ["clang_6_0", "gte_clang_3_6", "gte_clang_3_7", "gte_clang_3_8", "gte_clang_3_9", "gte_clang_4_0", "gte_clang_5_0", "gte_clang_6_0", "libloading", "runtime"] }
+clap = { version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "vec_map"] }
+clear_on_drop = { version = "0.2", default-features = false }
+cmake = { version = "0.1", default-features = false }
+derivative = { version = "1", default-features = false, features = ["use_core"] }
 digest = { version = "0.8", default-features = false, features = ["std"] }
-either = { version = "1" }
+either = { version = "1", features = ["use_std"] }
+env_logger = { version = "0.6", features = ["atty", "humantime", "regex", "termcolor"] }
+failure_derive = { version = "0.1", default-features = false }
+fixedbitset = { version = "0.2", default-features = false }
+fs_extra = { version = "1", default-features = false }
+futures-macro = { version = "0.3", default-features = false }
+generic-array = { version = "0.12", default-features = false }
 getrandom = { version = "0.1", default-features = false, features = ["std"] }
-libc = { version = "0.2", features = ["extra_traits"] }
+glob = { version = "0.3", default-features = false }
+heck = { version = "0.3", default-features = false }
+humantime = { version = "1", default-features = false }
+indexmap = { version = "1", default-features = false }
+itertools = { version = "0.8", features = ["use_std"] }
+jobserver = { version = "0.1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["std"] }
+libloading = { version = "0.5", default-features = false }
 log = { version = "0.4", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["use_std"] }
-petgraph = { version = "0.5" }
-proc-macro2 = { version = "0.4" }
-quote = { version = "0.6" }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
-rand_core = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-regex-syntax = { version = "0.6", default-features = false, features = ["unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-serde = { version = "1", features = ["derive", "rc"] }
-subtle = { version = "2" }
-syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["extra-traits", "full", "visit"] }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+memchr = { version = "2", features = ["std", "use_std"] }
+multimap = { version = "0.8", default-features = false }
+nom = { version = "4", features = ["alloc", "std", "verbose-errors"] }
+num-derive = { version = "0.3", default-features = false }
+num_enum_derive = { version = "0.4", default-features = false, features = ["std"] }
+peeking_take_while = { version = "0.1", default-features = false }
+petgraph = { version = "0.5", features = ["graphmap", "matrix_graph", "stable_graph"] }
+pin-project-internal = { version = "0.4", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
+proc-macro-crate = { version = "0.1", default-features = false }
+proc-macro-error = { version = "0.4", default-features = false }
+proc-macro-error-attr = { version = "0.4", default-features = false }
+proc-macro-hack = { version = "0.5", default-features = false }
+proc-macro2 = { version = "0.4", features = ["proc-macro"] }
+proptest-derive = { version = "0.1", default-features = false }
+prost = { version = "0.6", features = ["prost-derive"] }
+prost-build = { version = "0.6", default-features = false }
+prost-derive = { version = "0.6", default-features = false }
+prost-types = { version = "0.6", default-features = false }
+quick-error = { version = "1", default-features = false }
+quote-3b31131e45eafb45 = { package = "quote", version = "0.6", features = ["proc-macro"] }
+quote-dff4ba8e3ae991db = { package = "quote", version = "1", features = ["proc-macro"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false, features = ["alloc", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+ref-cast-impl = { version = "1", default-features = false }
+regex = { version = "1", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax = { version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+remove_dir_all = { version = "0.5", default-features = false }
+rental-impl = { version = "0.5", default-features = false }
+rustc-hash = { version = "1", features = ["std"] }
+rustc_version = { version = "0.2", default-features = false }
+rustversion = { version = "1", default-features = false }
+semver = { version = "0.9" }
+semver-parser = { version = "0.7", default-features = false }
+serde = { version = "1", features = ["derive", "rc", "serde_derive", "std"] }
+serde_derive = { version = "1" }
+shlex = { version = "0.1", default-features = false }
+strsim = { version = "0.8", default-features = false }
+structopt-derive-6f8ce4dd05d13bba = { package = "structopt-derive", version = "0.2", default-features = false }
+structopt-derive-9fbad63c4bcf4a8f = { package = "structopt-derive", version = "0.4", default-features = false }
+strum_macros = { version = "0.17", default-features = false }
+subtle-f595c2ba2a3f28df = { package = "subtle", version = "2", features = ["i128", "std"] }
+syn-3575ec1268b04181 = { package = "syn", version = "0.15", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-mid = { version = "0.5", default-features = false }
+synstructure = { version = "0.12", features = ["proc-macro"] }
+tempfile = { version = "3", default-features = false }
+termcolor = { version = "1", default-features = false }
+textwrap = { version = "0.11", default-features = false }
+thread_local = { version = "1", default-features = false }
+tokio-macros = { version = "0.2", default-features = false }
 toml = { version = "0.5" }
+tonic-build = { version = "0.1", features = ["rustfmt", "transport"] }
+tracing-attributes = { version = "0.1", default-features = false }
+typenum = { version = "1", default-features = false }
+unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
+unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
+unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
+vec_map = { version = "0.8", default-features = false }
+version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", default-features = false }
+which = { version = "3", default-features = false }
+zeroize_derive = { version = "1", default-features = false }
 
 [target.powerpc64-wrs-vxworks.dependencies]
-hyper = { version = "0.13" }
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
+encoding_rs = { version = "0.8", default-features = false }
+futures-util = { version = "0.3" }
+hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19", features = ["ct-logs", "rustls-native-certs", "tokio-runtime"] }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", features = ["rev-mappings"] }
+mio-uds = { version = "0.6", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rustls = { version = "0.16", default-features = false, features = ["dangerous_configuration"] }
+rustls-native-certs = { version = "0.1", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
+tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+unicase = { version = "2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
+
+[target.powerpc64-wrs-vxworks.build-dependencies]
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+unicase = { version = "2", default-features = false }
+version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
 
 [target.thumbv6m-none-eabi.dependencies]
-hyper = { version = "0.13" }
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+encoding_rs = { version = "0.8", default-features = false }
+futures-util = { version = "0.3" }
+hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19", features = ["ct-logs", "rustls-native-certs", "tokio-runtime"] }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", features = ["rev-mappings"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rustls = { version = "0.16", default-features = false, features = ["dangerous_configuration"] }
+rustls-native-certs = { version = "0.1", default-features = false }
+tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
+unicase = { version = "2", default-features = false }
+
+[target.thumbv6m-none-eabi.build-dependencies]
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+unicase = { version = "2", default-features = false }
+version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-0.toml
@@ -2,100 +2,134 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'unify-if-both'
+# resolver = '3'
+# unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '4'
-# workspace-hack-line-style = 'version-only'
+# dep-format-version = '1'
+# workspace-hack-line-style = 'full'
 # platforms = ['armv7-sony-vita-newlibeabihf', 'sparc64-unknown-openbsd']
 # [[traversal-excludes.ids]]
-# name = 'string_cache_codegen'
-# version = '0.5.2'
+# name = 'axum-core'
+# version = '0.3.4'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'encode_unicode'
+# version = '0.3.6'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'humantime'
+# version = '2.1.0'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'overload'
+# version = '0.1.1'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'xmas-elf'
+# version = '0.9.0'
 # crates-io = true
 # [[final-excludes.ids]]
-# name = 'cargo-platform'
-# version = '0.1.3'
+# name = 'CoreFoundation-sys'
+# version = '0.1.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'gcd'
-# version = '2.3.0'
+# name = 'forth3'
+# version = '0.1.0'
+# workspace-path = 'source/forth3'
+#
+# [[final-excludes.ids]]
+# name = 'generator'
+# version = '0.7.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'semver'
-# version = '1.0.18'
+# name = 'memoffset'
+# version = '0.9.0'
 # crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'spitebuf'
+# version = '0.1.0'
+# workspace-path = 'source/spitebuf'
+#
+# [[final-excludes.ids]]
+# name = 'tracing-modality'
+# version = '0.1.0'
+# source = 'git+https://github.com/auxoncorp/modality-tracing-rs?rev=9c23c188466357e7ad0c618b4edfe9514e9bf764#9c23c188466357e7ad0c618b4edfe9514e9bf764'
 
 [dependencies]
 acpi = { version = "4", default-features = false }
-addr2line = { version = "0.20" }
+addr2line = { version = "0.20", default-features = false }
 adler = { version = "1", default-features = false }
-adler32 = { version = "1" }
-anstream = { version = "0.5" }
-anstyle = { version = "1" }
-anstyle-parse = { version = "0.2" }
+adler32 = { version = "1", features = ["std"] }
+anstream = { version = "0.5", features = ["auto", "wincon"] }
+anstyle = { version = "1", features = ["std"] }
+anstyle-parse = { version = "0.2", features = ["utf8"] }
 anstyle-query = { version = "1", default-features = false }
-anyhow = { version = "1" }
+anyhow = { version = "1", features = ["std"] }
 async-channel = { version = "1", default-features = false }
 async-lock = { version = "2", default-features = false }
-async-std = { version = "1", features = ["unstable"] }
+async-std = { version = "1", features = ["alloc", "async-channel", "async-global-executor", "async-io", "async-lock", "async-process", "crossbeam-utils", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "unstable", "wasm-bindgen-futures"] }
 atty = { version = "0.2", default-features = false }
-axum = { version = "0.6", features = ["ws"] }
-axum-core = { version = "0.3", default-features = false }
+axum = { version = "0.6", default-features = false }
 az = { version = "1", default-features = false }
-backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+backtrace = { version = "0.3", features = ["std"] }
 backtrace-ext = { version = "0.2", default-features = false }
 bare-metal = { version = "1", default-features = false }
-base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
-base64-647d43efb71741da = { package = "base64", version = "0.21" }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["std"] }
+base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
 bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
 bincode = { version = "1", default-features = false }
-bit-set = { version = "0.5" }
+bit-set = { version = "0.5", features = ["std"] }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bit_field = { version = "0.10", default-features = false }
 bitfield = { version = "0.14", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
 bootloader_api = { version = "0.11", default-features = false }
-bytemuck = { version = "1", default-features = false, features = ["derive"] }
-byteorder = { version = "1" }
-bytes = { version = "1" }
+bytemuck = { version = "1", default-features = false }
+byteorder = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["std"] }
 cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
-chrono = { version = "0.4" }
-clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
-clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage"] }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
 clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
-cobs = { version = "0.2" }
+cobs = { version = "0.2", features = ["use_std"] }
 color_quant = { version = "1", default-features = false }
 colorchoice = { version = "1", default-features = false }
-concurrent-queue = { version = "2" }
+concurrent-queue = { version = "2", features = ["std"] }
 console-api = { version = "0.5", default-features = false, features = ["transport"] }
-console-subscriber = { version = "0.1" }
+console-subscriber = { version = "0.1", features = ["env-filter"] }
 console_error_panic_hook = { version = "0.1", default-features = false }
 const_format = { version = "0.2" }
 cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
 cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
-crc32fast = { version = "1" }
+crc32fast = { version = "1", features = ["std"] }
 critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
-crossbeam-channel = { version = "0.5" }
-crossbeam-deque = { version = "0.8" }
-crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
-crossbeam-utils = { version = "0.8" }
+crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
+crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "std"] }
+crossbeam-utils = { version = "0.8", features = ["std"] }
 d1-pac = { version = "0.0.31", default-features = false }
 deflate = { version = "0.8", default-features = false }
 defmt = { version = "0.3", default-features = false }
 dirs = { version = "4", default-features = false }
 dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
-either = { version = "1" }
+either = { version = "1", default-features = false }
 embedded-dma = { version = "0.2", default-features = false }
-embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
 embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
 embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
 embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
-embedded-graphics-simulator = { version = "0.3" }
+embedded-graphics-simulator = { version = "0.3", features = ["sdl2", "with-sdl"] }
 embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
 embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
 embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
@@ -103,67 +137,67 @@ embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
 embedded-io = { version = "0.5", default-features = false }
 equivalent = { version = "1", default-features = false }
 esp-alloc = { version = "0.3", default-features = false }
-esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
-esp-println = { version = "0.5", features = ["esp32c3"] }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp-println", "esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp-riscv-rt", "esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-println = { version = "0.5", features = ["colors", "critical-section", "esp32c3", "uart"] }
 esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
 esp32c3 = { version = "0.16", features = ["critical-section"] }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", features = ["rt", "vectored"] }
 event-listener = { version = "2", default-features = false }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
-flate2 = { version = "1" }
-float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
-float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
-fnv = { version = "1" }
-form_urlencoded = { version = "1" }
+flate2 = { version = "1", features = ["miniz_oxide", "rust_backend"] }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9", features = ["num-traits", "ratio"] }
+fnv = { version = "1", features = ["std"] }
+form_urlencoded = { version = "1", features = ["alloc", "std"] }
 fugit = { version = "0.3", default-features = false }
-futures = { version = "0.3" }
-futures-channel = { version = "0.3", features = ["sink"] }
-futures-core = { version = "0.3" }
+futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
-futures-io = { version = "0.3" }
-futures-sink = { version = "0.3" }
-futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+futures-io = { version = "0.3", features = ["std"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+gcd = { version = "2", default-features = false }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
-gif = { version = "0.11" }
-gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
-gloo = { version = "0.9", features = ["futures"] }
+gif = { version = "0.11", features = ["raii_no_panic", "std"] }
+gimli = { version = "0.27", default-features = false, features = ["read", "read-core"] }
+gloo = { version = "0.9", features = ["console", "dialogs", "events", "file", "futures", "gloo-console", "gloo-dialogs", "gloo-events", "gloo-file", "gloo-history", "gloo-net", "gloo-render", "gloo-storage", "gloo-timers", "gloo-utils", "gloo-worker", "history", "net", "render", "storage", "timers", "utils", "worker"] }
 gloo-console = { version = "0.2", default-features = false }
 gloo-dialogs = { version = "0.1", default-features = false }
 gloo-events = { version = "0.1", default-features = false }
-gloo-file = { version = "0.2", features = ["futures"] }
-gloo-history = { version = "0.1" }
-gloo-net = { version = "0.3" }
+gloo-file = { version = "0.2", features = ["futures", "futures-channel"] }
+gloo-history = { version = "0.1", features = ["query", "serde_urlencoded", "thiserror"] }
+gloo-net = { version = "0.3", features = ["eventsource", "futures-channel", "futures-core", "futures-sink", "http", "json", "pin-project", "serde", "serde_json", "websocket"] }
 gloo-render = { version = "0.1", default-features = false }
 gloo-storage = { version = "0.2", default-features = false }
-gloo-timers = { version = "0.2", features = ["futures"] }
-gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
-gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
+gloo-timers = { version = "0.2", features = ["futures", "futures-channel", "futures-core"] }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1", features = ["serde"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2", features = ["serde"] }
 gloo-worker = { version = "0.3", features = ["futures"] }
 h2 = { version = "0.3", default-features = false }
 hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
-hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
-hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
 hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["raw"] }
-hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
-heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
-hex = { version = "0.4", features = ["serde"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["base64", "flate2", "nom", "serialization"] }
+heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["alloc", "std"] }
 http = { version = "0.2", default-features = false }
 http-body = { version = "0.4", default-features = false }
-httparse = { version = "1" }
+httparse = { version = "1", features = ["std"] }
 httpdate = { version = "1", default-features = false }
-humantime = { version = "2", default-features = false }
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 hyper-timeout = { version = "0.4", default-features = false }
-idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
-image = { version = "0.23" }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
+image = { version = "0.23", features = ["bmp", "dds", "dxt", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "png", "pnm", "scoped_threadpool", "tga", "tiff", "webp"] }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
-indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
 input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
-io-lifetimes = { version = "1" }
+io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
 is-terminal = { version = "0.4", default-features = false }
 is_ci = { version = "1", default-features = false }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
@@ -171,115 +205,113 @@ jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"]
 js-sys = { version = "0.3", default-features = false }
 kv-log-macro = { version = "1", default-features = false }
 lazy_static = { version = "1", default-features = false }
-libc = { version = "0.2" }
+libc = { version = "0.2", features = ["std"] }
 libm = { version = "0.2" }
 linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
-log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
-maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std", "value-bag"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc", "tracing-01"] }
 matchers = { version = "0.1", default-features = false }
 matchit = { version = "0.7" }
-memchr = { version = "2", features = ["use_std"] }
-memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+memchr = { version = "2", features = ["std"] }
 micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
 micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
-miette = { version = "5", features = ["fancy"] }
+miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
 mime = { version = "0.3", default-features = false }
-minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
+minicbor = { version = "0.13", default-features = false, features = ["alloc", "derive", "minicbor-derive", "std"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
 miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
 miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext", "os-poll"] }
 modality-ingest-client = { version = "0.1", default-features = false }
-mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
-mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
 mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
-mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
-mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
 mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
 mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
 native-tls = { version = "0.2", default-features = false }
 nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
 nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
-nom = { version = "7" }
+nom = { version = "7", features = ["alloc", "std"] }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.1", default-features = false }
-num-integer = { version = "0.1", features = ["i128"] }
-num-iter = { version = "0.1" }
+num-integer = { version = "0.1", features = ["i128", "std"] }
+num-iter = { version = "0.1", features = ["std"] }
 num-rational = { version = "0.3", default-features = false }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
+num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
 num_cpus = { version = "1", default-features = false }
-object = { version = "0.31", default-features = false, features = ["compression", "read"] }
-once_cell = { version = "1" }
+object = { version = "0.31", default-features = false, features = ["archive", "coff", "elf", "macho", "pe", "read_core", "unaligned"] }
+once_cell = { version = "1", features = ["alloc", "race", "std"] }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
-overload = { version = "0.1", default-features = false }
 ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
-owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
-percent-encoding = { version = "2" }
+owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
+percent-encoding = { version = "2", features = ["alloc", "std"] }
 pin-project = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
 pinned = { version = "0.1", default-features = false }
-png = { version = "0.16" }
-portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
-postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
+png = { version = "0.16", features = ["deflate", "png-encoding"] }
+portable-atomic = { version = "1", features = ["critical-section", "fallback", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["heapless", "heapless-cas", "use-std"] }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
 postcard-cobs = { version = "0.1.5-pre", default-features = false }
-postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 profont = { version = "0.6", default-features = false }
-proptest = { version = "1" }
-prost = { version = "0.11" }
-prost-types = { version = "0.11" }
+proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+prost = { version = "0.11", features = ["prost-derive", "std"] }
+prost-types = { version = "0.11", features = ["std"] }
 quick-error = { version = "1", default-features = false }
 r0 = { version = "1", default-features = false }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
-rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
-rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os = { version = "0.1", default-features = false }
 rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
-rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
 rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
 raw-cpuid = { version = "10", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1" }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
-regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+regex = { version = "1", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "meta", "nfa-pikevm", "nfa-thompson", "std", "syntax", "unicode-case", "unicode-perl", "unicode-word-boundary"] }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", default-features = false, features = ["std", "unicode-case", "unicode-perl"] }
 ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
 riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
 riscv-rt = { version = "0.11", default-features = false }
 rsdp = { version = "2", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
 ryu = { version = "1", default-features = false }
 scoped_threadpool = { version = "0.1", default-features = false }
-scopeguard = { version = "1" }
+scopeguard = { version = "1", features = ["use_std"] }
 sdl2 = { version = "0.32" }
 sdl2-sys = { version = "0.32" }
-serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde = { version = "1", features = ["alloc", "derive", "serde_derive", "std"] }
 serde-wasm-bindgen = { version = "0.5", default-features = false }
-serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_json = { version = "1", features = ["std"] }
 serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_urlencoded = { version = "0.7", default-features = false }
-serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
-serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f", features = ["libudev"] }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
 sharded-slab = { version = "0.1", default-features = false }
-slab = { version = "0.4" }
+slab = { version = "0.4", features = ["std"] }
 smallvec = { version = "1", default-features = false }
 smawk = { version = "0.3", default-features = false }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
-stable_deref_trait = { version = "1" }
+stable_deref_trait = { version = "1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
-strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", default-features = false, features = ["derive", "strum_macros"] }
 supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
 supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
 supports-hyperlinks = { version = "2", default-features = false }
@@ -288,134 +320,133 @@ sync_wrapper = { version = "0.1", default-features = false }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
 terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
-textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
 textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
 thiserror = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 tiff = { version = "0.6", default-features = false }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
-tinyvec = { version = "1", features = ["alloc"] }
+tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
 tinyvec_macros = { version = "0.1", default-features = false }
-tokio = { version = "1", features = ["full", "tracing"] }
+tokio = { version = "1", features = ["bytes", "io-std", "io-util", "libc", "macros", "mio", "net", "rt", "socket2", "sync", "time", "tokio-macros", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-native-tls = { version = "0.3", default-features = false }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
+tokio-stream = { version = "0.1", features = ["net", "time"] }
+tokio-util = { version = "0.7", features = ["codec", "tracing"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
-tonic = { version = "0.9" }
-tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tonic = { version = "0.9", features = ["channel", "codegen", "prost", "transport"] }
+tower = { version = "0.4", default-features = false, features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
-tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
-tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "std", "tracing-attributes"] }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std"] }
 tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
-tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
 tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
-tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
-tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", features = ["std"] }
+tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
 tracing-wasm = { version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 unarray = { version = "0.1", default-features = false }
 unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
 unicode-linebreak = { version = "0.1", default-features = false }
-unicode-normalization = { version = "0.1" }
+unicode-normalization = { version = "0.1", default-features = false, features = ["std"] }
 unicode-width = { version = "0.1" }
 url = { version = "2" }
 utf8parse = { version = "0.2" }
-uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
-uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["getrandom", "std", "v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
 value-bag = { version = "1", default-features = false }
 vcell = { version = "0.1", default-features = false }
 void = { version = "1", default-features = false }
 volatile = { version = "0.4", default-features = false, features = ["unstable"] }
 wait-timeout = { version = "0.2", default-features = false }
 want = { version = "0.3", default-features = false }
-wasm-bindgen = { version = "0.2" }
+wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
-weezl = { version = "0.1" }
-winnow = { version = "0.5" }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "Blob", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "Element", "ErrorEvent", "Event", "EventSource", "EventTarget", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "Node", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "UiEvent", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerGlobalScope", "WorkerOptions", "console"] }
+weezl = { version = "0.1", features = ["alloc", "std"] }
+winnow = { version = "0.5", features = ["alloc", "std"] }
 
 [build-dependencies]
 acpi = { version = "4", default-features = false }
-addr2line = { version = "0.20" }
+addr2line = { version = "0.20", features = ["cpp_demangle", "fallible-iterator", "memmap2", "object", "rustc-demangle", "smallvec", "std", "std-object"] }
 adler = { version = "1", default-features = false }
 aes = { version = "0.8", default-features = false }
-aho-corasick = { version = "1" }
+aho-corasick = { version = "1", features = ["perf-literal", "std"] }
 ansi_term = { version = "0.12", default-features = false }
-anstream = { version = "0.5" }
-anstyle = { version = "1" }
-anstyle-parse = { version = "0.2" }
+anstream = { version = "0.5", features = ["auto", "wincon"] }
+anstyle = { version = "1", features = ["std"] }
+anstyle-parse = { version = "0.2", features = ["utf8"] }
 anstyle-query = { version = "1", default-features = false }
-anyhow = { version = "1" }
+anyhow = { version = "1", features = ["std"] }
 arrayvec = { version = "0.5", default-features = false }
 async-lock = { version = "2", default-features = false }
 async-process = { version = "1", default-features = false }
-async-scoped = { version = "0.7", default-features = false, features = ["use-tokio"] }
+async-scoped = { version = "0.7", default-features = false, features = ["tokio", "use-tokio"] }
 async-trait = { version = "0.1", default-features = false }
 atomicwrites = { version = "0.4", default-features = false }
 atty = { version = "0.2", default-features = false }
 autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
 autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
-axum = { version = "0.6", features = ["ws"] }
-axum-core = { version = "0.3", default-features = false }
+axum = { version = "0.6", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "ws"] }
 az = { version = "1", default-features = false }
-backtrace = { version = "0.3", features = ["gimli-symbolize"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize", "std"] }
 backtrace-ext = { version = "0.2", default-features = false }
-base64-647d43efb71741da = { package = "base64", version = "0.21" }
+base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
 base64ct = { version = "1", default-features = false }
 basic-toml = { version = "0.1", default-features = false }
 bincode = { version = "1", default-features = false }
-binread = { version = "2" }
+binread = { version = "2", features = ["std"] }
 binread_derive = { version = "2", default-features = false }
 bit_field = { version = "0.10", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false }
-bitvec = { version = "1" }
+bitvec = { version = "1", features = ["alloc", "atomic", "std"] }
 block-buffer = { version = "0.10", default-features = false }
-bootloader = { version = "0.11" }
+bootloader = { version = "0.11", features = ["bios", "uefi"] }
 bootloader-boot-config = { version = "0.11", default-features = false }
 bootloader_api = { version = "0.11", default-features = false }
-bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["unicode"] }
+bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["lazy_static", "regex-automata", "unicode"] }
 bumpalo = { version = "3" }
 bytecount = { version = "0.6", default-features = false }
-bytemuck = { version = "1", default-features = false, features = ["derive"] }
+bytemuck = { version = "1", default-features = false, features = ["bytemuck_derive", "derive"] }
 bytemuck_derive = { version = "1", default-features = false }
-byteorder = { version = "1" }
-bytes = { version = "1" }
+byteorder = { version = "1", features = ["std"] }
+bytes = { version = "1", features = ["std"] }
 bzip2 = { version = "0.4", default-features = false }
 bzip2-sys = { version = "0.1", default-features = false }
-camino = { version = "1", default-features = false, features = ["serde1"] }
+camino = { version = "1", default-features = false, features = ["serde", "serde1"] }
 camino-tempfile = { version = "1", default-features = false }
 cargo-binutils = { version = "0.3", default-features = false }
 cargo-espflash = { version = "2", default-features = false }
 cargo-lock = { version = "9", default-features = false }
-cargo-nextest = { version = "0.9" }
-cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
+cargo-nextest = { version = "0.9", features = ["default-no-update", "self-update"] }
+cargo-platform = { version = "0.1", default-features = false }
 cargo_metadata-582f2526e08bb6a0 = { package = "cargo_metadata", version = "0.14" }
+cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
 cargo_metadata-9067fe90e8c1f593 = { package = "cargo_metadata", version = "0.17" }
-cc = { version = "1", default-features = false, features = ["parallel"] }
-cfg-expr = { version = "0.15", features = ["targets"] }
+cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
+cfg-expr = { version = "0.15", features = ["target-lexicon", "targets"] }
 cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
 cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
-chrono = { version = "0.4" }
+chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
 cipher = { version = "0.4", default-features = false }
-clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
-clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["wrap_help"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "term_size", "vec_map", "wrap_help"] }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
 clap_complete = { version = "4" }
-clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
 clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
+clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
 clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
-cobs = { version = "0.2" }
+cobs = { version = "0.2", default-features = false }
 color-eyre = { version = "0.6", default-features = false }
 colorchoice = { version = "1", default-features = false }
-comfy-table = { version = "7" }
+comfy-table = { version = "7", features = ["crossterm", "tty"] }
 config = { version = "0.13", default-features = false, features = ["toml"] }
-console = { version = "0.15" }
+console = { version = "0.15", features = ["ansi-parsing", "unicode-width"] }
 const_format = { version = "0.2" }
 const_format_proc_macros = { version = "0.2" }
 constant_time_eq = { version = "0.1", default-features = false }
@@ -425,11 +456,11 @@ cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/
 cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
-crc32fast = { version = "1" }
-crossbeam-channel = { version = "0.5" }
-crossbeam-utils = { version = "0.8" }
+crc32fast = { version = "1", features = ["std"] }
+crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
+crossbeam-utils = { version = "0.8", default-features = false, features = ["std"] }
+crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25", features = ["bracketed-paste"] }
 crossterm-2f80eeee3b1b6c7e = { package = "crossterm", version = "0.26", default-features = false }
-crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 cssparser = { version = "0.27", default-features = false }
 cssparser-macros = { version = "0.6", default-features = false }
@@ -437,23 +468,23 @@ csv = { version = "1", default-features = false }
 csv-core = { version = "0.1" }
 ctrlc = { version = "3", default-features = false, features = ["termination"] }
 cvt = { version = "0.1", default-features = false }
-darling-56bd22fc3884b12 = { package = "darling", version = "0.20" }
-darling-582f2526e08bb6a0 = { package = "darling", version = "0.14" }
-darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["suggestions"] }
-darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["suggestions"] }
-darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20", features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["strsim", "suggestions"] }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["strsim", "suggestions"] }
 darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
-data-encoding = { version = "2" }
+darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+data-encoding = { version = "2", features = ["alloc", "std"] }
 debug-ignore = { version = "1", default-features = false }
 defmt = { version = "0.3", default-features = false }
 defmt-macros = { version = "0.3", default-features = false }
 defmt-parser = { version = "0.3", default-features = false, features = ["unstable"] }
-deku = { version = "0.16" }
-deku_derive = { version = "0.16", default-features = false, features = ["std"] }
+deku = { version = "0.16", features = ["alloc", "const_generics", "std"] }
+deku_derive = { version = "0.16", default-features = false, features = ["proc-macro-crate", "std"] }
 derivative = { version = "2", default-features = false }
-derive_more = { version = "0.99" }
-dialoguer = { version = "0.10" }
-digest = { version = "0.10", features = ["mac", "std"] }
+derive_more = { version = "0.99", features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "convert_case", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "iterator", "mul", "mul_assign", "not", "rustc_version", "sum", "try_into", "unwrap"] }
+dialoguer = { version = "0.10", features = ["editor", "password", "tempfile", "zeroize"] }
+digest = { version = "0.10", features = ["alloc", "block-buffer", "core-api", "mac", "std", "subtle"] }
 directories = { version = "5", default-features = false }
 dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
 doc-comment = { version = "0.3", default-features = false }
@@ -463,21 +494,21 @@ dtoa-short = { version = "0.3", default-features = false }
 duct = { version = "0.13", default-features = false }
 dunce = { version = "1", default-features = false }
 edit-distance = { version = "2", default-features = false }
-either = { version = "1" }
+either = { version = "1", features = ["use_std"] }
 embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
 embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
 embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
 embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
 enable-ansi-support = { version = "0.2", default-features = false }
-env_logger = { version = "0.10" }
+env_logger = { version = "0.10", features = ["auto-color", "color", "humantime", "regex"] }
 envy = { version = "0.4", default-features = false }
 equivalent = { version = "1", default-features = false }
 esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["interrupt"] }
-esp-idf-part = { version = "0.4" }
-espflash = { version = "2" }
+esp-idf-part = { version = "0.4", features = ["csv", "deku", "parse_int", "regex", "std", "thiserror"] }
+espflash = { version = "2", features = ["cli"] }
 event-listener = { version = "2", default-features = false }
-eyre = { version = "0.6" }
-failure = { version = "0.1" }
+eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
+failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
 failure_derive = { version = "0.1", default-features = false }
 fallible-iterator = { version = "0.2", default-features = false, features = ["std"] }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
@@ -485,134 +516,132 @@ fatfs = { version = "0.3", default-features = false, features = ["alloc", "std"]
 file-id = { version = "0.2", default-features = false }
 filetime = { version = "0.2", default-features = false }
 fixedbitset = { version = "0.4", default-features = false }
-flate2 = { version = "1" }
-float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
-fnv = { version = "1" }
-form_urlencoded = { version = "1" }
+flate2 = { version = "1", features = ["miniz_oxide", "rust_backend"] }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
+fnv = { version = "1", features = ["std"] }
+form_urlencoded = { version = "1", features = ["alloc", "std"] }
 fs_at = { version = "0.1" }
 fs_extra = { version = "1", default-features = false }
 funty = { version = "2", default-features = false }
 futf = { version = "0.1", default-features = false }
 future-queue = { version = "0.3", default-features = false }
-futures = { version = "0.3" }
-futures-channel = { version = "0.3", features = ["sink"] }
+futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
+futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
 futures-concurrency = { version = "7", default-features = false }
-futures-core = { version = "0.3" }
+futures-core = { version = "0.3", features = ["alloc", "std"] }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
-futures-io = { version = "0.3" }
-futures-lite = { version = "1" }
+futures-io = { version = "0.3", features = ["std"] }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
 futures-macro = { version = "0.3", default-features = false }
-futures-sink = { version = "0.3" }
-futures-task = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+futures-sink = { version = "0.3", features = ["alloc", "std"] }
+futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+futures-util = { version = "0.3", default-features = false, features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 fxhash = { version = "0.2", default-features = false }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
-gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "fallible-iterator", "read", "read-core", "stable_deref_trait", "std"] }
 gloo-worker-macros = { version = "0.1", default-features = false }
 gpt = { version = "3", default-features = false }
 guppy = { version = "0.17", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
 hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
-hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
-hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
 hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["raw"] }
-heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["raw"] }
+heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
 heck = { version = "0.4" }
-hex = { version = "0.4", features = ["serde"] }
+hex = { version = "0.4", features = ["alloc", "serde", "std"] }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
 home = { version = "0.5", default-features = false }
 html5ever = { version = "0.25", default-features = false }
 http = { version = "0.2", default-features = false }
 http-body = { version = "0.4", default-features = false }
 http-range-header = { version = "0.3", default-features = false }
-httparse = { version = "1" }
+httparse = { version = "1", features = ["std"] }
 httpdate = { version = "1", default-features = false }
-humantime = { version = "2", default-features = false }
 humantime-serde = { version = "1", default-features = false }
-hyper = { version = "0.14", features = ["full"] }
+hyper = { version = "0.14", features = ["http1", "runtime", "server", "socket2", "stream", "tcp"] }
 ident_case = { version = "1", default-features = false }
-idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
-indent_write = { version = "2" }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
+indent_write = { version = "2", features = ["std"] }
 indenter = { version = "0.3" }
-indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
-indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
-indicatif = { version = "0.17" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
+indicatif = { version = "0.17", features = ["unicode-width"] }
 inout = { version = "0.1", default-features = false }
 input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
-io-lifetimes = { version = "1" }
+io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
 is-terminal = { version = "0.4", default-features = false }
 is_ci = { version = "1", default-features = false }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", default-features = false, features = ["use_alloc"] }
-itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11" }
-itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
+itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11", features = ["use_alloc", "use_std"] }
+itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4", features = ["std"] }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 just = { version = "1" }
 lazy_static = { version = "1", default-features = false }
 lexiclean = { version = "0.0.1", default-features = false }
-libc = { version = "0.2" }
-linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+libc = { version = "0.2", features = ["std"] }
+linked_list_allocator = { version = "0.10", default-features = false }
 llvm-tools = { version = "0.1", default-features = false }
 local-ip-address = { version = "0.5", default-features = false }
-lock_api = { version = "0.4" }
-log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+lock_api = { version = "0.4", features = ["atomic_usize"] }
+log = { version = "0.4", default-features = false, features = ["std"] }
 mac = { version = "0.1", default-features = false }
-maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false, features = ["alloc"] }
 markup5ever = { version = "0.10", default-features = false }
 matchers = { version = "0.1", default-features = false }
 matches = { version = "0.1", default-features = false }
 matchit = { version = "0.7" }
 mbrman = { version = "0.5", default-features = false }
 md5 = { version = "0.7", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["use_std"] }
+memchr = { version = "2", features = ["std", "use_std"] }
 memmap2 = { version = "0.5", default-features = false }
 micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
-miette = { version = "5", features = ["fancy"] }
+miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
 miette-derive = { version = "5", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
 minicbor-derive = { version = "0.8", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio = { version = "0.8", default-features = false, features = ["net", "os-ext"] }
+mio = { version = "0.8", default-features = false, features = ["net", "os-ext", "os-poll"] }
 mukti-metadata = { version = "0.1", default-features = false }
-mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
-mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
 mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
-mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
-mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
 mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
 mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
 nested = { version = "0.1", default-features = false }
 new_debug_unreachable = { version = "1", default-features = false }
 nextest-filtering = { version = "0.5" }
 nextest-metadata = { version = "0.9", default-features = false }
-nextest-runner = { version = "0.45", default-features = false, features = ["self-update"] }
+nextest-runner = { version = "0.45", default-features = false, features = ["mukti-metadata", "self-update", "self_update"] }
 nextest-workspace-hack = { version = "0.1", default-features = false }
 nipper = { version = "0.1", default-features = false }
-nodrop = { version = "0.1" }
-nom = { version = "7" }
+nodrop = { version = "0.1", features = ["std"] }
+nom = { version = "7", features = ["alloc", "std"] }
 nom-tracable = { version = "0.9" }
 nom-tracable-macros = { version = "0.9", default-features = false }
-nom_locate = { version = "4" }
+nom_locate = { version = "4", features = ["alloc", "std"] }
 normpath = { version = "1", default-features = false }
-notify = { version = "6" }
-notify-debouncer-full = { version = "0.3" }
+notify = { version = "6", features = ["crossbeam-channel", "fsevent-sys", "macos_fsevent"] }
+notify-debouncer-full = { version = "0.3", features = ["crossbeam", "crossbeam-channel"] }
 nu-ansi-term = { version = "0.46", default-features = false }
-num-traits = { version = "0.2", features = ["i128", "libm"] }
+num-traits = { version = "0.2", features = ["std"] }
 num_cpus = { version = "1", default-features = false }
-number_prefix = { version = "0.4" }
-object = { version = "0.31", default-features = false, features = ["compression", "read"] }
-once_cell = { version = "1" }
+number_prefix = { version = "0.4", features = ["std"] }
+object = { version = "0.31", default-features = false, features = ["archive", "coff", "compression", "elf", "flate2", "macho", "pe", "read", "read_core", "ruzstd", "std", "unaligned", "xcoff"] }
+once_cell = { version = "1", features = ["alloc", "race", "std"] }
 open = { version = "5", default-features = false }
 option-ext = { version = "0.2", default-features = false }
 os_pipe = { version = "1", default-features = false }
-overload = { version = "0.1", default-features = false }
-owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
 parking = { version = "2", default-features = false }
 parking_lot = { version = "0.12" }
 parking_lot_core = { version = "0.9", default-features = false }
@@ -620,54 +649,55 @@ parse_int = { version = "0.6" }
 password-hash = { version = "0.4", default-features = false, features = ["rand_core"] }
 paste = { version = "1", default-features = false }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
-pbkdf2 = { version = "0.11" }
-percent-encoding = { version = "2" }
+pbkdf2 = { version = "0.11", features = ["hmac", "password-hash", "sha2", "simple"] }
+percent-encoding = { version = "2", features = ["alloc", "std"] }
 petgraph = { version = "0.6", default-features = false }
-phf = { version = "0.8", features = ["macros"] }
+phf = { version = "0.8", features = ["macros", "phf_macros", "proc-macro-hack", "std"] }
 phf_codegen = { version = "0.8", default-features = false }
-phf_generator = { version = "0.8", default-features = false }
+phf_generator-93f6ce9d446188ac = { package = "phf_generator", version = "0.10", default-features = false }
+phf_generator-c38e5c1d305a1b54 = { package = "phf_generator", version = "0.8", default-features = false }
 phf_macros = { version = "0.8", default-features = false }
-phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
-phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8" }
+phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10", features = ["std"] }
+phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8", features = ["std"] }
 pin-project = { version = "1", default-features = false }
 pin-project-internal = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
-portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+portable-atomic = { version = "1", features = ["fallback", "require-cas"] }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
 postcard-derive = { version = "0.1", default-features = false }
-postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 precomputed-hash = { version = "0.1", default-features = false }
 proc-macro-crate = { version = "1", default-features = false }
-proc-macro-error = { version = "1" }
+proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
 proc-macro-error-attr = { version = "1", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro2 = { version = "1" }
+proc-macro2 = { version = "1", features = ["proc-macro"] }
 profont = { version = "0.6", default-features = false }
 proptest-derive = { version = "0.4", default-features = false }
 prost-derive = { version = "0.11", default-features = false }
 quick-junit = { version = "0.3", default-features = false }
 quick-xml-2b5c6dc72f624058 = { package = "quick-xml", version = "0.23" }
 quick-xml-b73a96c0a5f6a7d9 = { package = "quick-xml", version = "0.29" }
-quote = { version = "1" }
+quote = { version = "1", features = ["proc-macro"] }
 radium = { version = "0.7", default-features = false }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
-rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
 raw-cpuid = { version = "10", default-features = false }
 recursion = { version = "0.4" }
-regex = { version = "1" }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
-regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+regex = { version = "1", features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "dfa-onepass", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"] }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 remove_dir_all = { version = "0.8" }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls", "stream", "trust-dns"] }
-ring = { version = "0.16" }
+reqwest = { version = "0.11", default-features = false, features = ["__rustls", "__tls", "blocking", "hyper-rustls", "json", "rustls", "rustls-pemfile", "rustls-tls", "rustls-tls-webpki-roots", "serde_json", "stream", "tokio-rustls", "tokio-util", "trust-dns", "trust-dns-resolver", "wasm-streams", "webpki-roots"] }
+ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
 ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
 riscv-rt-macros = { version = "0.2", default-features = false }
 riscv-target = { version = "0.1", default-features = false }
@@ -675,65 +705,67 @@ rsdp = { version = "2", default-features = false }
 rustc-cfg = { version = "0.4", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc_version = { version = "0.4", default-features = false }
-rustls = { version = "0.21" }
-rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100" }
-rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101" }
+rustls = { version = "0.21", features = ["log", "logging", "tls12"] }
+rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100", features = ["alloc", "std"] }
+rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
 rustversion = { version = "1", default-features = false }
 ruzstd = { version = "0.3", default-features = false }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
-scopeguard = { version = "1" }
+scopeguard = { version = "1", features = ["use_std"] }
 sct = { version = "0.7", default-features = false }
 seahash = { version = "4" }
 selectors = { version = "0.22", default-features = false }
-self_update = { version = "0.37", default-features = false, features = ["archive-tar", "compression-flate2"] }
-serde = { version = "1", features = ["alloc", "derive", "rc"] }
+self_update = { version = "0.37", default-features = false, features = ["archive-tar", "compression-flate2", "either", "flate2", "tar"] }
+semver = { version = "1", features = ["serde", "std"] }
+serde = { version = "1", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
 serde-big-array = { version = "0.4", default-features = false }
 serde_derive = { version = "1" }
 serde_ignored = { version = "0.1", default-features = false }
-serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_json = { version = "1", features = ["raw_value", "std", "unbounded_depth"] }
 serde_path_to_error = { version = "0.1", default-features = false }
 serde_plain = { version = "1", default-features = false }
 serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_urlencoded = { version = "0.7", default-features = false }
-serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
 servo_arc = { version = "0.1", default-features = false }
-sha1 = { version = "0.10" }
-sha2 = { version = "0.10" }
+sha1 = { version = "0.10", features = ["std"] }
+sha2 = { version = "0.10", features = ["std"] }
 sharded-slab = { version = "0.1", default-features = false }
 shared_child = { version = "1", default-features = false }
-shell-words = { version = "1" }
-similar = { version = "2", features = ["unicode"] }
-siphasher = { version = "0.3" }
-slab = { version = "0.4" }
+shell-words = { version = "1", features = ["std"] }
+similar = { version = "2", features = ["bstr", "text", "unicode", "unicode-segmentation"] }
+siphasher = { version = "0.3", features = ["std"] }
+slab = { version = "0.4", features = ["std"] }
 slip-codec = { version = "0.3" }
 smallvec = { version = "1", default-features = false }
 smawk = { version = "0.3", default-features = false }
-smol_str = { version = "0.2", features = ["serde"] }
-snafu = { version = "0.7" }
+smol_str = { version = "0.2", features = ["serde", "std"] }
+snafu = { version = "0.7", features = ["rust_1_39", "rust_1_46", "std"] }
 snafu-derive = { version = "0.7", default-features = false, features = ["rust_1_39", "rust_1_46"] }
 socket2 = { version = "0.4", default-features = false, features = ["all"] }
-stable_deref_trait = { version = "1" }
+stable_deref_trait = { version = "1", features = ["alloc", "std"] }
 static_assertions = { version = "1", default-features = false }
-string_cache = { version = "0.8" }
+string_cache = { version = "0.8", features = ["serde", "serde_support"] }
+string_cache_codegen = { version = "0.5", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
-strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
-strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
-strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
+strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive", "std", "strum_macros"] }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive", "std", "strum_macros"] }
 strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
+strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
 subtle = { version = "2", default-features = false }
 supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
 supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
 supports-hyperlinks = { version = "2", default-features = false }
 supports-unicode = { version = "2", default-features = false }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
-synstructure = { version = "0.12" }
+synstructure = { version = "0.12", features = ["proc-macro"] }
 tap = { version = "1", default-features = false }
-tar = { version = "0.4" }
+tar = { version = "0.4", features = ["xattr"] }
 target = { version = "2", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "3", default-features = false, features = ["custom", "summaries"] }
@@ -742,68 +774,68 @@ tempfile = { version = "3", default-features = false }
 tendril = { version = "0.4", default-features = false }
 term_size = { version = "0.3" }
 termcolor = { version = "1", default-features = false }
-terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
 terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
-textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
 textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
 thin-slice = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
-time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "parsing"] }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["alloc", "formatting", "parsing", "std"] }
 time-core = { version = "0.1", default-features = false }
-tinyvec = { version = "1", features = ["alloc"] }
+tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
 tinyvec_macros = { version = "0.1", default-features = false }
-tokio = { version = "1", features = ["full", "tracing"] }
+tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 tokio-macros = { version = "2", default-features = false }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
-tokio-tungstenite = { version = "0.19" }
-tokio-util = { version = "0.7", features = ["codec", "io"] }
-toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
+tokio-stream = { version = "0.1", default-features = false, features = ["fs", "sync", "tokio-util"] }
+tokio-tungstenite = { version = "0.19", features = ["connect", "handshake", "stream"] }
+tokio-util = { version = "0.7", features = ["io"] }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5" }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
-tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
-tower-http = { version = "0.4", features = ["fs", "trace"] }
+tower = { version = "0.4", default-features = false, features = ["__common", "futures-core", "futures-util", "log", "make", "pin-project", "pin-project-lite", "tokio", "tracing", "util"] }
+tower-http = { version = "0.4", features = ["fs", "httpdate", "mime", "mime_guess", "percent-encoding", "set-status", "tokio", "tokio-util", "trace", "tracing"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
-tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
-tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
 tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
-tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std"] }
 tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
-tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
 tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
-tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
 trunk = { version = "0.17", default-features = false }
 try-lock = { version = "0.2", default-features = false }
-tungstenite = { version = "0.19", default-features = false, features = ["handshake"] }
+tungstenite = { version = "0.19", default-features = false, features = ["data-encoding", "handshake", "http", "httparse", "sha1", "url"] }
 twox-hash = { version = "1", default-features = false }
-typed-arena = { version = "2" }
+typed-arena = { version = "2", features = ["std"] }
 typenum = { version = "1", default-features = false }
 unicase = { version = "2", default-features = false }
 unicode-bidi = { version = "0.3", default-features = false, features = ["hardcoded-data", "std"] }
 unicode-ident = { version = "1", default-features = false }
 unicode-linebreak = { version = "0.1", default-features = false }
-unicode-normalization = { version = "0.1" }
+unicode-normalization = { version = "0.1", features = ["std"] }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
 unicode-xid = { version = "0.2" }
 untrusted = { version = "0.7", default-features = false }
-update-informer = { version = "1" }
-ureq = { version = "2", default-features = false, features = ["gzip", "json", "tls"] }
+update-informer = { version = "1", features = ["crates", "rustls-tls", "ureq"] }
+ureq = { version = "2", default-features = false, features = ["flate2", "gzip", "json", "rustls", "serde", "serde_json", "tls", "webpki", "webpki-roots"] }
 url = { version = "2" }
 urlencoding = { version = "2", default-features = false }
 utf-8 = { version = "0.7", default-features = false }
 utf8parse = { version = "0.2" }
-uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
 vec_map = { version = "0.8", default-features = false }
-vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc"] }
+vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc", "rustc_version", "time"] }
 version_check = { version = "0.9", default-features = false }
 volatile = { version = "0.4", default-features = false, features = ["unstable"] }
-vte = { version = "0.10" }
+vte = { version = "0.10", features = ["arrayvec", "no_std"] }
 vte_generate_state_changes = { version = "0.1", default-features = false }
 waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
@@ -814,97 +846,87 @@ wasm-bindgen-macro-support = { version = "0.2", default-features = false, featur
 wasm-bindgen-shared = { version = "0.2", default-features = false }
 webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
 which = { version = "4", default-features = false }
-winnow = { version = "0.5" }
+winnow = { version = "0.5", features = ["alloc", "std"] }
 wyz = { version = "0.5", default-features = false }
-xmas-elf = { version = "0.9", default-features = false }
-zero = { version = "0.1", default-features = false }
-zeroize = { version = "1" }
-zip = { version = "0.6" }
-zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["zstdmt"] }
-zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11" }
-zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
+zeroize = { version = "1", features = ["alloc"] }
+zip = { version = "0.6", features = ["aes", "aes-crypto", "bzip2", "constant_time_eq", "deflate", "flate2", "hmac", "pbkdf2", "sha1", "time", "zstd"] }
+zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11", features = ["arrays", "legacy", "zdict_builder"] }
+zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["arrays", "legacy", "zdict_builder", "zstdmt"] }
 zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
 [target.armv7-sony-vita-newlibeabihf.dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2" }
+async-global-executor = { version = "2", features = ["async-io"] }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
-async-task = { version = "4" }
+async-task = { version = "4", features = ["std"] }
 atomic-waker = { version = "1", default-features = false }
-bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 blocking = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1" }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio = { version = "0.8" }
+memoffset = { version = "0.6" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10" }
 openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9", default-features = false }
 parking = { version = "2", default-features = false }
-polling = { version = "2" }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
-signal-hook = { version = "0.3" }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+signal-hook = { version = "0.3", default-features = false, features = ["channel", "iterator"] }
 signal-hook-registry = { version = "1", default-features = false }
-smallvec = { version = "1", default-features = false, features = ["write"] }
 static_assertions = { version = "1", default-features = false }
-unicode-bidi = { version = "0.3" }
 waker-fn = { version = "1", default-features = false }
 
 [target.armv7-sony-vita-newlibeabihf.build-dependencies]
-ahash = { version = "0.8" }
+ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
 arc-swap = { version = "1", default-features = false }
 async-io = { version = "1", default-features = false }
 base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
-bitmaps = { version = "2" }
-bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", default-features = false, features = ["std", "unicode"] }
-btoi = { version = "0.4" }
+bitmaps = { version = "2", features = ["std"] }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", default-features = false, features = ["alloc", "std", "unicode"] }
+btoi = { version = "0.4", features = ["std"] }
 bytesize = { version = "1" }
-cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
 cargo-util = { version = "0.2", default-features = false }
 clru = { version = "0.6", default-features = false }
-concurrent-queue = { version = "2" }
+concurrent-queue = { version = "2", features = ["std"] }
 const-oid = { version = "0.9", default-features = false }
 crates-io = { version = "0.37", default-features = false }
+crossbeam-utils = { version = "0.8" }
 crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 ct-codecs = { version = "1", default-features = false }
-curl = { version = "0.4", features = ["http2"] }
-curl-sys = { version = "0.4", features = ["http2"] }
-der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
-digest = { version = "0.10", default-features = false, features = ["oid"] }
-ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
-ed25519-compact = { version = "2", default-features = false, features = ["random"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
-encoding_rs = { version = "0.8" }
+curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
+curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
+digest = { version = "0.10", default-features = false, features = ["const-oid", "oid"] }
+ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
 enum-as-inner = { version = "0.5", default-features = false }
 errno = { version = "0.3", default-features = false }
-faster-hex = { version = "0.8" }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
 ff = { version = "0.13", default-features = false, features = ["alloc"] }
 fiat-crypto = { version = "0.1", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
+flate2 = { version = "1", default-features = false, features = ["any_zlib", "libz-sys", "zlib"] }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
+futures-util = { version = "0.3" }
 generic-array = { version = "0.14", default-features = false, features = ["zeroize"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
-git2 = { version = "0.17" }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "wasm-bindgen"] }
+git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 git2-curl = { version = "0.18", default-features = false }
-gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
 gix-actor = { version = "0.20", default-features = false }
 gix-attributes = { version = "0.12", default-features = false }
 gix-bitmap = { version = "0.2", default-features = false }
@@ -939,43 +961,45 @@ gix-revision = { version = "0.13", default-features = false }
 gix-sec = { version = "0.8", default-features = false }
 gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
 gix-trace = { version = "0.1" }
-gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
 gix-traverse = { version = "0.25", default-features = false }
 gix-url = { version = "0.18", default-features = false }
 gix-utils = { version = "0.1", default-features = false }
 gix-validate = { version = "0.7", default-features = false }
 gix-worktree = { version = "0.17", default-features = false }
 glob = { version = "0.3", default-features = false }
-globset = { version = "0.4" }
+globset = { version = "0.4", features = ["log"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
 h2 = { version = "0.3", default-features = false }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
 hkdf = { version = "0.12", default-features = false }
 hostname = { version = "0.3" }
 http-auth = { version = "0.1", default-features = false }
+hyper = { version = "0.14", default-features = false, features = ["client", "h2", "http2"] }
 hyper-rustls = { version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
-imara-diff = { version = "0.1" }
+imara-diff = { version = "0.1", features = ["unified_diff"] }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
 io-close = { version = "0.3", default-features = false }
-ipnet = { version = "2" }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
-kstring = { version = "2" }
+ipnet = { version = "2", features = ["std"] }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
+kstring = { version = "2", features = ["std", "unsafe"] }
 lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked-hash-map = { version = "0.5", default-features = false }
 lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1" }
+match_cfg = { version = "0.1", features = ["use_core"] }
 maybe-async = { version = "0.2", features = ["is_sync"] }
-mio = { version = "0.8" }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+mio = { version = "0.8", features = ["log"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
 num_threads = { version = "0.1", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 opener = { version = "0.5", default-features = false }
@@ -983,132 +1007,124 @@ openssl = { version = "0.10", features = ["vendored"] }
 openssl-macros = { version = "0.1", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-ordered-float = { version = "2" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "2", features = ["std"] }
 orion = { version = "0.17", default-features = false }
-os_info = { version = "3" }
-p384 = { version = "0.13" }
-pasetors = { version = "0.6", features = ["serde", "v3"] }
+os_info = { version = "3", features = ["serde"] }
+p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
+pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
 pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
-pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
-polling = { version = "2" }
+pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
+polling = { version = "2", features = ["std"] }
 primeorder = { version = "0.13", default-features = false }
-prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
 quick-error = { version = "1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rand_xoshiro = { version = "0.6", default-features = false }
 regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
 rfc6979 = { version = "0.4", default-features = false }
 rustfix = { version = "0.6", default-features = false }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["std", "termios", "use-libc-auxv"] }
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
 rustls-pemfile = { version = "1", default-features = false }
-sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
 self_update = { version = "0.37", default-features = false, features = ["rustls"] }
 serde-value = { version = "0.7", default-features = false }
 sha1_smol = { version = "1", default-features = false }
 shell-escape = { version = "0.1", default-features = false }
-signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["mio-0_8", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
-signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
-sized-chunks = { version = "0.6" }
+signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6", features = ["std"] }
 smallvec = { version = "1", default-features = false, features = ["write"] }
-spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
 subtle = { version = "2", default-features = false, features = ["i128"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", default-features = false, features = ["visit-mut"] }
 time-468e82937335b1c9 = { package = "time", version = "0.3", default-features = false, features = ["local-offset", "macros"] }
 time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
-tokio-rustls = { version = "0.24" }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
-trust-dns-resolver = { version = "0.22" }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+tokio-util = { version = "0.7", default-features = false, features = ["codec", "tracing"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
 unicode-bidi = { version = "0.3" }
 unicode-bom = { version = "2", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
-xattr = { version = "1" }
+xattr = { version = "1", features = ["unsupported"] }
 
 [target.sparc64-unknown-openbsd.dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2" }
+async-global-executor = { version = "2", features = ["async-io"] }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
-async-task = { version = "4" }
+async-task = { version = "4", features = ["std"] }
 atomic-waker = { version = "1", default-features = false }
-bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 blocking = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1" }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-mio = { version = "0.8" }
+memoffset = { version = "0.6" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
-once_cell = { version = "1", default-features = false, features = ["unstable"] }
-openssl = { version = "0.10", features = ["vendored"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["fs", "ioctl", "poll", "process", "signal", "term"] }
+openssl = { version = "0.10" }
 openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+openssl-sys = { version = "0.9", default-features = false }
 parking = { version = "2", default-features = false }
-polling = { version = "2" }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
-signal-hook = { version = "0.3" }
+polling = { version = "2", features = ["std"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+signal-hook = { version = "0.3", default-features = false, features = ["channel", "iterator"] }
 signal-hook-registry = { version = "1", default-features = false }
-smallvec = { version = "1", default-features = false, features = ["write"] }
 static_assertions = { version = "1", default-features = false }
-unicode-bidi = { version = "0.3" }
 waker-fn = { version = "1", default-features = false }
 
 [target.sparc64-unknown-openbsd.build-dependencies]
-ahash = { version = "0.8" }
+ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
 arc-swap = { version = "1", default-features = false }
 async-io = { version = "1", default-features = false }
 base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
-bitmaps = { version = "2" }
-bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", default-features = false, features = ["std", "unicode"] }
-btoi = { version = "0.4" }
+bitmaps = { version = "2", features = ["std"] }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", default-features = false, features = ["alloc", "std", "unicode"] }
+btoi = { version = "0.4", features = ["std"] }
 bytesize = { version = "1" }
-cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
 cargo-util = { version = "0.2", default-features = false }
 clru = { version = "0.6", default-features = false }
-concurrent-queue = { version = "2" }
+concurrent-queue = { version = "2", features = ["std"] }
 const-oid = { version = "0.9", default-features = false }
 crates-io = { version = "0.37", default-features = false }
 crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 ct-codecs = { version = "1", default-features = false }
-curl = { version = "0.4", features = ["http2"] }
-curl-sys = { version = "0.4", features = ["http2"] }
-der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
-digest = { version = "0.10", default-features = false, features = ["oid"] }
-ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
-ed25519-compact = { version = "2", default-features = false, features = ["random"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
-encoding_rs = { version = "0.8" }
+curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
+curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
+der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
+digest = { version = "0.10", default-features = false, features = ["const-oid", "oid"] }
+ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
+encoding_rs = { version = "0.8", features = ["alloc"] }
 enum-as-inner = { version = "0.5", default-features = false }
 errno = { version = "0.3", default-features = false }
-faster-hex = { version = "0.8" }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
 ff = { version = "0.13", default-features = false, features = ["alloc"] }
 fiat-crypto = { version = "0.1", default-features = false }
-flate2 = { version = "1", default-features = false, features = ["zlib"] }
+flate2 = { version = "1", default-features = false, features = ["any_zlib", "libz-sys", "zlib"] }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
+futures-util = { version = "0.3" }
 generic-array = { version = "0.14", default-features = false, features = ["zeroize"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js"] }
-git2 = { version = "0.17" }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "wasm-bindgen"] }
+git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 git2-curl = { version = "0.18", default-features = false }
-gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
 gix-actor = { version = "0.20", default-features = false }
 gix-attributes = { version = "0.12", default-features = false }
 gix-bitmap = { version = "0.2", default-features = false }
@@ -1143,47 +1159,49 @@ gix-revision = { version = "0.13", default-features = false }
 gix-sec = { version = "0.8", default-features = false }
 gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
 gix-trace = { version = "0.1" }
-gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
 gix-traverse = { version = "0.25", default-features = false }
 gix-url = { version = "0.18", default-features = false }
 gix-utils = { version = "0.1", default-features = false }
 gix-validate = { version = "0.7", default-features = false }
 gix-worktree = { version = "0.17", default-features = false }
 glob = { version = "0.3", default-features = false }
-globset = { version = "0.4" }
+globset = { version = "0.4", features = ["log"] }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
 h2 = { version = "0.3", default-features = false }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
 hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more"] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more"] }
 hkdf = { version = "0.12", default-features = false }
 hostname = { version = "0.3" }
 http-auth = { version = "0.1", default-features = false }
+hyper = { version = "0.14", default-features = false, features = ["client", "h2", "http2"] }
 hyper-rustls = { version = "0.24", default-features = false }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
-imara-diff = { version = "0.1" }
+imara-diff = { version = "0.1", features = ["unified_diff"] }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
 io-close = { version = "0.3", default-features = false }
-ipnet = { version = "2" }
+ipnet = { version = "2", features = ["std"] }
 is-docker = { version = "0.2", default-features = false }
 is-wsl = { version = "0.4", default-features = false }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
 kqueue = { version = "1", default-features = false }
 kqueue-sys = { version = "1", default-features = false }
-kstring = { version = "2" }
+kstring = { version = "2", features = ["std", "unsafe"] }
 lazycell = { version = "1", default-features = false }
 libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
-libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked-hash-map = { version = "0.5", default-features = false }
 lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1" }
+match_cfg = { version = "0.1", features = ["use_core"] }
 maybe-async = { version = "0.2", features = ["is_sync"] }
-mio = { version = "0.8" }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+mio = { version = "0.8", features = ["log"] }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
 num_threads = { version = "0.1", default-features = false }
 once_cell = { version = "1", default-features = false, features = ["unstable"] }
 opener = { version = "0.5", default-features = false }
@@ -1191,52 +1209,53 @@ openssl = { version = "0.10", features = ["vendored"] }
 openssl-macros = { version = "0.1", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-ordered-float = { version = "2" }
+openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+ordered-float = { version = "2", features = ["std"] }
 orion = { version = "0.17", default-features = false }
-os_info = { version = "3" }
-p384 = { version = "0.13" }
-pasetors = { version = "0.6", features = ["serde", "v3"] }
+os_info = { version = "3", features = ["serde"] }
+p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
+pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
 pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
-pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
-polling = { version = "2" }
+pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
+polling = { version = "2", features = ["std"] }
 primeorder = { version = "0.13", default-features = false }
-prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
 quick-error = { version = "1", default-features = false }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rand_xoshiro = { version = "0.6", default-features = false }
 regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-search"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
 rfc6979 = { version = "0.4", default-features = false }
 rustfix = { version = "0.6", default-features = false }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["std", "termios", "use-libc-auxv"] }
 rustls = { version = "0.21", default-features = false, features = ["dangerous_configuration"] }
 rustls-pemfile = { version = "1", default-features = false }
-sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
 self_update = { version = "0.37", default-features = false, features = ["rustls"] }
 serde-value = { version = "0.7", default-features = false }
 sha1_smol = { version = "1", default-features = false }
 shell-escape = { version = "0.1", default-features = false }
-signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["mio-0_8", "support-v0_8"] }
 signal-hook-registry = { version = "1", default-features = false }
-signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
-sized-chunks = { version = "0.6" }
+signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6", features = ["std"] }
 smallvec = { version = "1", default-features = false, features = ["write"] }
-spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
 subtle = { version = "2", default-features = false, features = ["i128"] }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", default-features = false, features = ["visit-mut"] }
 time-468e82937335b1c9 = { package = "time", version = "0.3", default-features = false, features = ["local-offset", "macros"] }
 time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
-tokio-rustls = { version = "0.24" }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
-trust-dns-resolver = { version = "0.22" }
+tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
+tokio-util = { version = "0.7", default-features = false, features = ["codec", "tracing"] }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
+trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
 unicode-bidi = { version = "0.3" }
 unicode-bom = { version = "2", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
-xattr = { version = "1" }
+xattr = { version = "1", features = ["unsupported"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-1.toml
@@ -2,188 +2,1130 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'unify-if-both'
-# output-single-feature = false
-# dep-format-version = '3'
-# workspace-hack-line-style = 'full'
+# resolver = 'install'
+# unify-target-host = 'auto'
+# output-single-feature = true
+# dep-format-version = '4'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['powerpc64-wrs-vxworks']
-# [[traversal-excludes.ids]]
-# name = 'riscv-atomic-emulation-trap'
-# version = '0.4.0'
+#
+# [traversal-excludes]
+# [[final-excludes.ids]]
+# name = 'quick-xml'
+# version = '0.23.1'
 # crates-io = true
 #
-# [final-excludes]
+# [[final-excludes.ids]]
+# name = 'same-file'
+# version = '1.0.6'
+# crates-io = true
 
 [dependencies]
+acpi = { version = "4", default-features = false }
 addr2line = { version = "0.20" }
+adler = { version = "1", default-features = false }
+adler32 = { version = "1" }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1" }
+async-channel = { version = "1", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-std = { version = "1", features = ["unstable"] }
+atty = { version = "0.2", default-features = false }
 axum = { version = "0.6", features = ["ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["gimli-symbolize"] }
-bitflags = { version = "2", default-features = false, features = ["std"] }
+backtrace-ext = { version = "0.2", default-features = false }
+bare-metal = { version = "1", default-features = false }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
+bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
+bincode = { version = "1", default-features = false }
+bit-set = { version = "0.5" }
+bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit_field = { version = "0.10", default-features = false }
+bitfield = { version = "0.14", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
+bootloader_api = { version = "0.11", default-features = false }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
 byteorder = { version = "1" }
-clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+bytes = { version = "1" }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 cobs = { version = "0.2" }
-cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+color_quant = { version = "1", default-features = false }
+colorchoice = { version = "1", default-features = false }
+concurrent-queue = { version = "2" }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
+console-subscriber = { version = "0.1" }
+console_error_panic_hook = { version = "0.1", default-features = false }
+const_format = { version = "0.2" }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+crc32fast = { version = "1" }
 critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
-digest = { version = "0.10", features = ["mac", "oid", "std"] }
+crossbeam-channel = { version = "0.5" }
+crossbeam-deque = { version = "0.8" }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8" }
+d1-pac = { version = "0.0.31", default-features = false }
+deflate = { version = "0.8", default-features = false }
+defmt = { version = "0.3", default-features = false }
+dirs = { version = "4", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
 either = { version = "1" }
-embedded-hal = { version = "0.2", default-features = false, features = ["unproven"] }
+embedded-dma = { version = "0.2", default-features = false }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
+embedded-graphics-simulator = { version = "0.3" }
+embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
+embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+embedded-io = { version = "0.5", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-alloc = { version = "0.3", default-features = false }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-println = { version = "0.5", features = ["esp32c3"] }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
+esp32c3 = { version = "0.16", features = ["critical-section"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
+event-listener = { version = "2", default-features = false }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
 flate2 = { version = "1", features = ["zlib"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
+fugit = { version = "0.3", default-features = false }
 futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
 futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
 futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
-generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-getrandom = { version = "0.2", default-features = false, features = ["js", "std"] }
+gcd = { version = "2", default-features = false }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
+gif = { version = "0.11" }
 gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+gloo = { version = "0.9", features = ["futures"] }
+gloo-console = { version = "0.2", default-features = false }
+gloo-dialogs = { version = "0.1", default-features = false }
+gloo-events = { version = "0.1", default-features = false }
+gloo-file = { version = "0.2", features = ["futures"] }
+gloo-history = { version = "0.1" }
+gloo-net = { version = "0.3" }
+gloo-render = { version = "0.1", default-features = false }
+gloo-storage = { version = "0.2", default-features = false }
+gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
+gloo-worker = { version = "0.3", features = ["futures"] }
+h2 = { version = "0.3", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
 heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
 hex = { version = "0.4", features = ["serde"] }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+httparse = { version = "1" }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
-libz-sys = { version = "1", default-features = false, features = ["libc"] }
+hyper-timeout = { version = "0.4", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+image = { version = "0.23" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1" }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
+js-sys = { version = "0.3", default-features = false }
+kv-log-macro = { version = "1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+libc = { version = "0.2", features = ["extra_traits"] }
+libm = { version = "0.2" }
 linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
 log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
 maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+matchers = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
 memchr = { version = "2", features = ["use_std"] }
-miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
+miette = { version = "5", features = ["fancy"] }
+mime = { version = "0.3", default-features = false }
+minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
+miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
 mio = { version = "0.8", features = ["net", "os-ext"] }
-nb = { version = "0.1", default-features = false, features = ["unstable"] }
+modality-ingest-client = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
+nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
+nom = { version = "7" }
+nu-ansi-term = { version = "0.46", default-features = false }
+num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1", features = ["i128"] }
+num-iter = { version = "0.1" }
+num-rational = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
+num_cpus = { version = "1", default-features = false }
 object = { version = "0.31", default-features = false, features = ["compression", "read"] }
 once_cell = { version = "1", features = ["unstable"] }
+os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
+overload = { version = "0.1", default-features = false }
+ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
 owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
 percent-encoding = { version = "2" }
+pin-project = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pinned = { version = "0.1", default-features = false }
+png = { version = "0.16" }
 portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
-postcard = { version = "1", features = ["experimental-derive", "use-std"] }
-rand = { version = "0.8", features = ["small_rng"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
+postcard-cobs = { version = "0.1.5-pre", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+profont = { version = "0.6", default-features = false }
+proptest = { version = "1" }
+prost = { version = "0.11" }
+prost-types = { version = "0.11" }
+quick-error = { version = "1", default-features = false }
+r0 = { version = "1", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
 regex = { version = "1" }
-regex-automata = { version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.7" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
 riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.11", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
+ryu = { version = "1", default-features = false }
+scoped_threadpool = { version = "0.1", default-features = false }
 scopeguard = { version = "1" }
+sdl2 = { version = "0.32" }
+sdl2-sys = { version = "0.32" }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde-wasm-bindgen = { version = "0.5", default-features = false }
 serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
+sharded-slab = { version = "0.1", default-features = false }
+slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["write"] }
+smawk = { version = "0.3", default-features = false }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
 stable_deref_trait = { version = "1" }
-strum = { version = "0.25", features = ["derive"] }
-subtle = { version = "2", default-features = false, features = ["i128"] }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
+sync_wrapper = { version = "0.1", default-features = false }
+tempfile = { version = "3", default-features = false }
+termcolor = { version = "1", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+thiserror = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+tiff = { version = "0.6", default-features = false }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+tinyvec = { version = "1", features = ["alloc"] }
+tinyvec_macros = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["full", "tracing"] }
+tokio-io-timeout = { version = "1", default-features = false }
+tokio-native-tls = { version = "0.3", default-features = false }
 tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
+tonic = { version = "0.9" }
 tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-core = { version = "0.1" }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
 tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-wasm = { version = "0.2", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+unarray = { version = "0.1", default-features = false }
 unicode-bidi = { version = "0.3" }
+unicode-linebreak = { version = "0.1", default-features = false }
 unicode-normalization = { version = "0.1" }
-uuid = { version = "1", features = ["serde", "v4"] }
-zeroize = { version = "1" }
+unicode-width = { version = "0.1" }
+url = { version = "2" }
+utf8parse = { version = "0.2" }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+value-bag = { version = "1", default-features = false }
+vcell = { version = "0.1", default-features = false }
+void = { version = "1", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+wait-timeout = { version = "0.2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
+weezl = { version = "0.1" }
+winnow = { version = "0.5" }
 
 [build-dependencies]
+acpi = { version = "4", default-features = false }
 addr2line = { version = "0.20" }
+adler = { version = "1", default-features = false }
+adler32 = { version = "1" }
+aes = { version = "0.8", default-features = false }
+aho-corasick = { version = "1" }
+ansi_term = { version = "0.12", default-features = false }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
+anstyle-query = { version = "1", default-features = false }
+anyhow = { version = "1" }
+arrayvec = { version = "0.5", default-features = false }
+async-channel = { version = "1", default-features = false }
+async-lock = { version = "2", default-features = false }
+async-process = { version = "1", default-features = false }
+async-scoped = { version = "0.7", default-features = false, features = ["use-tokio"] }
+async-std = { version = "1", features = ["unstable"] }
+async-trait = { version = "0.1", default-features = false }
+atomicwrites = { version = "0.4", default-features = false }
+atty = { version = "0.2", default-features = false }
+autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
+autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
 axum = { version = "0.6", features = ["ws"] }
+axum-core = { version = "0.3", default-features = false }
+az = { version = "1", default-features = false }
 backtrace = { version = "0.3", features = ["gimli-symbolize"] }
-bitflags = { version = "2", default-features = false, features = ["std"] }
+backtrace-ext = { version = "0.2", default-features = false }
+bare-metal = { version = "1", default-features = false }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
+base64ct = { version = "1", default-features = false, features = ["alloc"] }
+basic-toml = { version = "0.1", default-features = false }
+bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
+bincode = { version = "1", default-features = false }
+binread = { version = "2" }
+binread_derive = { version = "2", default-features = false }
+bit-set = { version = "0.5" }
+bit-vec = { version = "0.6", default-features = false, features = ["std"] }
+bit_field = { version = "0.10", default-features = false }
+bitfield = { version = "0.14", default-features = false }
+bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
+bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 bitvec = { version = "1" }
+block-buffer = { version = "0.10", default-features = false }
+bootloader = { version = "0.11" }
+bootloader-boot-config = { version = "0.11", default-features = false }
+bootloader_api = { version = "0.11", default-features = false }
+bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["unicode"] }
+bumpalo = { version = "3" }
+bytecount = { version = "0.6", default-features = false }
 bytemuck = { version = "1", default-features = false, features = ["derive"] }
+bytemuck_derive = { version = "1", default-features = false }
 byteorder = { version = "1" }
+bytes = { version = "1" }
+bzip2 = { version = "0.4", default-features = false }
+bzip2-sys = { version = "0.1", default-features = false }
+camino = { version = "1", default-features = false, features = ["serde1"] }
+camino-tempfile = { version = "1", default-features = false }
+cargo-binutils = { version = "0.3", default-features = false }
+cargo-espflash = { version = "2", default-features = false }
+cargo-lock = { version = "9", default-features = false }
+cargo-nextest = { version = "0.9" }
+cargo-platform = { version = "0.1", default-features = false }
+cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
+cargo_metadata-582f2526e08bb6a0 = { package = "cargo_metadata", version = "0.14" }
+cargo_metadata-9067fe90e8c1f593 = { package = "cargo_metadata", version = "0.17" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
-clap = { version = "4", features = ["derive", "env", "wrap_help"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
+cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
+cipher = { version = "0.4", default-features = false }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
+clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["wrap_help"] }
 clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
+clap_complete = { version = "4" }
+clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
+clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
+clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
+clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
 cobs = { version = "0.2" }
-cordyceps = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+color-eyre = { version = "0.6", default-features = false }
+color_quant = { version = "1", default-features = false }
+colorchoice = { version = "1", default-features = false }
+comfy-table = { version = "7" }
+concurrent-queue = { version = "2" }
+config = { version = "0.13", default-features = false, features = ["toml"] }
+console = { version = "0.15" }
+console-api = { version = "0.5", default-features = false, features = ["transport"] }
+console-subscriber = { version = "0.1" }
+console_error_panic_hook = { version = "0.1", default-features = false }
+const-oid = { version = "0.9", default-features = false }
+const_format = { version = "0.2" }
+const_format_proc_macros = { version = "0.2" }
+constant_time_eq = { version = "0.1", default-features = false }
+convert_case = { version = "0.4", default-features = false }
+cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
+cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
+cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"] }
+crc = { version = "3", default-features = false }
+crc-catalog = { version = "2", default-features = false }
+crc32fast = { version = "1" }
 critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
+crossbeam-channel = { version = "0.5" }
+crossbeam-deque = { version = "0.8" }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8" }
+crossterm-2f80eeee3b1b6c7e = { package = "crossterm", version = "0.26", default-features = false }
+crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
+crypto-common = { version = "0.1", default-features = false, features = ["std"] }
+cssparser = { version = "0.27", default-features = false }
+cssparser-macros = { version = "0.6", default-features = false }
+csv = { version = "1", default-features = false }
+csv-core = { version = "0.1" }
+ctrlc = { version = "3", default-features = false, features = ["termination"] }
+cvt = { version = "0.1", default-features = false }
+d1-pac = { version = "0.0.31", default-features = false }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20" }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14" }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["suggestions"] }
+darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
+darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+data-encoding = { version = "2" }
+debug-ignore = { version = "1", default-features = false }
+deflate = { version = "0.8", default-features = false }
+defmt = { version = "0.3", default-features = false }
+defmt-macros = { version = "0.3", default-features = false }
+defmt-parser = { version = "0.3", default-features = false, features = ["unstable"] }
+deku = { version = "0.16" }
+deku_derive = { version = "0.16", default-features = false, features = ["std"] }
+derivative = { version = "2", default-features = false }
+derive_more = { version = "0.99" }
+dialoguer = { version = "0.10" }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
+directories = { version = "5", default-features = false }
+dirs = { version = "4", default-features = false }
+dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
+dirs-sys-9fbad63c4bcf4a8f = { package = "dirs-sys", version = "0.4", default-features = false }
+doc-comment = { version = "0.3", default-features = false }
+dotenvy = { version = "0.15", default-features = false }
+dtoa = { version = "1", default-features = false }
+dtoa-short = { version = "0.3", default-features = false }
+duct = { version = "0.13", default-features = false }
+dunce = { version = "1", default-features = false }
+edit-distance = { version = "2", default-features = false }
 either = { version = "1" }
+embedded-dma = { version = "0.2", default-features = false }
+embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
+embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
+embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
+embedded-graphics-simulator = { version = "0.3" }
+embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
+embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
+embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
+embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
+embedded-io = { version = "0.5", default-features = false }
+enable-ansi-support = { version = "0.2", default-features = false }
+env_logger = { version = "0.10" }
+envy = { version = "0.4", default-features = false }
+equivalent = { version = "1", default-features = false }
+esp-alloc = { version = "0.3", default-features = false }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["interrupt"] }
+esp-idf-part = { version = "0.4" }
+esp-println = { version = "0.5", features = ["esp32c3"] }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
+esp32c3 = { version = "0.16", features = ["critical-section"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
+espflash = { version = "2" }
+event-listener = { version = "2", default-features = false }
+eyre = { version = "0.6" }
+failure = { version = "0.1" }
+failure_derive = { version = "0.1", default-features = false }
+fallible-iterator = { version = "0.2", default-features = false, features = ["std"] }
+fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
+fatfs = { version = "0.3", default-features = false, features = ["alloc", "std"] }
+file-id = { version = "0.2", default-features = false }
+filetime = { version = "0.2", default-features = false }
+fixedbitset = { version = "0.4", default-features = false }
 flate2 = { version = "1", features = ["zlib"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
+fs_at = { version = "0.1" }
+fs_extra = { version = "1", default-features = false }
+fugit = { version = "0.3", default-features = false }
+funty = { version = "2", default-features = false }
+futf = { version = "0.1", default-features = false }
+future-queue = { version = "0.3", default-features = false }
 futures = { version = "0.3" }
 futures-channel = { version = "0.3", features = ["sink"] }
+futures-concurrency = { version = "7", default-features = false }
 futures-core = { version = "0.3" }
+futures-executor = { version = "0.3", default-features = false, features = ["std"] }
 futures-io = { version = "0.3" }
+futures-lite = { version = "1" }
+futures-macro = { version = "0.3", default-features = false }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
+fxhash = { version = "0.2", default-features = false }
+gcd = { version = "2", default-features = false }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
-getrandom = { version = "0.2", default-features = false, features = ["js", "std"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
+getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
+gif = { version = "0.11" }
 gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+gloo = { version = "0.9", features = ["futures"] }
+gloo-console = { version = "0.2", default-features = false }
+gloo-dialogs = { version = "0.1", default-features = false }
+gloo-events = { version = "0.1", default-features = false }
+gloo-file = { version = "0.2", features = ["futures"] }
+gloo-history = { version = "0.1" }
+gloo-net = { version = "0.3" }
+gloo-render = { version = "0.1", default-features = false }
+gloo-storage = { version = "0.2", default-features = false }
+gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
+gloo-worker = { version = "0.3", features = ["futures"] }
+gloo-worker-macros = { version = "0.1", default-features = false }
+gpt = { version = "3", default-features = false }
+guppy = { version = "0.17", default-features = false }
+guppy-workspace-hack = { version = "0.1", default-features = false }
+h2 = { version = "0.3", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
+hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
 heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+heck = { version = "0.4" }
 hex = { version = "0.4", features = ["serde"] }
+hmac = { version = "0.12", default-features = false, features = ["reset"] }
+home = { version = "0.5", default-features = false }
+html5ever = { version = "0.25", default-features = false }
+http = { version = "0.2", default-features = false }
+http-body = { version = "0.4", default-features = false }
+http-range-header = { version = "0.3", default-features = false }
+httparse = { version = "1" }
+httpdate = { version = "1", default-features = false }
+humantime = { version = "2", default-features = false }
+humantime-serde = { version = "1", default-features = false }
 hyper = { version = "0.14", features = ["full"] }
+hyper-timeout = { version = "0.4", default-features = false }
+ident_case = { version = "1", default-features = false }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+image = { version = "0.23" }
+indent_write = { version = "2" }
+indenter = { version = "0.3" }
+indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+indicatif = { version = "0.17" }
+inout = { version = "0.1", default-features = false }
+input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
+io-lifetimes = { version = "1" }
+is-terminal = { version = "0.4", default-features = false }
+is_ci = { version = "1", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", default-features = false, features = ["use_alloc"] }
+itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11" }
+itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
+itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
+jobserver = { version = "0.1", default-features = false }
+jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
+js-sys = { version = "0.3", default-features = false }
+just = { version = "1" }
+kv-log-macro = { version = "1", default-features = false }
+lazy_static = { version = "1", default-features = false }
+lexiclean = { version = "0.0.1", default-features = false }
+libc = { version = "0.2", features = ["extra_traits"] }
+libm = { version = "0.2" }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
+llvm-tools = { version = "0.1", default-features = false }
+local-ip-address = { version = "0.5", default-features = false }
+lock_api = { version = "0.4" }
 log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+mac = { version = "0.1", default-features = false }
 maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
+markup5ever = { version = "0.10", default-features = false }
+matchers = { version = "0.1", default-features = false }
+matches = { version = "0.1", default-features = false }
+matchit = { version = "0.7" }
+mbrman = { version = "0.5", default-features = false }
+md5 = { version = "0.7", default-features = false, features = ["std"] }
 memchr = { version = "2", features = ["use_std"] }
-miniz_oxide = { version = "0.7", default-features = false, features = ["with-alloc"] }
+memmap2 = { version = "0.5", default-features = false }
+memoffset-274715c4dabd11b0 = { package = "memoffset", version = "0.9" }
+micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
+micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
+miette = { version = "5", features = ["fancy"] }
+miette-derive = { version = "5", default-features = false }
+mime = { version = "0.3", default-features = false }
+mime_guess = { version = "2", default-features = false }
+minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
+minicbor-derive = { version = "0.8", default-features = false }
+minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
+miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
+miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
+miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
 mio = { version = "0.8", features = ["net", "os-ext"] }
+modality-ingest-client = { version = "0.1", default-features = false }
+mukti-metadata = { version = "0.1", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
+mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
+mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
+nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
+nested = { version = "0.1", default-features = false }
+new_debug_unreachable = { version = "1", default-features = false }
+nextest-filtering = { version = "0.5" }
+nextest-metadata = { version = "0.9", default-features = false }
+nextest-runner = { version = "0.45", default-features = false, features = ["self-update"] }
+nextest-workspace-hack = { version = "0.1", default-features = false }
+nipper = { version = "0.1", default-features = false }
+nodrop = { version = "0.1" }
+nom = { version = "7" }
+nom-tracable = { version = "0.9" }
+nom-tracable-macros = { version = "0.9", default-features = false }
+nom_locate = { version = "4" }
+normpath = { version = "1", default-features = false }
+notify = { version = "6" }
+notify-debouncer-full = { version = "0.3" }
+nu-ansi-term = { version = "0.46", default-features = false }
+num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1", features = ["i128"] }
+num-iter = { version = "0.1" }
+num-rational = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
+num_cpus = { version = "1", default-features = false }
+number_prefix = { version = "0.4" }
 object = { version = "0.31", default-features = false, features = ["compression", "read"] }
 once_cell = { version = "1", features = ["unstable"] }
+open = { version = "5", default-features = false }
+option-ext = { version = "0.2", default-features = false }
+os_pipe = { version = "1", default-features = false }
+os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
+overload = { version = "0.1", default-features = false }
+ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
 owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+parking = { version = "2", default-features = false }
+parking_lot = { version = "0.12" }
+parking_lot_core = { version = "0.9", default-features = false }
+parse_int = { version = "0.6" }
+password-hash = { version = "0.4", default-features = false, features = ["rand_core"] }
+paste = { version = "1", default-features = false }
+pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
+pbkdf2 = { version = "0.11" }
 percent-encoding = { version = "2" }
+petgraph = { version = "0.6", default-features = false }
+phf = { version = "0.8", features = ["macros"] }
+phf_codegen = { version = "0.8", default-features = false }
+phf_generator-93f6ce9d446188ac = { package = "phf_generator", version = "0.10", default-features = false }
+phf_generator-c38e5c1d305a1b54 = { package = "phf_generator", version = "0.8", default-features = false }
+phf_macros = { version = "0.8", default-features = false }
+phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
+phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8" }
+pin-project = { version = "1", default-features = false }
+pin-project-internal = { version = "1", default-features = false }
+pin-project-lite = { version = "0.2", default-features = false }
+pin-utils = { version = "0.1", default-features = false }
+pinned = { version = "0.1", default-features = false }
+pkg-config = { version = "0.3", default-features = false }
+png = { version = "0.16" }
 portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
-postcard = { version = "1", features = ["experimental-derive", "use-std"] }
-rand = { version = "0.8", features = ["small_rng"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
+postcard-cobs = { version = "0.1.5-pre", default-features = false }
+postcard-derive = { version = "0.1", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+precomputed-hash = { version = "0.1", default-features = false }
+proc-macro-crate = { version = "1", default-features = false }
+proc-macro-error = { version = "1" }
+proc-macro-error-attr = { version = "1", default-features = false }
+proc-macro-hack = { version = "0.5", default-features = false }
+proc-macro2 = { version = "1" }
+profont = { version = "0.6", default-features = false }
+proptest = { version = "1" }
+proptest-derive = { version = "0.4", default-features = false }
+prost = { version = "0.11" }
+prost-derive = { version = "0.11", default-features = false }
+prost-types = { version = "0.11" }
+quick-error = { version = "1", default-features = false }
+quick-junit = { version = "0.3", default-features = false }
+quick-xml = { version = "0.29" }
+quote = { version = "1" }
+r0 = { version = "1", default-features = false }
+radium = { version = "0.7", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
+rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
+rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
+rand_hc = { version = "0.1", default-features = false }
+rand_isaac = { version = "0.1", default-features = false }
+rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
+rand_os = { version = "0.1", default-features = false }
+rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
+rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+raw-cpuid = { version = "10", default-features = false }
+rayon = { version = "1", default-features = false }
+rayon-core = { version = "1", default-features = false }
+recursion = { version = "0.4" }
 regex = { version = "1" }
-regex-automata = { version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
-regex-syntax = { version = "0.7" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
+remove_dir_all = { version = "0.8" }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "default-tls", "json", "rustls-tls", "stream", "trust-dns"] }
+ring = { version = "0.16" }
+ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
+riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
+riscv-rt = { version = "0.11", default-features = false }
+riscv-rt-macros = { version = "0.2", default-features = false }
+riscv-target = { version = "0.1", default-features = false }
+rsdp = { version = "2", default-features = false }
+rustc-cfg = { version = "0.4", default-features = false }
+rustc-demangle = { version = "0.1", default-features = false }
+rustc_version = { version = "0.4", default-features = false }
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100" }
+rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101" }
+rustversion = { version = "1", default-features = false }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
+ruzstd = { version = "0.3", default-features = false }
+ryu = { version = "1", default-features = false }
+scoped_threadpool = { version = "0.1", default-features = false }
 scopeguard = { version = "1" }
+sct = { version = "0.7", default-features = false }
+sdl2 = { version = "0.32" }
+sdl2-sys = { version = "0.32" }
+seahash = { version = "4" }
+selectors = { version = "0.22", default-features = false }
+self_update = { version = "0.37", features = ["archive-tar", "compression-flate2", "rustls"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde-big-array = { version = "0.4", default-features = false }
+serde-wasm-bindgen = { version = "0.5", default-features = false }
+serde_derive = { version = "1" }
+serde_ignored = { version = "0.1", default-features = false }
 serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
+serde_path_to_error = { version = "0.1", default-features = false }
+serde_plain = { version = "1", default-features = false }
+serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
+serde_urlencoded = { version = "0.7", default-features = false }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
+servo_arc = { version = "0.1", default-features = false }
+sha1 = { version = "0.10" }
+sha2 = { version = "0.10" }
+sharded-slab = { version = "0.1", default-features = false }
+shared_child = { version = "1", default-features = false }
+shell-words = { version = "1" }
+similar = { version = "2", features = ["unicode"] }
+siphasher = { version = "0.3" }
+slab = { version = "0.4" }
+slip-codec = { version = "0.3" }
 smallvec = { version = "1", default-features = false, features = ["write"] }
+smawk = { version = "0.3", default-features = false }
+smol_str = { version = "0.2", features = ["serde"] }
+snafu = { version = "0.7" }
+snafu-derive = { version = "0.7", default-features = false, features = ["rust_1_39", "rust_1_46"] }
+socket2 = { version = "0.4", default-features = false, features = ["all"] }
 stable_deref_trait = { version = "1" }
-strum = { version = "0.25", features = ["derive"] }
+static_assertions = { version = "1", default-features = false }
+string_cache = { version = "0.8" }
+string_cache_codegen = { version = "0.5", default-features = false }
+strip-ansi-escapes = { version = "0.1", default-features = false }
+strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
+strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
+strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
+strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
 subtle = { version = "2", default-features = false, features = ["i128"] }
+supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
+supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
+supports-hyperlinks = { version = "2", default-features = false }
+supports-unicode = { version = "2", default-features = false }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
-time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+sync_wrapper = { version = "0.1", default-features = false }
+synstructure = { version = "0.12" }
+tap = { version = "1", default-features = false }
+tar = { version = "0.4" }
+target = { version = "2", default-features = false }
+target-lexicon = { version = "0.12", features = ["std"] }
+target-spec = { version = "3", default-features = false, features = ["custom", "summaries"] }
+target-spec-miette = { version = "0.3", default-features = false }
+tempfile = { version = "3", default-features = false }
+tendril = { version = "0.4", default-features = false }
+term_size = { version = "0.3" }
+termcolor = { version = "1", default-features = false }
+terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
+textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
+thin-slice = { version = "0.1", default-features = false }
+thiserror = { version = "1", default-features = false }
+thiserror-impl = { version = "1", default-features = false }
+thread_local = { version = "1", default-features = false }
+tiff = { version = "0.6", default-features = false }
+time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
+time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
+time-core = { version = "0.1", default-features = false }
+time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
+tinyvec = { version = "1", features = ["alloc"] }
+tinyvec_macros = { version = "0.1", default-features = false }
 tokio = { version = "1", features = ["full", "tracing"] }
+tokio-io-timeout = { version = "1", default-features = false }
+tokio-macros = { version = "2", default-features = false }
+tokio-native-tls = { version = "0.3", default-features = false }
 tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-tungstenite = { version = "0.19" }
 tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
+toml-d8f496e17d97b5cb = { package = "toml", version = "0.5" }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
+tonic = { version = "0.9" }
 tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
-tracing = { version = "0.1", features = ["log"] }
-tracing-core = { version = "0.1" }
+tower-http = { version = "0.4", features = ["fs", "trace"] }
+tower-layer = { version = "0.3", default-features = false }
+tower-service = { version = "0.3", default-features = false }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
+tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
+tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
+tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
+tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
 tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-wasm = { version = "0.2", default-features = false }
+trunk = { version = "0.17", default-features = false }
+try-lock = { version = "0.2", default-features = false }
+tungstenite = { version = "0.19", default-features = false, features = ["handshake"] }
+twox-hash = { version = "1", default-features = false }
+typed-arena = { version = "2" }
+typenum = { version = "1", default-features = false }
+unarray = { version = "0.1", default-features = false }
+unicase = { version = "2", default-features = false }
 unicode-bidi = { version = "0.3" }
+unicode-ident = { version = "1", default-features = false }
+unicode-linebreak = { version = "0.1", default-features = false }
 unicode-normalization = { version = "0.1" }
-uuid = { version = "1", features = ["serde", "v4"] }
+unicode-segmentation = { version = "1", default-features = false }
+unicode-width = { version = "0.1" }
+unicode-xid = { version = "0.2" }
+untrusted = { version = "0.7", default-features = false }
+update-informer = { version = "1" }
+ureq = { version = "2", default-features = false, features = ["gzip", "json", "tls"] }
+url = { version = "2" }
+urlencoding = { version = "2", default-features = false }
+utf-8 = { version = "0.7", default-features = false }
+utf8parse = { version = "0.2" }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
+value-bag = { version = "1", default-features = false }
+vcell = { version = "0.1", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
+vec_map = { version = "0.8", default-features = false }
+vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc"] }
+version_check = { version = "0.9", default-features = false }
+void = { version = "1", default-features = false }
+volatile = { version = "0.4", default-features = false, features = ["unstable"] }
+vte = { version = "0.10" }
+vte_generate_state_changes = { version = "0.1", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
+waker-fn = { version = "1", default-features = false }
+walkdir = { version = "2", default-features = false }
+want = { version = "0.3", default-features = false }
+wasm-bindgen = { version = "0.2" }
+wasm-bindgen-backend = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-macro = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-macro-support = { version = "0.2", default-features = false, features = ["spans"] }
+wasm-bindgen-shared = { version = "0.2", default-features = false }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
+webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
+weezl = { version = "0.1" }
+which = { version = "4", default-features = false }
+winnow = { version = "0.5" }
+wyz = { version = "0.5", default-features = false }
+xmas-elf = { version = "0.9", default-features = false }
+zero = { version = "0.1", default-features = false }
 zeroize = { version = "1" }
+zip = { version = "0.6" }
+zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["zstdmt"] }
+zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11" }
+zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
+zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
 [target.powerpc64-wrs-vxworks.dependencies]
-crossbeam-utils = { version = "0.8" }
-io-lifetimes = { version = "1" }
-libc = { version = "0.2", features = ["extra_traits", "use_std"] }
-nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1" }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
 openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-rustix = { version = "0.37", features = ["fs", "termios"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2" }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
 signal-hook = { version = "0.3" }
+signal-hook-registry = { version = "1", default-features = false }
+static_assertions = { version = "1", default-features = false }
+waker-fn = { version = "1", default-features = false }
 
 [target.powerpc64-wrs-vxworks.build-dependencies]
-crossbeam-utils = { version = "0.8" }
-io-lifetimes = { version = "1" }
-itertools = { version = "0.10" }
-libc = { version = "0.2", features = ["extra_traits", "use_std"] }
-nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+ahash = { version = "0.8" }
+arc-swap = { version = "1", default-features = false }
+async-executor = { version = "1", default-features = false }
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+bitmaps = { version = "2" }
+blocking = { version = "1", default-features = false }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
+btoi = { version = "0.4" }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
+der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
+encoding_rs = { version = "0.8" }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+faster-hex = { version = "0.8" }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+git2 = { version = "0.17" }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4" }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1" }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kstring = { version = "2" }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+linked-hash-map = { version = "0.5", default-features = false }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1" }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+opener = { version = "0.5", default-features = false }
 openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
 openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-rustix = { version = "0.37", features = ["fs", "termios"] }
+ordered-float = { version = "2" }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3" }
+p384 = { version = "0.13" }
+pasetors = { version = "0.6", features = ["serde", "v3"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
+polling = { version = "2" }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rand_xoshiro = { version = "0.6", default-features = false }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
 signal-hook = { version = "0.3" }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6" }
+spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
+unicode-bom = { version = "2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-2.toml
@@ -2,95 +2,88 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture mnemos_b3b4da9
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = 'install'
+# unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '2'
+# dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['nvptx64-nvidia-cuda', 'thumbv7em-none-eabi', 'i686-uwp-windows-msvc']
 # [[traversal-excludes.ids]]
-# name = 'cargo_metadata'
-# version = '0.14.2'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'cfg-if'
-# version = '0.1.10'
-# crates-io = true
-# [[final-excludes.ids]]
-# name = 'hal-core'
+# name = 'spitebuf'
 # version = '0.1.0'
-# source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+# workspace-path = 'source/spitebuf'
+#
+# [final-excludes]
 
 [dependencies]
 acpi = { version = "4", default-features = false }
-addr2line = { version = "0.20", features = ["cpp_demangle", "fallible-iterator", "memmap2", "object", "rustc-demangle", "smallvec", "std", "std-object"] }
+addr2line = { version = "0.20" }
 adler = { version = "1", default-features = false }
-adler32 = { version = "1", features = ["std"] }
-anstream = { version = "0.5", features = ["auto", "wincon"] }
-anstyle = { version = "1", features = ["std"] }
-anstyle-parse = { version = "0.2", features = ["utf8"] }
+adler32 = { version = "1" }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
 anstyle-query = { version = "1", default-features = false }
-anyhow = { version = "1", features = ["std"] }
+anyhow = { version = "1" }
 async-channel = { version = "1", default-features = false }
 async-lock = { version = "2", default-features = false }
-async-std = { version = "1", features = ["alloc", "async-channel", "async-global-executor", "async-io", "async-lock", "async-process", "crossbeam-utils", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "unstable", "wasm-bindgen-futures"] }
+async-std = { version = "1", features = ["unstable"] }
 atty = { version = "0.2", default-features = false }
-axum = { version = "0.6", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "ws"] }
+axum = { version = "0.6", features = ["ws"] }
 axum-core = { version = "0.3", default-features = false }
 az = { version = "1", default-features = false }
-backtrace = { version = "0.3", features = ["gimli-symbolize", "std"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
 backtrace-ext = { version = "0.2", default-features = false }
 bare-metal = { version = "1", default-features = false }
-base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["std"] }
-base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
 bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
 bincode = { version = "1", default-features = false }
-bit-set = { version = "0.5", features = ["std"] }
+bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bit_field = { version = "0.10", default-features = false }
 bitfield = { version = "0.14", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
 bootloader_api = { version = "0.11", default-features = false }
-bytemuck = { version = "1", default-features = false, features = ["bytemuck_derive", "derive"] }
-byteorder = { version = "1", features = ["std"] }
-bytes = { version = "1", features = ["std"] }
-cfg-if = { version = "1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
-clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
-clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
+byteorder = { version = "1" }
+bytes = { version = "1" }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
 clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
-cobs = { version = "0.2", features = ["use_std"] }
+cobs = { version = "0.2" }
 color_quant = { version = "1", default-features = false }
 colorchoice = { version = "1", default-features = false }
-concurrent-queue = { version = "2", features = ["std"] }
+concurrent-queue = { version = "2" }
 console-api = { version = "0.5", default-features = false, features = ["transport"] }
-console-subscriber = { version = "0.1", features = ["env-filter"] }
+console-subscriber = { version = "0.1" }
 console_error_panic_hook = { version = "0.1", default-features = false }
 const_format = { version = "0.2" }
 cordyceps-29129200550082f8 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium", default-features = false }
 cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc"] }
-crc32fast = { version = "1", features = ["std"] }
+crc32fast = { version = "1" }
 critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
-crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
-crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
-crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "std"] }
-crossbeam-utils = { version = "0.8", features = ["std"] }
+crossbeam-channel = { version = "0.5" }
+crossbeam-deque = { version = "0.8" }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8" }
 d1-pac = { version = "0.0.31", default-features = false }
 deflate = { version = "0.8", default-features = false }
 defmt = { version = "0.3", default-features = false }
 dirs = { version = "4", default-features = false }
 dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
-either = { version = "1", features = ["use_std"] }
+either = { version = "1" }
 embedded-dma = { version = "0.2", default-features = false }
-embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
 embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
 embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
 embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
-embedded-graphics-simulator = { version = "0.3", features = ["sdl2", "with-sdl"] }
+embedded-graphics-simulator = { version = "0.3" }
 embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
 embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
 embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
@@ -98,67 +91,68 @@ embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
 embedded-io = { version = "0.5", default-features = false }
 equivalent = { version = "1", default-features = false }
 esp-alloc = { version = "0.3", default-features = false }
-esp-backtrace = { version = "0.7", default-features = false, features = ["esp-println", "esp32c3", "exception-handler", "panic-handler", "print-uart"] }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp-riscv-rt", "esp32c3", "rv-zero-rtc-bss", "vectored"] }
-esp-println = { version = "0.5", features = ["colors", "critical-section", "esp32c3", "uart"] }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-println = { version = "0.5", features = ["esp32c3"] }
 esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
 esp32c3 = { version = "0.16", features = ["critical-section"] }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", features = ["rt", "vectored"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
 event-listener = { version = "2", default-features = false }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
-flate2 = { version = "1", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
-float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
-float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9", features = ["num-traits", "ratio"] }
-fnv = { version = "1", features = ["std"] }
-form_urlencoded = { version = "1", features = ["alloc", "std"] }
+flate2 = { version = "1", features = ["zlib"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
 fugit = { version = "0.3", default-features = false }
-futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-core = { version = "0.3" }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
-futures-io = { version = "0.3", features = ["std"] }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+futures-io = { version = "0.3" }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 gcd = { version = "2", default-features = false }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "std", "wasm-bindgen"] }
-gif = { version = "0.11", features = ["raii_no_panic", "std"] }
-gimli = { version = "0.27", default-features = false, features = ["endian-reader", "fallible-iterator", "read", "read-core", "stable_deref_trait", "std"] }
-gloo = { version = "0.9", features = ["console", "dialogs", "events", "file", "futures", "gloo-console", "gloo-dialogs", "gloo-events", "gloo-file", "gloo-history", "gloo-net", "gloo-render", "gloo-storage", "gloo-timers", "gloo-utils", "gloo-worker", "history", "net", "render", "storage", "timers", "utils", "worker"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
+gif = { version = "0.11" }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+gloo = { version = "0.9", features = ["futures"] }
 gloo-console = { version = "0.2", default-features = false }
 gloo-dialogs = { version = "0.1", default-features = false }
 gloo-events = { version = "0.1", default-features = false }
-gloo-file = { version = "0.2", features = ["futures", "futures-channel"] }
-gloo-history = { version = "0.1", features = ["query", "serde_urlencoded", "thiserror"] }
-gloo-net = { version = "0.3", features = ["eventsource", "futures-channel", "futures-core", "futures-sink", "http", "json", "pin-project", "serde", "serde_json", "websocket"] }
+gloo-file = { version = "0.2", features = ["futures"] }
+gloo-history = { version = "0.1" }
+gloo-net = { version = "0.3" }
 gloo-render = { version = "0.1", default-features = false }
 gloo-storage = { version = "0.2", default-features = false }
-gloo-timers = { version = "0.2", features = ["futures", "futures-channel", "futures-core"] }
-gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1", features = ["serde"] }
-gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2", features = ["serde"] }
+gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
 gloo-worker = { version = "0.3", features = ["futures"] }
 h2 = { version = "0.3", default-features = false }
-hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
-hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
 hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
-hdrhistogram = { version = "7", default-features = false, features = ["base64", "flate2", "nom", "serialization"] }
-heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
-hex = { version = "0.4", features = ["alloc", "serde", "std"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
+hex = { version = "0.4", features = ["serde"] }
 http = { version = "0.2", default-features = false }
 http-body = { version = "0.4", default-features = false }
-httparse = { version = "1", features = ["std"] }
+httparse = { version = "1" }
 httpdate = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
-hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+hyper = { version = "0.14", features = ["full"] }
 hyper-timeout = { version = "0.4", default-features = false }
-idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
-image = { version = "0.23", features = ["bmp", "dds", "dxt", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "png", "pnm", "scoped_threadpool", "tga", "tiff", "webp"] }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+image = { version = "0.23" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
-indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
 input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
-io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
+io-lifetimes = { version = "1" }
 is-terminal = { version = "0.4", default-features = false }
 is_ci = { version = "1", default-features = false }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
@@ -166,115 +160,115 @@ jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"]
 js-sys = { version = "0.3", default-features = false }
 kv-log-macro = { version = "1", default-features = false }
 lazy_static = { version = "1", default-features = false }
-libc = { version = "0.2", features = ["extra_traits", "std"] }
+libc = { version = "0.2", features = ["extra_traits"] }
 libm = { version = "0.2" }
 linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
-log = { version = "0.4", default-features = false, features = ["kv_unstable", "std", "value-bag"] }
-maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc", "tracing-01"] }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
 matchers = { version = "0.1", default-features = false }
 matchit = { version = "0.7" }
-memchr = { version = "2", features = ["std", "use_std"] }
+memchr = { version = "2", features = ["use_std"] }
 memoffset = { version = "0.9" }
 micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
 micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
-miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
+miette = { version = "5", features = ["fancy"] }
 mime = { version = "0.3", default-features = false }
-minicbor = { version = "0.13", default-features = false, features = ["alloc", "derive", "minicbor-derive", "std"] }
+minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
 miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
 miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio = { version = "0.8", features = ["log", "net", "os-ext", "os-poll"] }
+mio = { version = "0.8", features = ["net", "os-ext"] }
 modality-ingest-client = { version = "0.1", default-features = false }
-mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
-mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
 mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
-mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
-mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
 mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
 mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
 native-tls = { version = "0.2", default-features = false }
 nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
 nb-dff4ba8e3ae991db = { package = "nb", version = "1", default-features = false }
-nom = { version = "7", features = ["alloc", "std"] }
+nom = { version = "7" }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.1", default-features = false }
-num-integer = { version = "0.1", features = ["i128", "std"] }
-num-iter = { version = "0.1", features = ["std"] }
+num-integer = { version = "0.1", features = ["i128"] }
+num-iter = { version = "0.1" }
 num-rational = { version = "0.3", default-features = false }
-num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
 num_cpus = { version = "1", default-features = false }
-object = { version = "0.31", default-features = false, features = ["archive", "coff", "compression", "elf", "flate2", "macho", "pe", "read", "read_core", "ruzstd", "std", "unaligned", "xcoff"] }
-once_cell = { version = "1", features = ["alloc", "race", "std", "unstable"] }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1", features = ["unstable"] }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 overload = { version = "0.1", default-features = false }
 ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
-owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
-percent-encoding = { version = "2", features = ["alloc", "std"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
+percent-encoding = { version = "2" }
 pin-project = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
 pinned = { version = "0.1", default-features = false }
-png = { version = "0.16", features = ["deflate", "png-encoding"] }
-portable-atomic = { version = "1", features = ["critical-section", "fallback", "require-cas"] }
-postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["heapless", "heapless-cas", "use-std"] }
-postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
+png = { version = "0.16" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
 postcard-cobs = { version = "0.1.5-pre", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 profont = { version = "0.6", default-features = false }
-proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
-prost = { version = "0.11", features = ["prost-derive", "std"] }
-prost-types = { version = "0.11", features = ["std"] }
+proptest = { version = "1" }
+prost = { version = "0.11" }
+prost-types = { version = "0.11" }
 quick-error = { version = "1", default-features = false }
 r0 = { version = "1", default-features = false }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
-rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
-rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os = { version = "0.1", default-features = false }
 rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
-rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
 rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
 raw-cpuid = { version = "10", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
-regex = { version = "1", features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"] }
-regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex = { version = "1" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
 ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
 riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
 riscv-rt = { version = "0.11", default-features = false }
 rsdp = { version = "2", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
 ryu = { version = "1", default-features = false }
 scoped_threadpool = { version = "0.1", default-features = false }
-scopeguard = { version = "1", features = ["use_std"] }
+scopeguard = { version = "1" }
 sdl2 = { version = "0.32" }
 sdl2-sys = { version = "0.32" }
-serde = { version = "1", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-wasm-bindgen = { version = "0.5", default-features = false }
-serde_json = { version = "1", features = ["raw_value", "std", "unbounded_depth"] }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
 serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_urlencoded = { version = "0.7", default-features = false }
-serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f", features = ["libudev"] }
-serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
 sharded-slab = { version = "0.1", default-features = false }
-slab = { version = "0.4", features = ["std"] }
+slab = { version = "0.4" }
 smallvec = { version = "1", default-features = false, features = ["write"] }
 smawk = { version = "0.3", default-features = false }
 socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+stable_deref_trait = { version = "1" }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
-strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive", "std", "strum_macros"] }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
 supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
 supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
 supports-hyperlinks = { version = "2", default-features = false }
@@ -283,148 +277,150 @@ sync_wrapper = { version = "0.1", default-features = false }
 tempfile = { version = "3", default-features = false }
 termcolor = { version = "1", default-features = false }
 terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
-textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
 textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
 thiserror = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 tiff = { version = "0.6", default-features = false }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
-tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
+tinyvec = { version = "1", features = ["alloc"] }
 tinyvec_macros = { version = "0.1", default-features = false }
-tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "tracing", "windows-sys"] }
+tokio = { version = "1", features = ["full", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-native-tls = { version = "0.3", default-features = false }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
-tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
-toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
-tonic = { version = "0.9", features = ["channel", "codegen", "prost", "transport"] }
-tower = { version = "0.4", default-features = false, features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
+tonic = { version = "0.9" }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
-tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
-tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
-tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std", "valuable"] }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
 tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
 tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
-tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", features = ["std"] }
-tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-wasm = { version = "0.2", default-features = false }
 try-lock = { version = "0.2", default-features = false }
 unarray = { version = "0.1", default-features = false }
-unicode-bidi = { version = "0.3", features = ["hardcoded-data", "std"] }
+unicode-bidi = { version = "0.3" }
 unicode-linebreak = { version = "0.1", default-features = false }
-unicode-normalization = { version = "0.1", features = ["std"] }
+unicode-normalization = { version = "0.1" }
 unicode-width = { version = "0.1" }
 url = { version = "2" }
 utf8parse = { version = "0.2" }
-uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["getrandom", "std", "v4"] }
-uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
 value-bag = { version = "1", default-features = false }
 vcell = { version = "0.1", default-features = false }
 void = { version = "1", default-features = false }
 volatile = { version = "0.4", default-features = false, features = ["unstable"] }
 wait-timeout = { version = "0.2", default-features = false }
 want = { version = "0.3", default-features = false }
-wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
+wasm-bindgen = { version = "0.2" }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "Blob", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "Element", "ErrorEvent", "Event", "EventSource", "EventTarget", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "Node", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "UiEvent", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerGlobalScope", "WorkerOptions", "console"] }
-weezl = { version = "0.1", features = ["alloc", "std"] }
-winnow = { version = "0.5", features = ["alloc", "std"] }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
+weezl = { version = "0.1" }
+winnow = { version = "0.5" }
 
 [build-dependencies]
 acpi = { version = "4", default-features = false }
-addr2line = { version = "0.20", features = ["cpp_demangle", "fallible-iterator", "memmap2", "object", "rustc-demangle", "smallvec", "std", "std-object"] }
+addr2line = { version = "0.20" }
 adler = { version = "1", default-features = false }
-adler32 = { version = "1", features = ["std"] }
+adler32 = { version = "1" }
 aes = { version = "0.8", default-features = false }
-aho-corasick = { version = "1", features = ["perf-literal", "std"] }
+aho-corasick = { version = "1" }
 ansi_term = { version = "0.12", default-features = false }
-anstream = { version = "0.5", features = ["auto", "wincon"] }
-anstyle = { version = "1", features = ["std"] }
-anstyle-parse = { version = "0.2", features = ["utf8"] }
+anstream = { version = "0.5" }
+anstyle = { version = "1" }
+anstyle-parse = { version = "0.2" }
 anstyle-query = { version = "1", default-features = false }
-anyhow = { version = "1", features = ["std"] }
+anyhow = { version = "1" }
 arrayvec = { version = "0.5", default-features = false }
 async-channel = { version = "1", default-features = false }
 async-lock = { version = "2", default-features = false }
 async-process = { version = "1", default-features = false }
-async-scoped = { version = "0.7", default-features = false, features = ["tokio", "use-tokio"] }
-async-std = { version = "1", features = ["alloc", "async-channel", "async-global-executor", "async-io", "async-lock", "async-process", "crossbeam-utils", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "unstable", "wasm-bindgen-futures"] }
+async-scoped = { version = "0.7", default-features = false, features = ["use-tokio"] }
+async-std = { version = "1", features = ["unstable"] }
 async-trait = { version = "0.1", default-features = false }
 atomicwrites = { version = "0.4", default-features = false }
 atty = { version = "0.2", default-features = false }
 autocfg-c65f7effa3be6d31 = { package = "autocfg", version = "0.1", default-features = false }
 autocfg-dff4ba8e3ae991db = { package = "autocfg", version = "1", default-features = false }
-axum = { version = "0.6", features = ["form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "ws"] }
+axum = { version = "0.6", features = ["ws"] }
 axum-core = { version = "0.3", default-features = false }
 az = { version = "1", default-features = false }
-backtrace = { version = "0.3", features = ["gimli-symbolize", "std"] }
+backtrace = { version = "0.3", features = ["gimli-symbolize"] }
 backtrace-ext = { version = "0.2", default-features = false }
 bare-metal = { version = "1", default-features = false }
-base64-594e8ee84c453af0 = { package = "base64", version = "0.13", features = ["std"] }
-base64-647d43efb71741da = { package = "base64", version = "0.21", features = ["std"] }
+base64-594e8ee84c453af0 = { package = "base64", version = "0.13" }
+base64-647d43efb71741da = { package = "base64", version = "0.21" }
 base64ct = { version = "1", default-features = false, features = ["alloc"] }
 basic-toml = { version = "0.1", default-features = false }
 bbq10kbd = { git = "https://github.com/hawkw/bbq10kbd", branch = "eliza/async", default-features = false, features = ["embedded-hal-async"] }
 bincode = { version = "1", default-features = false }
-binread = { version = "2", features = ["std"] }
+binread = { version = "2" }
 binread_derive = { version = "2", default-features = false }
-bit-set = { version = "0.5", features = ["std"] }
+bit-set = { version = "0.5" }
 bit-vec = { version = "0.6", default-features = false, features = ["std"] }
 bit_field = { version = "0.10", default-features = false }
 bitfield = { version = "0.14", default-features = false }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2", default-features = false, features = ["std"] }
-bitvec = { version = "1", features = ["alloc", "atomic", "std"] }
+bitvec = { version = "1" }
 block-buffer = { version = "0.10", default-features = false }
-bootloader = { version = "0.11", features = ["bios", "uefi"] }
+bootloader = { version = "0.11" }
 bootloader-boot-config = { version = "0.11", default-features = false }
 bootloader_api = { version = "0.11", default-features = false }
-bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["lazy_static", "regex-automata", "unicode"] }
+bstr-6f8ce4dd05d13bba = { package = "bstr", version = "0.2", default-features = false, features = ["unicode"] }
 bumpalo = { version = "3" }
 bytecount = { version = "0.6", default-features = false }
-bytemuck = { version = "1", default-features = false, features = ["bytemuck_derive", "derive"] }
+bytemuck = { version = "1", default-features = false, features = ["derive"] }
 bytemuck_derive = { version = "1", default-features = false }
-byteorder = { version = "1", features = ["std"] }
-bytes = { version = "1", features = ["std"] }
+byteorder = { version = "1" }
+bytes = { version = "1" }
 bzip2 = { version = "0.4", default-features = false }
 bzip2-sys = { version = "0.1", default-features = false }
-camino = { version = "1", default-features = false, features = ["serde", "serde1"] }
+camino = { version = "1", default-features = false, features = ["serde1"] }
 camino-tempfile = { version = "1", default-features = false }
 cargo-binutils = { version = "0.3", default-features = false }
 cargo-espflash = { version = "2", default-features = false }
 cargo-lock = { version = "9", default-features = false }
-cargo-nextest = { version = "0.9", features = ["default-no-update", "self-update"] }
+cargo-nextest = { version = "0.9" }
 cargo-platform = { version = "0.1", default-features = false }
 cargo_metadata-3575ec1268b04181 = { package = "cargo_metadata", version = "0.15" }
+cargo_metadata-582f2526e08bb6a0 = { package = "cargo_metadata", version = "0.14" }
 cargo_metadata-9067fe90e8c1f593 = { package = "cargo_metadata", version = "0.17" }
-cc = { version = "1", default-features = false, features = ["jobserver", "parallel"] }
-cfg-expr = { version = "0.15", features = ["target-lexicon", "targets"] }
-cfg-if = { version = "1", default-features = false }
-chrono = { version = "0.4", features = ["clock", "iana-time-zone", "js-sys", "oldtime", "std", "time", "wasm-bindgen", "wasmbind", "winapi"] }
+cc = { version = "1", default-features = false, features = ["parallel"] }
+cfg-expr = { version = "0.15", features = ["targets"] }
+cfg-if-c65f7effa3be6d31 = { package = "cfg-if", version = "0.1", default-features = false }
+cfg-if-dff4ba8e3ae991db = { package = "cfg-if", version = "1", default-features = false }
+chrono = { version = "0.4" }
 cipher = { version = "0.4", default-features = false }
-clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["ansi_term", "atty", "color", "strsim", "suggestions", "term_size", "vec_map", "wrap_help"] }
-clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
-clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["color", "derive", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+clap-164d15cefe24d7eb = { package = "clap", version = "4", features = ["derive", "env", "wrap_help"] }
+clap-7b89eefb6aaa9bf3 = { package = "clap", version = "3", features = ["derive", "env"] }
+clap-f595c2ba2a3f28df = { package = "clap", version = "2", features = ["wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = ["color", "env", "std", "suggestions", "usage", "wrap_help"] }
 clap_complete = { version = "4" }
-clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
 clap_derive-164d15cefe24d7eb = { package = "clap_derive", version = "4" }
+clap_derive-7b89eefb6aaa9bf3 = { package = "clap_derive", version = "3" }
 clap_lex-6f8ce4dd05d13bba = { package = "clap_lex", version = "0.2", default-features = false }
 clap_lex-d8f496e17d97b5cb = { package = "clap_lex", version = "0.5", default-features = false }
-cobs = { version = "0.2", features = ["use_std"] }
+cobs = { version = "0.2" }
 color-eyre = { version = "0.6", default-features = false }
 color_quant = { version = "1", default-features = false }
 colorchoice = { version = "1", default-features = false }
-comfy-table = { version = "7", features = ["crossterm", "tty"] }
-concurrent-queue = { version = "2", features = ["std"] }
+comfy-table = { version = "7" }
+concurrent-queue = { version = "2" }
 config = { version = "0.13", default-features = false, features = ["toml"] }
-console = { version = "0.15", features = ["ansi-parsing", "unicode-width"] }
+console = { version = "0.15" }
 console-api = { version = "0.5", default-features = false, features = ["transport"] }
-console-subscriber = { version = "0.1", features = ["env-filter"] }
+console-subscriber = { version = "0.1" }
 console_error_panic_hook = { version = "0.1", default-features = false }
 const-oid = { version = "0.9", default-features = false }
 const_format = { version = "0.2" }
@@ -436,14 +432,14 @@ cordyceps-453ff9c272a9ee45 = { package = "cordyceps", git = "https://github.com/
 cpp_demangle = { version = "0.4", default-features = false, features = ["alloc"] }
 crc = { version = "3", default-features = false }
 crc-catalog = { version = "2", default-features = false }
-crc32fast = { version = "1", features = ["std"] }
+crc32fast = { version = "1" }
 critical-section = { version = "1", default-features = false, features = ["restore-state-bool"] }
-crossbeam-channel = { version = "0.5", features = ["crossbeam-utils", "std"] }
-crossbeam-deque = { version = "0.8", features = ["crossbeam-epoch", "crossbeam-utils", "std"] }
-crossbeam-epoch = { version = "0.9", default-features = false, features = ["alloc", "std"] }
-crossbeam-utils = { version = "0.8", features = ["std"] }
-crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25", features = ["bracketed-paste"] }
+crossbeam-channel = { version = "0.5" }
+crossbeam-deque = { version = "0.8" }
+crossbeam-epoch = { version = "0.9", default-features = false, features = ["std"] }
+crossbeam-utils = { version = "0.8" }
 crossterm-2f80eeee3b1b6c7e = { package = "crossterm", version = "0.26", default-features = false }
+crossterm-2ffb4c3fe830441c = { package = "crossterm", version = "0.25" }
 crypto-common = { version = "0.1", default-features = false, features = ["std"] }
 cssparser = { version = "0.27", default-features = false }
 cssparser-macros = { version = "0.6", default-features = false }
@@ -452,24 +448,24 @@ csv-core = { version = "0.1" }
 ctrlc = { version = "3", default-features = false, features = ["termination"] }
 cvt = { version = "0.1", default-features = false }
 d1-pac = { version = "0.0.31", default-features = false }
-darling-582f2526e08bb6a0 = { package = "darling", version = "0.14", features = ["suggestions"] }
-darling-56bd22fc3884b12 = { package = "darling", version = "0.20", features = ["suggestions"] }
-darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["strsim", "suggestions"] }
-darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["strsim", "suggestions"] }
-darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+darling-56bd22fc3884b12 = { package = "darling", version = "0.20" }
+darling-582f2526e08bb6a0 = { package = "darling", version = "0.14" }
+darling_core-56bd22fc3884b12 = { package = "darling_core", version = "0.20", default-features = false, features = ["suggestions"] }
+darling_core-582f2526e08bb6a0 = { package = "darling_core", version = "0.14", default-features = false, features = ["suggestions"] }
 darling_macro-56bd22fc3884b12 = { package = "darling_macro", version = "0.20", default-features = false }
-data-encoding = { version = "2", features = ["alloc", "std"] }
+darling_macro-582f2526e08bb6a0 = { package = "darling_macro", version = "0.14", default-features = false }
+data-encoding = { version = "2" }
 debug-ignore = { version = "1", default-features = false }
 deflate = { version = "0.8", default-features = false }
 defmt = { version = "0.3", default-features = false }
 defmt-macros = { version = "0.3", default-features = false }
 defmt-parser = { version = "0.3", default-features = false, features = ["unstable"] }
-deku = { version = "0.16", features = ["alloc", "const_generics", "std"] }
-deku_derive = { version = "0.16", default-features = false, features = ["proc-macro-crate", "std"] }
+deku = { version = "0.16" }
+deku_derive = { version = "0.16", default-features = false, features = ["std"] }
 derivative = { version = "2", default-features = false }
-derive_more = { version = "0.99", features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "convert_case", "deref", "deref_mut", "display", "error", "from", "from_str", "index", "index_mut", "into", "into_iterator", "is_variant", "iterator", "mul", "mul_assign", "not", "rustc_version", "sum", "try_into", "unwrap"] }
-dialoguer = { version = "0.10", features = ["editor", "password", "tempfile", "zeroize"] }
-digest = { version = "0.10", features = ["alloc", "block-buffer", "const-oid", "core-api", "mac", "oid", "std", "subtle"] }
+derive_more = { version = "0.99" }
+dialoguer = { version = "0.10" }
+digest = { version = "0.10", features = ["mac", "oid", "std"] }
 directories = { version = "5", default-features = false }
 dirs = { version = "4", default-features = false }
 dirs-sys-468e82937335b1c9 = { package = "dirs-sys", version = "0.3", default-features = false }
@@ -481,35 +477,35 @@ dtoa-short = { version = "0.3", default-features = false }
 duct = { version = "0.13", default-features = false }
 dunce = { version = "1", default-features = false }
 edit-distance = { version = "2", default-features = false }
-either = { version = "1", features = ["use_std"] }
+either = { version = "1" }
 embedded-dma = { version = "0.2", default-features = false }
-embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
 embedded-graphics-c38e5c1d305a1b54 = { package = "embedded-graphics", version = "0.8" }
+embedded-graphics-ca01ad9e24f5d932 = { package = "embedded-graphics", version = "0.7" }
 embedded-graphics-core-468e82937335b1c9 = { package = "embedded-graphics-core", version = "0.3" }
 embedded-graphics-core-9fbad63c4bcf4a8f = { package = "embedded-graphics-core", version = "0.4" }
-embedded-graphics-simulator = { version = "0.3", features = ["sdl2", "with-sdl"] }
+embedded-graphics-simulator = { version = "0.3" }
 embedded-graphics-web-simulator = { git = "https://github.com/spookyvision/embedded-graphics-web-simulator", default-features = false }
 embedded-hal-6f8ce4dd05d13bba = { package = "embedded-hal", version = "0.2", default-features = false, features = ["unproven"] }
 embedded-hal-728fa4101789dbbe = { package = "embedded-hal", version = "1.0.0-alpha.11", default-features = false }
 embedded-hal-async = { version = "0.2.0-alpha.2", default-features = false }
 embedded-io = { version = "0.5", default-features = false }
 enable-ansi-support = { version = "0.2", default-features = false }
-env_logger = { version = "0.10", features = ["auto-color", "color", "humantime", "regex"] }
+env_logger = { version = "0.10" }
 envy = { version = "0.4", default-features = false }
 equivalent = { version = "1", default-features = false }
 esp-alloc = { version = "0.3", default-features = false }
-esp-backtrace = { version = "0.7", default-features = false, features = ["esp-println", "esp32c3", "exception-handler", "panic-handler", "print-uart"] }
-esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp-riscv-rt", "esp32c3", "rv-zero-rtc-bss", "vectored"] }
+esp-backtrace = { version = "0.7", default-features = false, features = ["esp32c3", "exception-handler", "panic-handler", "print-uart"] }
+esp-hal-common = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["esp32c3", "rv-zero-rtc-bss", "vectored"] }
 esp-hal-procmacros = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["interrupt"] }
-esp-idf-part = { version = "0.4", features = ["csv", "deku", "parse_int", "regex", "std", "thiserror"] }
-esp-println = { version = "0.5", features = ["colors", "critical-section", "esp32c3", "uart"] }
+esp-idf-part = { version = "0.4" }
+esp-println = { version = "0.5", features = ["esp32c3"] }
 esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", default-features = false, features = ["zero-rtc-fast-bss"] }
 esp32c3 = { version = "0.16", features = ["critical-section"] }
-esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76", features = ["rt", "vectored"] }
-espflash = { version = "2", features = ["cli"] }
+esp32c3-hal = { git = "https://github.com/esp-rs/esp-hal", rev = "5a8be302b4049a6ebc17bd712d97c85a9fd83f76" }
+espflash = { version = "2" }
 event-listener = { version = "2", default-features = false }
-eyre = { version = "0.6", features = ["auto-install", "track-caller"] }
-failure = { version = "0.1", features = ["backtrace", "derive", "failure_derive", "std"] }
+eyre = { version = "0.6" }
+failure = { version = "0.1" }
 failure_derive = { version = "0.1", default-features = false }
 fallible-iterator = { version = "0.2", default-features = false, features = ["std"] }
 fastrand-dff4ba8e3ae991db = { package = "fastrand", version = "1", default-features = false }
@@ -517,90 +513,91 @@ fatfs = { version = "0.3", default-features = false, features = ["alloc", "std"]
 file-id = { version = "0.2", default-features = false }
 filetime = { version = "0.2", default-features = false }
 fixedbitset = { version = "0.4", default-features = false }
-flate2 = { version = "1", features = ["any_zlib", "libz-sys", "miniz_oxide", "rust_backend", "zlib"] }
-float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8", features = ["num-traits", "ratio"] }
-float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9", features = ["num-traits", "ratio"] }
-fnv = { version = "1", features = ["std"] }
-form_urlencoded = { version = "1", features = ["alloc", "std"] }
+flate2 = { version = "1", features = ["zlib"] }
+float-cmp-274715c4dabd11b0 = { package = "float-cmp", version = "0.9" }
+float-cmp-c38e5c1d305a1b54 = { package = "float-cmp", version = "0.8" }
+fnv = { version = "1" }
+form_urlencoded = { version = "1" }
 fs_at = { version = "0.1" }
 fs_extra = { version = "1", default-features = false }
 fugit = { version = "0.3", default-features = false }
 funty = { version = "2", default-features = false }
 futf = { version = "0.1", default-features = false }
 future-queue = { version = "0.3", default-features = false }
-futures = { version = "0.3", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3", features = ["alloc", "futures-sink", "sink", "std"] }
+futures = { version = "0.3" }
+futures-channel = { version = "0.3", features = ["sink"] }
 futures-concurrency = { version = "7", default-features = false }
-futures-core = { version = "0.3", features = ["alloc", "std"] }
+futures-core = { version = "0.3" }
 futures-executor = { version = "0.3", default-features = false, features = ["std"] }
-futures-io = { version = "0.3", features = ["std"] }
-futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+futures-io = { version = "0.3" }
+futures-lite = { version = "1" }
 futures-macro = { version = "0.3", default-features = false }
-futures-sink = { version = "0.3", features = ["alloc", "std"] }
-futures-task = { version = "0.3", default-features = false, features = ["alloc", "std"] }
-futures-util = { version = "0.3", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
+futures-sink = { version = "0.3" }
+futures-task = { version = "0.3", default-features = false, features = ["std"] }
+futures-util = { version = "0.3", features = ["channel", "io", "sink"] }
 fxhash = { version = "0.2", default-features = false }
 gcd = { version = "2", default-features = false }
 generic-array = { version = "0.14", default-features = false, features = ["more_lengths", "zeroize"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "std"] }
 getrandom-c65f7effa3be6d31 = { package = "getrandom", version = "0.1", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "js-sys", "std", "wasm-bindgen"] }
-gif = { version = "0.11", features = ["raii_no_panic", "std"] }
-gimli = { version = "0.27", default-features = false, features = ["endian-reader", "fallible-iterator", "read", "read-core", "stable_deref_trait", "std"] }
-gloo = { version = "0.9", features = ["console", "dialogs", "events", "file", "futures", "gloo-console", "gloo-dialogs", "gloo-events", "gloo-file", "gloo-history", "gloo-net", "gloo-render", "gloo-storage", "gloo-timers", "gloo-utils", "gloo-worker", "history", "net", "render", "storage", "timers", "utils", "worker"] }
+gif = { version = "0.11" }
+gimli = { version = "0.27", default-features = false, features = ["endian-reader", "std"] }
+gloo = { version = "0.9", features = ["futures"] }
 gloo-console = { version = "0.2", default-features = false }
 gloo-dialogs = { version = "0.1", default-features = false }
 gloo-events = { version = "0.1", default-features = false }
-gloo-file = { version = "0.2", features = ["futures", "futures-channel"] }
-gloo-history = { version = "0.1", features = ["query", "serde_urlencoded", "thiserror"] }
-gloo-net = { version = "0.3", features = ["eventsource", "futures-channel", "futures-core", "futures-sink", "http", "json", "pin-project", "serde", "serde_json", "websocket"] }
+gloo-file = { version = "0.2", features = ["futures"] }
+gloo-history = { version = "0.1" }
+gloo-net = { version = "0.3" }
 gloo-render = { version = "0.1", default-features = false }
 gloo-storage = { version = "0.2", default-features = false }
-gloo-timers = { version = "0.2", features = ["futures", "futures-channel", "futures-core"] }
-gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1", features = ["serde"] }
-gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2", features = ["serde"] }
+gloo-timers = { version = "0.2", features = ["futures"] }
+gloo-utils-6f8ce4dd05d13bba = { package = "gloo-utils", version = "0.2" }
+gloo-utils-c65f7effa3be6d31 = { package = "gloo-utils", version = "0.1" }
 gloo-worker = { version = "0.3", features = ["futures"] }
 gloo-worker-macros = { version = "0.1", default-features = false }
 gpt = { version = "3", default-features = false }
 guppy = { version = "0.17", default-features = false }
 guppy-workspace-hack = { version = "0.1", default-features = false }
 h2 = { version = "0.3", default-features = false }
-hal-x86_64 = { git = "https://github.com/hawkw/mycelium", features = ["alloc"] }
-hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
+hal-core = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["embedded-graphics-core"] }
+hal-x86_64 = { git = "https://github.com/hawkw/mycelium" }
 hash32-468e82937335b1c9 = { package = "hash32", version = "0.3", default-features = false }
-hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hash32-6f8ce4dd05d13bba = { package = "hash32", version = "0.2", default-features = false }
 hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", default-features = false, features = ["inline-more", "raw"] }
-hdrhistogram = { version = "7", default-features = false, features = ["base64", "flate2", "nom", "serialization"] }
-heapless = { version = "0.7", features = ["atomic-polyfill", "cas", "defmt", "defmt-impl", "serde"] }
+hashbrown-5ef9efb8ec2df382 = { package = "hashbrown", version = "0.12", default-features = false, features = ["inline-more", "raw"] }
+hdrhistogram = { version = "7", default-features = false, features = ["serialization"] }
+heapless = { version = "0.7", features = ["defmt-impl", "serde"] }
 heck = { version = "0.4" }
-hex = { version = "0.4", features = ["alloc", "serde", "std"] }
+hex = { version = "0.4", features = ["serde"] }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
 home = { version = "0.5", default-features = false }
 html5ever = { version = "0.25", default-features = false }
 http = { version = "0.2", default-features = false }
 http-body = { version = "0.4", default-features = false }
 http-range-header = { version = "0.3", default-features = false }
-httparse = { version = "1", features = ["std"] }
+httparse = { version = "1" }
 httpdate = { version = "1", default-features = false }
 humantime = { version = "2", default-features = false }
 humantime-serde = { version = "1", default-features = false }
-hyper = { version = "0.14", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
+hyper = { version = "0.14", features = ["full"] }
 hyper-timeout = { version = "0.4", default-features = false }
 ident_case = { version = "1", default-features = false }
-idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4", features = ["alloc", "std"] }
-image = { version = "0.23", features = ["bmp", "dds", "dxt", "farbfeld", "gif", "hdr", "ico", "jpeg", "jpeg_rayon", "png", "pnm", "scoped_threadpool", "tga", "tiff", "webp"] }
-indent_write = { version = "2", features = ["std"] }
+idna-9fbad63c4bcf4a8f = { package = "idna", version = "0.4" }
+image = { version = "0.23" }
+indent_write = { version = "2" }
 indenter = { version = "0.3" }
 indexmap-dff4ba8e3ae991db = { package = "indexmap", version = "1", default-features = false, features = ["std"] }
-indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2", features = ["std"] }
-indicatif = { version = "0.17", features = ["unicode-width"] }
+indexmap-f595c2ba2a3f28df = { package = "indexmap", version = "2" }
+indicatif = { version = "0.17" }
 inout = { version = "0.1", default-features = false }
 input-mgr = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033", default-features = false }
-io-lifetimes = { version = "1", features = ["close", "hermit-abi", "libc", "windows-sys"] }
+io-lifetimes = { version = "1" }
 is-terminal = { version = "0.4", default-features = false }
 is_ci = { version = "1", default-features = false }
 itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", default-features = false, features = ["use_alloc"] }
-itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11", features = ["use_alloc", "use_std"] }
-itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4", features = ["std"] }
+itertools-a6292c17cd707f01 = { package = "itertools", version = "0.11" }
+itoa-9fbad63c4bcf4a8f = { package = "itoa", version = "0.4" }
 itoa-dff4ba8e3ae991db = { package = "itoa", version = "1", default-features = false }
 jobserver = { version = "0.1", default-features = false }
 jpeg-decoder = { version = "0.1", default-features = false, features = ["rayon"] }
@@ -609,46 +606,46 @@ just = { version = "1" }
 kv-log-macro = { version = "1", default-features = false }
 lazy_static = { version = "1", default-features = false }
 lexiclean = { version = "0.0.1", default-features = false }
-libc = { version = "0.2", features = ["extra_traits", "std"] }
+libc = { version = "0.2", features = ["extra_traits"] }
 libm = { version = "0.2" }
 libz-sys = { version = "1", default-features = false, features = ["libc"] }
 linked_list_allocator = { version = "0.10", default-features = false, features = ["const_mut_refs"] }
 llvm-tools = { version = "0.1", default-features = false }
 local-ip-address = { version = "0.5", default-features = false }
-lock_api = { version = "0.4", features = ["atomic_usize"] }
-log = { version = "0.4", default-features = false, features = ["kv_unstable", "std", "value-bag"] }
+lock_api = { version = "0.4" }
+log = { version = "0.4", default-features = false, features = ["kv_unstable", "std"] }
 mac = { version = "0.1", default-features = false }
-maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["alloc", "tracing-01"] }
+maitake = { git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", features = ["tracing-01"] }
 markup5ever = { version = "0.10", default-features = false }
 matchers = { version = "0.1", default-features = false }
 matches = { version = "0.1", default-features = false }
 matchit = { version = "0.7" }
 mbrman = { version = "0.5", default-features = false }
 md5 = { version = "0.7", default-features = false, features = ["std"] }
-memchr = { version = "2", features = ["std", "use_std"] }
+memchr = { version = "2", features = ["use_std"] }
 memmap2 = { version = "0.5", default-features = false }
 memoffset = { version = "0.9" }
 micromath-dff4ba8e3ae991db = { package = "micromath", version = "1", default-features = false }
 micromath-f595c2ba2a3f28df = { package = "micromath", version = "2", default-features = false }
-miette = { version = "5", features = ["backtrace", "backtrace-ext", "fancy", "fancy-no-backtrace", "is-terminal", "owo-colors", "supports-color", "supports-hyperlinks", "supports-unicode", "terminal_size", "textwrap"] }
+miette = { version = "5", features = ["fancy"] }
 miette-derive = { version = "5", default-features = false }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", default-features = false }
-minicbor = { version = "0.13", default-features = false, features = ["alloc", "derive", "minicbor-derive", "std"] }
+minicbor = { version = "0.13", default-features = false, features = ["derive", "std"] }
 minicbor-derive = { version = "0.8", default-features = false }
 minimal-lexical = { version = "0.2", default-features = false, features = ["std"] }
 miniz_oxide-468e82937335b1c9 = { package = "miniz_oxide", version = "0.3", default-features = false }
 miniz_oxide-9fbad63c4bcf4a8f = { package = "miniz_oxide", version = "0.4", default-features = false, features = ["no_extern_crate_alloc"] }
 miniz_oxide-ca01ad9e24f5d932 = { package = "miniz_oxide", version = "0.7", default-features = false, features = ["with-alloc"] }
-mio = { version = "0.8", features = ["log", "net", "os-ext", "os-poll"] }
+mio = { version = "0.8", features = ["net", "os-ext"] }
 modality-ingest-client = { version = "0.1", default-features = false }
 mukti-metadata = { version = "0.1", default-features = false }
-mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump", "hal-core", "mycelium-util", "tracing"] }
-mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-alloc = { git = "https://github.com/hawkw/mycelium", default-features = false, features = ["buddy", "bump"] }
 mycelium-bitfield-863e1bb9b8a06b29 = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064", default-features = false }
-mycelium-trace = { git = "https://github.com/hawkw/mycelium", features = ["embedded-graphics"] }
-mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
+mycelium-bitfield-8c33345d9971b90c = { package = "mycelium-bitfield", git = "https://github.com/hawkw/mycelium", default-features = false }
+mycelium-trace = { git = "https://github.com/hawkw/mycelium" }
 mycelium-util-863e1bb9b8a06b29 = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium.git", rev = "101a4abaa19afdd131b334a16d92c9fb4909c064" }
+mycelium-util-8c33345d9971b90c = { package = "mycelium-util", git = "https://github.com/hawkw/mycelium" }
 mycotest = { git = "https://github.com/hawkw/mycelium", default-features = false }
 native-tls = { version = "0.2", default-features = false }
 nb-c65f7effa3be6d31 = { package = "nb", version = "0.1", default-features = false, features = ["unstable"] }
@@ -657,34 +654,34 @@ nested = { version = "0.1", default-features = false }
 new_debug_unreachable = { version = "1", default-features = false }
 nextest-filtering = { version = "0.5" }
 nextest-metadata = { version = "0.9", default-features = false }
-nextest-runner = { version = "0.45", default-features = false, features = ["mukti-metadata", "self-update", "self_update"] }
+nextest-runner = { version = "0.45", default-features = false, features = ["self-update"] }
 nextest-workspace-hack = { version = "0.1", default-features = false }
 nipper = { version = "0.1", default-features = false }
-nodrop = { version = "0.1", features = ["std"] }
-nom = { version = "7", features = ["alloc", "std"] }
+nodrop = { version = "0.1" }
+nom = { version = "7" }
 nom-tracable = { version = "0.9" }
 nom-tracable-macros = { version = "0.9", default-features = false }
-nom_locate = { version = "4", features = ["alloc", "std"] }
+nom_locate = { version = "4" }
 normpath = { version = "1", default-features = false }
-notify = { version = "6", features = ["crossbeam-channel", "fsevent-sys", "macos_fsevent"] }
-notify-debouncer-full = { version = "0.3", features = ["crossbeam", "crossbeam-channel"] }
+notify = { version = "6" }
+notify-debouncer-full = { version = "0.3" }
 nu-ansi-term = { version = "0.46", default-features = false }
 num = { version = "0.1", default-features = false }
-num-integer = { version = "0.1", features = ["i128", "std"] }
-num-iter = { version = "0.1", features = ["std"] }
+num-integer = { version = "0.1", features = ["i128"] }
+num-iter = { version = "0.1" }
 num-rational = { version = "0.3", default-features = false }
-num-traits = { version = "0.2", features = ["i128", "libm", "std"] }
+num-traits = { version = "0.2", features = ["i128", "libm"] }
 num_cpus = { version = "1", default-features = false }
-number_prefix = { version = "0.4", features = ["std"] }
-object = { version = "0.31", default-features = false, features = ["archive", "coff", "compression", "elf", "flate2", "macho", "pe", "read", "read_core", "ruzstd", "std", "unaligned", "xcoff"] }
-once_cell = { version = "1", features = ["alloc", "race", "std", "unstable"] }
+number_prefix = { version = "0.4" }
+object = { version = "0.31", default-features = false, features = ["compression", "read"] }
+once_cell = { version = "1", features = ["unstable"] }
 open = { version = "5", default-features = false }
 option-ext = { version = "0.2", default-features = false }
 os_pipe = { version = "1", default-features = false }
 os_str_bytes = { version = "6", default-features = false, features = ["raw_os_str"] }
 overload = { version = "0.1", default-features = false }
 ovmf-prebuilt = { version = "0.1.0-alpha.1", default-features = false }
-owo-colors = { version = "3", default-features = false, features = ["supports-color", "supports-colors"] }
+owo-colors = { version = "3", default-features = false, features = ["supports-colors"] }
 parking = { version = "2", default-features = false }
 parking_lot = { version = "0.12" }
 parking_lot_core = { version = "0.9", default-features = false }
@@ -692,77 +689,77 @@ parse_int = { version = "0.6" }
 password-hash = { version = "0.4", default-features = false, features = ["rand_core"] }
 paste = { version = "1", default-features = false }
 pathdiff = { version = "0.2", default-features = false, features = ["camino"] }
-pbkdf2 = { version = "0.11", features = ["hmac", "password-hash", "sha2", "simple"] }
-percent-encoding = { version = "2", features = ["alloc", "std"] }
+pbkdf2 = { version = "0.11" }
+percent-encoding = { version = "2" }
 petgraph = { version = "0.6", default-features = false }
-phf = { version = "0.8", features = ["macros", "phf_macros", "proc-macro-hack", "std"] }
+phf = { version = "0.8", features = ["macros"] }
 phf_codegen = { version = "0.8", default-features = false }
 phf_generator-93f6ce9d446188ac = { package = "phf_generator", version = "0.10", default-features = false }
 phf_generator-c38e5c1d305a1b54 = { package = "phf_generator", version = "0.8", default-features = false }
 phf_macros = { version = "0.8", default-features = false }
-phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10", features = ["std"] }
-phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8", features = ["std"] }
+phf_shared-93f6ce9d446188ac = { package = "phf_shared", version = "0.10" }
+phf_shared-c38e5c1d305a1b54 = { package = "phf_shared", version = "0.8" }
 pin-project = { version = "1", default-features = false }
 pin-project-internal = { version = "1", default-features = false }
 pin-project-lite = { version = "0.2", default-features = false }
 pin-utils = { version = "0.1", default-features = false }
 pinned = { version = "0.1", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
-png = { version = "0.16", features = ["deflate", "png-encoding"] }
-portable-atomic = { version = "1", features = ["critical-section", "fallback", "require-cas"] }
-postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["heapless", "heapless-cas", "use-std"] }
-postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["alloc", "const_format", "experimental-derive", "heapless", "heapless-cas", "postcard-derive", "use-std"] }
+png = { version = "0.16" }
+portable-atomic = { version = "1", features = ["critical-section", "require-cas"] }
+postcard-ca01ad9e24f5d932 = { package = "postcard", version = "0.7", features = ["use-std"] }
 postcard-cobs = { version = "0.1.5-pre", default-features = false }
 postcard-derive = { version = "0.1", default-features = false }
+postcard-dff4ba8e3ae991db = { package = "postcard", version = "1", features = ["experimental-derive", "use-std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 precomputed-hash = { version = "0.1", default-features = false }
 proc-macro-crate = { version = "1", default-features = false }
-proc-macro-error = { version = "1", features = ["syn", "syn-error"] }
+proc-macro-error = { version = "1" }
 proc-macro-error-attr = { version = "1", default-features = false }
 proc-macro-hack = { version = "0.5", default-features = false }
-proc-macro2 = { version = "1", features = ["proc-macro"] }
+proc-macro2 = { version = "1" }
 profont = { version = "0.6", default-features = false }
-proptest = { version = "1", features = ["bit-set", "break-dead-code", "fork", "lazy_static", "regex-syntax", "rusty-fork", "std", "tempfile", "timeout"] }
+proptest = { version = "1" }
 proptest-derive = { version = "0.4", default-features = false }
-prost = { version = "0.11", features = ["prost-derive", "std"] }
+prost = { version = "0.11" }
 prost-derive = { version = "0.11", default-features = false }
-prost-types = { version = "0.11", features = ["std"] }
+prost-types = { version = "0.11" }
 quick-error = { version = "1", default-features = false }
 quick-junit = { version = "0.3", default-features = false }
 quick-xml-2b5c6dc72f624058 = { package = "quick-xml", version = "0.23" }
 quick-xml-b73a96c0a5f6a7d9 = { package = "quick-xml", version = "0.29" }
-quote = { version = "1", features = ["proc-macro"] }
+quote = { version = "1" }
 r0 = { version = "1", default-features = false }
 radium = { version = "0.7", default-features = false }
-rand-3b31131e45eafb45 = { package = "rand", version = "0.6", features = ["alloc", "rand_os", "std"] }
-rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["alloc", "getrandom", "getrandom_package", "libc", "rand_pcg", "small_rng", "std"] }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
-rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand-3b31131e45eafb45 = { package = "rand", version = "0.6" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand-ca01ad9e24f5d932 = { package = "rand", version = "0.7", features = ["small_rng"] }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3", default-features = false, features = ["std"] }
+rand_chacha-c65f7effa3be6d31 = { package = "rand_chacha", version = "0.1", default-features = false }
+rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["std"] }
 rand_core-468e82937335b1c9 = { package = "rand_core", version = "0.3", default-features = false }
-rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["alloc", "std"] }
-rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["alloc", "getrandom", "std"] }
-rand_core-3b31131e45eafb45 = { package = "rand_core", version = "0.6", default-features = false, features = ["alloc", "getrandom", "std"] }
+rand_core-9fbad63c4bcf4a8f = { package = "rand_core", version = "0.4", default-features = false, features = ["std"] }
+rand_core-d8f496e17d97b5cb = { package = "rand_core", version = "0.5", default-features = false, features = ["std"] }
 rand_hc = { version = "0.1", default-features = false }
 rand_isaac = { version = "0.1", default-features = false }
 rand_jitter = { version = "0.1", default-features = false, features = ["std"] }
 rand_os = { version = "0.1", default-features = false }
-rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_pcg-6f8ce4dd05d13bba = { package = "rand_pcg", version = "0.2", default-features = false }
-rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
+rand_pcg-c65f7effa3be6d31 = { package = "rand_pcg", version = "0.1", default-features = false }
 rand_xorshift-468e82937335b1c9 = { package = "rand_xorshift", version = "0.3", default-features = false }
+rand_xorshift-c65f7effa3be6d31 = { package = "rand_xorshift", version = "0.1", default-features = false }
 raw-cpuid = { version = "10", default-features = false }
 rayon = { version = "1", default-features = false }
 rayon-core = { version = "1", default-features = false }
 recursion = { version = "0.4" }
-regex = { version = "1", features = ["perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1", features = ["regex-syntax", "std"] }
-regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["alloc", "dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "nfa-pikevm", "nfa-thompson", "perf-inline", "perf-literal", "perf-literal-multisubstring", "perf-literal-substring", "std", "syntax", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment", "unicode-word-boundary"] }
-regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7", features = ["std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
+regex = { version = "1" }
+regex-automata-468e82937335b1c9 = { package = "regex-automata", version = "0.3", default-features = false, features = ["dfa-onepass", "dfa-search", "hybrid", "meta", "nfa-backtrack", "perf-inline", "perf-literal", "unicode"] }
+regex-automata-c65f7effa3be6d31 = { package = "regex-automata", version = "0.1" }
+regex-syntax-3b31131e45eafb45 = { package = "regex-syntax", version = "0.6" }
+regex-syntax-ca01ad9e24f5d932 = { package = "regex-syntax", version = "0.7" }
 remove_dir_all = { version = "0.8" }
-reqwest = { version = "0.11", default-features = false, features = ["__rustls", "__tls", "blocking", "default-tls", "hyper-rustls", "hyper-tls", "json", "native-tls-crate", "rustls", "rustls-pemfile", "rustls-tls", "rustls-tls-webpki-roots", "serde_json", "stream", "tokio-native-tls", "tokio-rustls", "tokio-util", "trust-dns", "trust-dns-resolver", "wasm-streams", "webpki-roots"] }
-ring = { version = "0.16", features = ["alloc", "dev_urandom_fallback", "once_cell"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "default-tls", "json", "rustls-tls", "stream", "trust-dns"] }
+ring = { version = "0.16" }
 ring-drawer = { git = "https://github.com/tosc-rs/teletype/", rev = "de95e610cc79db6d59ad6b40eb2d82adebb4e033" }
 riscv = { version = "0.10", default-features = false, features = ["critical-section-single-hart"] }
 riscv-rt = { version = "0.11", default-features = false }
@@ -772,73 +769,73 @@ rsdp = { version = "2", default-features = false }
 rustc-cfg = { version = "0.4", default-features = false }
 rustc-demangle = { version = "0.1", default-features = false }
 rustc_version = { version = "0.4", default-features = false }
-rustls = { version = "0.21", features = ["dangerous_configuration", "log", "logging", "tls12"] }
-rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100", features = ["alloc", "std"] }
-rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101", features = ["alloc", "std"] }
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
+rustls-webpki-1f4c5ed5f1f8932d = { package = "rustls-webpki", version = "0.100" }
+rustls-webpki-26f2e2773eea2a46 = { package = "rustls-webpki", version = "0.101" }
 rustversion = { version = "1", default-features = false }
-rusty-fork = { version = "0.3", default-features = false, features = ["timeout", "wait-timeout"] }
+rusty-fork = { version = "0.3", default-features = false, features = ["timeout"] }
 ruzstd = { version = "0.3", default-features = false }
 ryu = { version = "1", default-features = false }
 same-file = { version = "1", default-features = false }
 scoped_threadpool = { version = "0.1", default-features = false }
-scopeguard = { version = "1", features = ["use_std"] }
+scopeguard = { version = "1" }
 sct = { version = "0.7", default-features = false }
 sdl2 = { version = "0.32" }
 sdl2-sys = { version = "0.32" }
 seahash = { version = "4" }
 selectors = { version = "0.22", default-features = false }
-self_update = { version = "0.37", features = ["archive-tar", "compression-flate2", "either", "flate2", "rustls", "tar"] }
-semver = { version = "1", features = ["serde", "std"] }
-serde = { version = "1", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+self_update = { version = "0.37", features = ["archive-tar", "compression-flate2", "rustls"] }
+semver = { version = "1", features = ["serde"] }
+serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde-big-array = { version = "0.4", default-features = false }
 serde-wasm-bindgen = { version = "0.5", default-features = false }
 serde_derive = { version = "1" }
 serde_ignored = { version = "0.1", default-features = false }
-serde_json = { version = "1", features = ["raw_value", "std", "unbounded_depth"] }
+serde_json = { version = "1", features = ["raw_value", "unbounded_depth"] }
 serde_path_to_error = { version = "0.1", default-features = false }
 serde_plain = { version = "1", default-features = false }
 serde_spanned = { version = "0.6", default-features = false, features = ["serde"] }
 serde_urlencoded = { version = "0.7", default-features = false }
-serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f", features = ["libudev"] }
-serialport-164d15cefe24d7eb = { package = "serialport", version = "4", features = ["libudev"] }
+serialport-164d15cefe24d7eb = { package = "serialport", version = "4" }
+serialport-ddd52cfaddcf02fb = { package = "serialport", git = "https://github.com/metta-systems/serialport-rs", rev = "7fec572529ec35b82bd4e3636d897fe2f1c2233f" }
 servo_arc = { version = "0.1", default-features = false }
-sha1 = { version = "0.10", features = ["std"] }
-sha2 = { version = "0.10", features = ["std"] }
+sha1 = { version = "0.10" }
+sha2 = { version = "0.10" }
 sharded-slab = { version = "0.1", default-features = false }
 shared_child = { version = "1", default-features = false }
-shell-words = { version = "1", features = ["std"] }
-similar = { version = "2", features = ["bstr", "text", "unicode", "unicode-segmentation"] }
-siphasher = { version = "0.3", features = ["std"] }
-slab = { version = "0.4", features = ["std"] }
+shell-words = { version = "1" }
+similar = { version = "2", features = ["unicode"] }
+siphasher = { version = "0.3" }
+slab = { version = "0.4" }
 slip-codec = { version = "0.3" }
 smallvec = { version = "1", default-features = false, features = ["write"] }
 smawk = { version = "0.3", default-features = false }
-smol_str = { version = "0.2", features = ["serde", "std"] }
-snafu = { version = "0.7", features = ["rust_1_39", "rust_1_46", "std"] }
+smol_str = { version = "0.2", features = ["serde"] }
+snafu = { version = "0.7" }
 snafu-derive = { version = "0.7", default-features = false, features = ["rust_1_39", "rust_1_46"] }
 socket2-9fbad63c4bcf4a8f = { package = "socket2", version = "0.4", default-features = false, features = ["all"] }
-stable_deref_trait = { version = "1", features = ["alloc", "std"] }
+stable_deref_trait = { version = "1" }
 static_assertions = { version = "1", default-features = false }
-string_cache = { version = "0.8", features = ["serde", "serde_support"] }
+string_cache = { version = "0.8" }
 string_cache_codegen = { version = "0.5", default-features = false }
 strip-ansi-escapes = { version = "0.1", default-features = false }
 strsim-93f6ce9d446188ac = { package = "strsim", version = "0.10", default-features = false }
 strsim-c38e5c1d305a1b54 = { package = "strsim", version = "0.8", default-features = false }
-strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive", "std", "strum_macros"] }
-strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive", "std", "strum_macros"] }
-strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
+strum-2ffb4c3fe830441c = { package = "strum", version = "0.25", features = ["derive"] }
+strum-adf3d7031871b0af = { package = "strum", version = "0.24", features = ["derive"] }
 strum_macros-2ffb4c3fe830441c = { package = "strum_macros", version = "0.25", default-features = false }
+strum_macros-adf3d7031871b0af = { package = "strum_macros", version = "0.24", default-features = false }
 subtle = { version = "2", default-features = false, features = ["i128"] }
 supports-color-dff4ba8e3ae991db = { package = "supports-color", version = "1", default-features = false }
 supports-color-f595c2ba2a3f28df = { package = "supports-color", version = "2", default-features = false }
 supports-hyperlinks = { version = "2", default-features = false }
 supports-unicode = { version = "2", default-features = false }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["clone-impls", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "full", "visit", "visit-mut"] }
 sync_wrapper = { version = "0.1", default-features = false }
-synstructure = { version = "0.12", features = ["proc-macro"] }
+synstructure = { version = "0.12" }
 tap = { version = "1", default-features = false }
-tar = { version = "0.4", features = ["xattr"] }
+tar = { version = "0.4" }
 target = { version = "2", default-features = false }
 target-lexicon = { version = "0.12", features = ["std"] }
 target-spec = { version = "3", default-features = false, features = ["custom", "summaries"] }
@@ -847,137 +844,137 @@ tempfile = { version = "3", default-features = false }
 tendril = { version = "0.4", default-features = false }
 term_size = { version = "0.3" }
 termcolor = { version = "1", default-features = false }
-terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
 terminal_size-6f8ce4dd05d13bba = { package = "terminal_size", version = "0.2", default-features = false }
-textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
-textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15", features = ["smawk", "unicode-linebreak", "unicode-width"] }
+terminal_size-c65f7effa3be6d31 = { package = "terminal_size", version = "0.1", default-features = false }
+textwrap-3575ec1268b04181 = { package = "textwrap", version = "0.15" }
 textwrap-986da7b5efc2b80e = { package = "textwrap", version = "0.16", default-features = false }
+textwrap-a6292c17cd707f01 = { package = "textwrap", version = "0.11", default-features = false, features = ["term_size"] }
 thin-slice = { version = "0.1", default-features = false }
 thiserror = { version = "1", default-features = false }
 thiserror-impl = { version = "1", default-features = false }
 thread_local = { version = "1", default-features = false }
 tiff = { version = "0.6", default-features = false }
+time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
 time-c65f7effa3be6d31 = { package = "time", version = "0.1", default-features = false }
-time-468e82937335b1c9 = { package = "time", version = "0.3", features = ["alloc", "formatting", "local-offset", "macros", "parsing", "std"] }
 time-core = { version = "0.1", default-features = false }
 time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing"] }
-tinyvec = { version = "1", features = ["alloc", "tinyvec_macros"] }
+tinyvec = { version = "1", features = ["alloc"] }
 tinyvec_macros = { version = "0.1", default-features = false }
-tokio = { version = "1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "num_cpus", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "tracing", "windows-sys"] }
+tokio = { version = "1", features = ["full", "tracing"] }
 tokio-io-timeout = { version = "1", default-features = false }
 tokio-macros = { version = "2", default-features = false }
 tokio-native-tls = { version = "0.3", default-features = false }
-tokio-stream = { version = "0.1", features = ["fs", "net", "sync", "time", "tokio-util"] }
-tokio-tungstenite = { version = "0.19", features = ["connect", "handshake", "stream"] }
-tokio-util = { version = "0.7", features = ["codec", "io", "tracing"] }
+tokio-stream = { version = "0.1", features = ["fs", "net", "sync"] }
+tokio-tungstenite = { version = "0.19" }
+tokio-util = { version = "0.7", features = ["codec", "io"] }
+toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7" }
 toml-d8f496e17d97b5cb = { package = "toml", version = "0.5" }
-toml-ca01ad9e24f5d932 = { package = "toml", version = "0.7", features = ["display", "parse"] }
 toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
 toml_edit = { version = "0.19", features = ["serde"] }
-tonic = { version = "0.9", features = ["channel", "codegen", "prost", "transport"] }
-tower = { version = "0.4", default-features = false, features = ["__common", "balance", "buffer", "discover", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "timeout", "tokio", "tokio-util", "tracing", "util"] }
-tower-http = { version = "0.4", features = ["fs", "httpdate", "mime", "mime_guess", "percent-encoding", "set-status", "tokio", "tokio-util", "trace", "tracing"] }
+tonic = { version = "0.9" }
+tower = { version = "0.4", default-features = false, features = ["balance", "buffer", "limit", "log", "timeout", "util"] }
+tower-http = { version = "0.4", features = ["fs", "trace"] }
 tower-layer = { version = "0.3", default-features = false }
 tower-service = { version = "0.3", default-features = false }
-tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["attributes", "log", "std", "tracing-attributes"] }
-tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes", "tracing-attributes"] }
-tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
+tracing-49367297afd278d2 = { package = "tracing", git = "https://github.com/tokio-rs/tracing", default-features = false, features = ["attributes"] }
 tracing-attributes-49367297afd278d2 = { package = "tracing-attributes", git = "https://github.com/tokio-rs/tracing", default-features = false }
-tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1", features = ["once_cell", "std", "valuable"] }
+tracing-attributes-c65f7effa3be6d31 = { package = "tracing-attributes", version = "0.1", default-features = false }
+tracing-c65f7effa3be6d31 = { package = "tracing", version = "0.1", features = ["log"] }
 tracing-core-49367297afd278d2 = { package = "tracing-core", git = "https://github.com/tokio-rs/tracing", default-features = false }
+tracing-core-c65f7effa3be6d31 = { package = "tracing-core", version = "0.1" }
 tracing-log = { version = "0.1", default-features = false, features = ["log-tracer", "std"] }
 tracing-modality = { git = "https://github.com/auxoncorp/modality-tracing-rs", rev = "9c23c188466357e7ad0c618b4edfe9514e9bf764", default-features = false }
-tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields", features = ["std"] }
-tracing-subscriber = { version = "0.3", features = ["alloc", "ansi", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
+tracing-serde-structured = { git = "https://github.com/hawkw/tracing-serde-structured", branch = "eliza/span-fields" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-wasm = { version = "0.2", default-features = false }
 trunk = { version = "0.17", default-features = false }
 try-lock = { version = "0.2", default-features = false }
-tungstenite = { version = "0.19", default-features = false, features = ["data-encoding", "handshake", "http", "httparse", "sha1", "url"] }
+tungstenite = { version = "0.19", default-features = false, features = ["handshake"] }
 twox-hash = { version = "1", default-features = false }
-typed-arena = { version = "2", features = ["std"] }
+typed-arena = { version = "2" }
 typenum = { version = "1", default-features = false }
 unarray = { version = "0.1", default-features = false }
 unicase = { version = "2", default-features = false }
-unicode-bidi = { version = "0.3", features = ["hardcoded-data", "std"] }
+unicode-bidi = { version = "0.3" }
 unicode-ident = { version = "1", default-features = false }
 unicode-linebreak = { version = "0.1", default-features = false }
-unicode-normalization = { version = "0.1", features = ["std"] }
+unicode-normalization = { version = "0.1" }
 unicode-segmentation = { version = "1", default-features = false }
 unicode-width = { version = "0.1" }
 unicode-xid = { version = "0.2" }
 untrusted = { version = "0.7", default-features = false }
-update-informer = { version = "1", features = ["crates", "rustls-tls", "ureq"] }
-ureq = { version = "2", default-features = false, features = ["flate2", "gzip", "json", "rustls", "serde", "serde_json", "tls", "webpki", "webpki-roots"] }
+update-informer = { version = "1" }
+ureq = { version = "2", default-features = false, features = ["gzip", "json", "tls"] }
 url = { version = "2" }
 urlencoding = { version = "2", default-features = false }
 utf-8 = { version = "0.7", default-features = false }
 utf8parse = { version = "0.2" }
-uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["getrandom", "std", "v4"] }
-uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["getrandom", "rng", "serde", "std", "v4"] }
+uuid-c38e5c1d305a1b54 = { package = "uuid", version = "0.8", features = ["v4"] }
+uuid-dff4ba8e3ae991db = { package = "uuid", version = "1", features = ["serde", "v4"] }
 value-bag = { version = "1", default-features = false }
 vcell = { version = "0.1", default-features = false }
 vcpkg = { version = "0.2", default-features = false }
 vec_map = { version = "0.8", default-features = false }
-vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc", "rustc_version", "time"] }
+vergen = { version = "8", features = ["cargo", "git", "gitcl", "rustc"] }
 version_check = { version = "0.9", default-features = false }
 void = { version = "1", default-features = false }
 volatile = { version = "0.4", default-features = false, features = ["unstable"] }
-vte = { version = "0.10", features = ["arrayvec", "no_std"] }
+vte = { version = "0.10" }
 vte_generate_state_changes = { version = "0.1", default-features = false }
 wait-timeout = { version = "0.2", default-features = false }
 waker-fn = { version = "1", default-features = false }
 walkdir = { version = "2", default-features = false }
 want = { version = "0.3", default-features = false }
-wasm-bindgen = { version = "0.2", features = ["spans", "std"] }
+wasm-bindgen = { version = "0.2" }
 wasm-bindgen-backend = { version = "0.2", default-features = false, features = ["spans"] }
 wasm-bindgen-futures = { version = "0.4", default-features = false }
 wasm-bindgen-macro = { version = "0.2", default-features = false, features = ["spans"] }
 wasm-bindgen-macro-support = { version = "0.2", default-features = false, features = ["spans"] }
 wasm-bindgen-shared = { version = "0.2", default-features = false }
-web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "Blob", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "Element", "ErrorEvent", "Event", "EventSource", "EventTarget", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "Node", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "UiEvent", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerGlobalScope", "WorkerOptions", "console"] }
+web-sys = { version = "0.3", default-features = false, features = ["AbortSignal", "AddEventListenerOptions", "BinaryType", "BlobPropertyBag", "CanvasRenderingContext2d", "CloseEvent", "CloseEventInit", "DedicatedWorkerGlobalScope", "Document", "DomException", "ErrorEvent", "EventSource", "File", "FileList", "FilePropertyBag", "FileReader", "FormData", "Headers", "History", "HtmlCanvasElement", "HtmlHeadElement", "HtmlInputElement", "ImageData", "KeyboardEvent", "Location", "MessageEvent", "ObserverCallback", "ProgressEvent", "ReadableStream", "ReferrerPolicy", "Request", "RequestCache", "RequestCredentials", "RequestInit", "RequestMode", "RequestRedirect", "Response", "ResponseInit", "ResponseType", "Storage", "Url", "UrlSearchParams", "WebSocket", "Window", "Worker", "WorkerOptions", "console"] }
 webpki-roots-2b5c6dc72f624058 = { package = "webpki-roots", version = "0.23", default-features = false }
-weezl = { version = "0.1", features = ["alloc", "std"] }
+weezl = { version = "0.1" }
 which = { version = "4", default-features = false }
-winnow = { version = "0.5", features = ["alloc", "std"] }
+winnow = { version = "0.5" }
 wyz = { version = "0.5", default-features = false }
 xmas-elf = { version = "0.9", default-features = false }
 zero = { version = "0.1", default-features = false }
-zeroize = { version = "1", features = ["alloc"] }
-zip = { version = "0.6", features = ["aes", "aes-crypto", "bzip2", "constant_time_eq", "deflate", "flate2", "hmac", "pbkdf2", "sha1", "time", "zstd"] }
-zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11", features = ["arrays", "legacy", "zdict_builder"] }
-zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["arrays", "legacy", "zdict_builder", "zstdmt"] }
-zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
+zeroize = { version = "1" }
+zip = { version = "0.6" }
+zstd-5ef9efb8ec2df382 = { package = "zstd", version = "0.12", features = ["zstdmt"] }
+zstd-a6292c17cd707f01 = { package = "zstd", version = "0.11" }
 zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
+zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
 [target.nvptx64-nvidia-cuda.dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+futures-lite = { version = "1" }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
 parking = { version = "2", default-features = false }
-polling = { version = "2", features = ["std"] }
-rustix = { version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+polling = { version = "2" }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 waker-fn = { version = "1", default-features = false }
 
 [target.nvptx64-nvidia-cuda.build-dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
+encoding_rs = { version = "0.8" }
 enum-as-inner = { version = "0.5", default-features = false }
 errno = { version = "0.3", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
@@ -986,54 +983,54 @@ hostname = { version = "0.3" }
 hyper-rustls = { version = "0.24", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-ipnet = { version = "2", features = ["std"] }
+ipnet = { version = "2" }
 linked-hash-map = { version = "0.5", default-features = false }
 lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1", features = ["use_core"] }
-nix = { version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+match_cfg = { version = "0.1" }
+nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-macros = { version = "0.1", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
-polling = { version = "2", features = ["std"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+polling = { version = "2" }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
-rustix = { version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 rustls-pemfile = { version = "1", default-features = false }
-tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
-trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 
 [target.thumbv7em-none-eabi.dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+futures-lite = { version = "1" }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
 parking = { version = "2", default-features = false }
-polling = { version = "2", features = ["std"] }
-rustix = { version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+polling = { version = "2" }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 waker-fn = { version = "1", default-features = false }
 
 [target.thumbv7em-none-eabi.build-dependencies]
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
-encoding_rs = { version = "0.8", features = ["alloc"] }
+encoding_rs = { version = "0.8" }
 enum-as-inner = { version = "0.5", default-features = false }
 errno = { version = "0.3", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
@@ -1042,67 +1039,67 @@ hostname = { version = "0.3" }
 hyper-rustls = { version = "0.24", default-features = false }
 hyper-tls = { version = "0.5", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-ipnet = { version = "2", features = ["std"] }
+ipnet = { version = "2" }
 linked-hash-map = { version = "0.5", default-features = false }
 lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1", features = ["use_core"] }
-nix = { version = "0.26", default-features = false, features = ["dir", "fs", "ioctl", "poll", "process", "signal", "term"] }
+match_cfg = { version = "0.1" }
+nix = { version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
 openssl = { version = "0.10", features = ["vendored"] }
 openssl-macros = { version = "0.1", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["openssl-src", "vendored"] }
-polling = { version = "2", features = ["std"] }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+polling = { version = "2" }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
-rustix = { version = "0.37", features = ["fs", "io-lifetimes", "libc", "std", "termios", "use-libc-auxv"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rustix = { version = "0.37", features = ["fs", "termios"] }
 rustls-pemfile = { version = "1", default-features = false }
-tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
-trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 
 [target.i686-uwp-windows-msvc.dependencies]
-aho-corasick = { version = "1", features = ["perf-literal", "std"] }
+aho-corasick = { version = "1" }
 anstyle-wincon = { version = "2", default-features = false }
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
 errno = { version = "0.3", default-features = false }
-futures-lite = { version = "1", features = ["alloc", "fastrand", "futures-io", "memchr", "parking", "std", "waker-fn"] }
+futures-lite = { version = "1" }
 parking = { version = "2", default-features = false }
-polling = { version = "2", features = ["std"] }
-rustix = { version = "0.37", default-features = false, features = ["fs", "io-lifetimes", "std"] }
+polling = { version = "2" }
+rustix = { version = "0.37", default-features = false, features = ["fs", "std"] }
 schannel = { version = "0.1", default-features = false }
 waker-fn = { version = "1", default-features = false }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cguid", "commapi", "consoleapi", "errhandlingapi", "fileapi", "guiddef", "handleapi", "impl-default", "jobapi2", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "setupapi", "shellapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32", "Win32_Foundation", "Win32_Globalization", "Win32_NetworkManagement", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI", "Win32_UI_Shell"] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
 windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
 windows_i686_msvc-c8eced492e86ede7 = { package = "windows_i686_msvc", version = "0.48", default-features = false }
 
 [target.i686-uwp-windows-msvc.build-dependencies]
-ahash = { version = "0.8", features = ["getrandom", "runtime-rng", "std"] }
+ahash = { version = "0.8" }
 aligned = { version = "0.4", default-features = false }
 anstyle-wincon = { version = "2", default-features = false }
 arc-swap = { version = "1", default-features = false }
 as-slice = { version = "0.2", default-features = false }
 async-executor = { version = "1", default-features = false }
-async-global-executor = { version = "2", features = ["async-io"] }
+async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
-async-task = { version = "4", features = ["std"] }
+async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
-bitmaps = { version = "2", features = ["std"] }
+bitmaps = { version = "2" }
 blocking = { version = "1", default-features = false }
-bstr-dff4ba8e3ae991db = { package = "bstr", version = "1", features = ["alloc", "std", "unicode"] }
-btoi = { version = "0.4", features = ["std"] }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
+btoi = { version = "0.4" }
 bytesize = { version = "1" }
-cargo = { version = "0.72", default-features = false, features = ["openssl", "vendored-openssl"] }
+cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
 cargo-util = { version = "0.2", default-features = false }
 clru = { version = "0.6", default-features = false }
 cpufeatures = { version = "0.2", default-features = false }
@@ -1110,24 +1107,24 @@ crates-io = { version = "0.37", default-features = false }
 crossterm_winapi = { version = "0.9", default-features = false }
 crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
 ct-codecs = { version = "1", default-features = false }
-curl = { version = "0.4", features = ["http2", "openssl-probe", "openssl-sys", "ssl"] }
-curl-sys = { version = "0.4", features = ["http2", "libnghttp2-sys", "openssl-sys", "ssl"] }
-der = { version = "0.7", default-features = false, features = ["alloc", "oid", "pem", "std", "zeroize"] }
-ecdsa = { version = "0.16", default-features = false, features = ["alloc", "arithmetic", "der", "digest", "hazmat", "pem", "pkcs8", "rfc6979", "signing", "spki", "std", "verifying"] }
-ed25519-compact = { version = "2", default-features = false, features = ["getrandom", "random"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["alloc", "arithmetic", "digest", "ecdh", "ff", "group", "hazmat", "pem", "pkcs8", "sec1", "std"] }
-encode_unicode = { version = "0.3", features = ["std"] }
-encoding_rs = { version = "0.8", features = ["alloc"] }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
+der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
+encode_unicode = { version = "0.3" }
+encoding_rs = { version = "0.8" }
 enum-as-inner = { version = "0.5", default-features = false }
 errno = { version = "0.3", default-features = false }
-faster-hex = { version = "0.8", features = ["alloc", "serde", "std"] }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2", features = ["alloc", "std"] }
+faster-hex = { version = "0.8" }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
 ff = { version = "0.13", default-features = false, features = ["alloc"] }
 fiat-crypto = { version = "0.1", default-features = false }
 fwdansi = { version = "1", default-features = false }
-git2 = { version = "0.17", features = ["https", "openssl-probe", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+git2 = { version = "0.17" }
 git2-curl = { version = "0.18", default-features = false }
-gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "blocking-network-client", "gix-protocol", "gix-transport", "prodash", "progress-tree"] }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
 gix-actor = { version = "0.20", default-features = false }
 gix-attributes = { version = "0.12", default-features = false }
 gix-bitmap = { version = "0.2", default-features = false }
@@ -1162,14 +1159,14 @@ gix-revision = { version = "0.13", default-features = false }
 gix-sec = { version = "0.8", default-features = false }
 gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
 gix-trace = { version = "0.1" }
-gix-transport = { version = "0.31", features = ["base64", "blocking-client", "curl", "gix-credentials", "http-client", "http-client-curl"] }
+gix-transport = { version = "0.31", features = ["http-client-curl"] }
 gix-traverse = { version = "0.25", default-features = false }
 gix-url = { version = "0.18", default-features = false }
 gix-utils = { version = "0.1", default-features = false }
 gix-validate = { version = "0.7", default-features = false }
 gix-worktree = { version = "0.17", default-features = false }
 glob = { version = "0.3", default-features = false }
-globset = { version = "0.4", features = ["log"] }
+globset = { version = "0.4" }
 group = { version = "0.13", default-features = false, features = ["alloc"] }
 hkdf = { version = "0.12", default-features = false }
 hostname = { version = "0.3" }
@@ -1179,64 +1176,64 @@ hyper-tls = { version = "0.5", default-features = false }
 idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
 ignore = { version = "0.4", default-features = false }
 im-rc = { version = "15", default-features = false }
-imara-diff = { version = "0.1", features = ["unified_diff"] }
+imara-diff = { version = "0.1" }
 io-close = { version = "0.3", default-features = false }
-ipconfig = { version = "0.3", features = ["computer", "winreg"] }
-ipnet = { version = "2", features = ["std"] }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10", features = ["use_std"] }
-kstring = { version = "2", features = ["std", "unsafe"] }
+ipconfig = { version = "0.3" }
+ipnet = { version = "2" }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kstring = { version = "2" }
 lazycell = { version = "1", default-features = false }
-libgit2-sys = { version = "0.15", default-features = false, features = ["https", "libssh2-sys", "openssl-sys", "ssh", "ssh_key_from_memory"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
 linked-hash-map = { version = "0.5", default-features = false }
 lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1", features = ["use_core"] }
+match_cfg = { version = "0.1" }
 maybe-async = { version = "0.2", features = ["is_sync"] }
 miow = { version = "0.5", default-features = false }
 opener = { version = "0.5", default-features = false }
-ordered-float = { version = "2", features = ["std"] }
+ordered-float = { version = "2" }
 orion = { version = "0.17", default-features = false }
-os_info = { version = "3", features = ["serde"] }
-p384 = { version = "0.13", features = ["alloc", "arithmetic", "digest", "ecdh", "ecdsa", "ecdsa-core", "pem", "pkcs8", "sha2", "sha384", "std"] }
-pasetors = { version = "0.6", features = ["ed25519-compact", "orion", "p384", "paserk", "rand_core", "regex", "serde", "serde_json", "sha2", "std", "time", "v3", "v4"] }
+os_info = { version = "3" }
+p384 = { version = "0.13" }
+pasetors = { version = "0.6", features = ["serde", "v3"] }
 pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
-pkcs8 = { version = "0.10", default-features = false, features = ["alloc", "pem", "std"] }
-polling = { version = "2", features = ["std"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
+polling = { version = "2" }
 primeorder = { version = "0.13", default-features = false }
-prodash = { version = "23", default-features = false, features = ["parking_lot", "progress-tree"] }
+prodash = { version = "23", default-features = false, features = ["progress-tree"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rand_xoshiro = { version = "0.6", default-features = false }
-resolv-conf = { version = "0.7", default-features = false, features = ["hostname", "system"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
 rfc6979 = { version = "0.4", default-features = false }
 rustfix = { version = "0.6", default-features = false }
-rustix = { version = "0.37", default-features = false, features = ["fs", "io-lifetimes", "std"] }
+rustix = { version = "0.37", default-features = false, features = ["fs", "std"] }
 rustls-pemfile = { version = "1", default-features = false }
 schannel = { version = "0.1", default-features = false }
-sec1 = { version = "0.7", features = ["alloc", "der", "pem", "pkcs8", "point", "std", "subtle", "zeroize"] }
+sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
 serde-value = { version = "0.7", default-features = false }
 sha1_smol = { version = "1", default-features = false }
 shell-escape = { version = "0.1", default-features = false }
-signal-hook = { version = "0.3", features = ["channel", "iterator"] }
+signal-hook = { version = "0.3" }
 signal-hook-registry = { version = "1", default-features = false }
-signature = { version = "2", default-features = false, features = ["alloc", "digest", "rand_core", "std"] }
-sized-chunks = { version = "0.6", features = ["std"] }
+signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6" }
 socket2-d8f496e17d97b5cb = { package = "socket2", version = "0.5", default-features = false }
 spin = { version = "0.5", default-features = false }
-spki = { version = "0.7", default-features = false, features = ["alloc", "pem", "std"] }
-tokio-rustls = { version = "0.24", features = ["logging", "tls12"] }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio", "tokio-runtime"] }
-trust-dns-resolver = { version = "0.22", features = ["ipconfig", "resolv-conf", "system-config", "tokio", "tokio-runtime"] }
+spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
 unicode-bom = { version = "2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
-widestring = { version = "1", features = ["alloc", "std"] }
+widestring = { version = "1" }
 win32job = { version = "1", default-features = false }
 winapi = { version = "0.3", default-features = false, features = ["basetsd", "cguid", "commapi", "consoleapi", "errhandlingapi", "fileapi", "guiddef", "handleapi", "impl-default", "jobapi2", "knownfolders", "libloaderapi", "minwinbase", "minwindef", "ntdef", "ntsecapi", "ntstatus", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "setupapi", "shellapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winreg", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 winapi-util = { version = "0.1", default-features = false }
-windows = { version = "0.48", features = ["Globalization", "Win32", "Win32_Foundation", "Win32_Globalization", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Memory", "Win32_System_Threading"] }
-windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32", "Win32_Foundation", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Console", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_UI", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32", "Win32_Foundation", "Win32_Globalization", "Win32_NetworkManagement", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Security_Authentication", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI", "Win32_UI_Shell"] }
+windows = { version = "0.48", features = ["Globalization", "Win32_Foundation", "Win32_Globalization", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Memory", "Win32_System_Threading"] }
+windows-sys-53888c27b7ba5cf4 = { package = "windows-sys", version = "0.45", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse"] }
+windows-sys-b32c9ddb6d93a9d2 = { package = "windows-sys", version = "0.42", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_JobObjects", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
 windows-targets-b32c9ddb6d93a9d2 = { package = "windows-targets", version = "0.42", default-features = false }
 windows-targets-c8eced492e86ede7 = { package = "windows-targets", version = "0.48", default-features = false }
 windows_i686_msvc-b32c9ddb6d93a9d2 = { package = "windows_i686_msvc", version = "0.42", default-features = false }

--- a/fixtures/large/summaries/hyper_util_7afb1ed-0.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-0.toml
@@ -2,30 +2,23 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'thumbv7a-uwp-windows-msvc'
-target-features = ['sha', 'sse']
-flags = ['bar', 'foo']
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'hyper'
-version = '1.4.1'
+name = 'h2'
+version = '0.4.5'
 crates-io = true
 
 [[metadata.omitted-packages.ids]]
-name = 'mio'
+name = 'http-body'
 version = '1.0.1'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'tracing-core'
-version = '0.1.32'
 crates-io = true
 
 [[metadata.features-only]]
@@ -65,18 +58,19 @@ status = 'direct'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'http-body'
-version = '1.0.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
 name = 'http-body-util'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
+
+[[target-package]]
+name = 'hyper'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['client', 'default', 'full', 'http1', 'http2', 'server']
+optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
 
 [[target-package]]
 name = 'pin-project-lite'
@@ -97,8 +91,8 @@ name = 'tokio'
 version = '1.39.2'
 crates-io = true
 status = 'direct'
-features = ['default', 'libc', 'macros', 'mio', 'net', 'rt', 'signal', 'signal-hook-registry', 'socket2', 'sync', 'test-util', 'time', 'tokio-macros', 'windows-sys']
-optional-deps = ['mio', 'tokio-macros', 'windows-sys']
+features = ['default', 'libc', 'macros', 'mio', 'net', 'rt', 'signal', 'signal-hook-registry', 'socket2', 'sync', 'test-util', 'time', 'tokio-macros']
+optional-deps = ['mio', 'tokio-macros']
 
 [[target-package]]
 name = 'tokio-test'
@@ -138,6 +132,13 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
+name = 'futures-channel'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
 name = 'futures-core'
 version = '0.3.30'
 crates-io = true
@@ -147,6 +148,20 @@ features = ['alloc', 'default', 'std']
 [[target-package]]
 name = 'futures-task'
 version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'httparse'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'httpdate'
+version = '1.0.3'
 crates-io = true
 status = 'transitive'
 features = []
@@ -187,6 +202,13 @@ status = 'transitive'
 features = ['alloc', 'std']
 
 [[target-package]]
+name = 'mio'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['net', 'os-ext', 'os-poll']
+
+[[target-package]]
 name = 'pin-utils'
 version = '0.1.0'
 crates-io = true
@@ -217,6 +239,13 @@ status = 'transitive'
 features = ['std']
 
 [[target-package]]
+name = 'smallvec'
+version = '1.13.2'
+crates-io = true
+status = 'transitive'
+features = ['const_generics', 'const_new']
+
+[[target-package]]
 name = 'termcolor'
 version = '1.4.1'
 crates-io = true
@@ -231,22 +260,15 @@ status = 'transitive'
 features = ['default', 'time']
 
 [[target-package]]
-name = 'winapi-util'
-version = '0.1.8'
+name = 'try-lock'
+version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'windows-sys'
-version = '0.52.0'
-crates-io = true
-status = 'transitive'
-features = ['Win32', 'Win32_Foundation', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_Pipes', 'Win32_System_SystemInformation', 'Win32_System_SystemServices', 'default']
-
-[[target-package]]
-name = 'windows-targets'
-version = '0.52.6'
+name = 'want'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/hyper_util_7afb1ed-1.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-1.toml
@@ -2,16 +2,26 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-hermit'
-target-features = 'unknown'
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'riscv32gc-unknown-linux-musl'
+target-features = 'all'
+flags = ['abc']
+[[metadata.omitted-packages.ids]]
+name = 'tracing'
+version = '0.1.40'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'want'
+version = '0.3.1'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'hyper-util'
@@ -106,20 +116,6 @@ status = 'direct'
 features = []
 
 [[target-package]]
-name = 'addr2line'
-version = '0.22.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'adler'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'aho-corasick'
 version = '1.1.3'
 crates-io = true
@@ -137,20 +133,6 @@ features = []
 [[target-package]]
 name = 'atomic-waker'
 version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'backtrace'
-version = '0.3.73'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'cfg-if'
-version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -206,13 +188,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'gimli'
-version = '0.29.0'
-crates-io = true
-status = 'transitive'
-features = ['read', 'read-core']
-
-[[target-package]]
 name = 'h2'
 version = '0.4.5'
 crates-io = true
@@ -225,13 +200,6 @@ version = '0.14.5'
 crates-io = true
 status = 'transitive'
 features = ['raw']
-
-[[target-package]]
-name = 'hermit-abi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'httparse'
@@ -305,13 +273,6 @@ status = 'transitive'
 features = ['alloc', 'std']
 
 [[target-package]]
-name = 'miniz_oxide'
-version = '0.7.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'mio'
 version = '1.0.1'
 crates-io = true
@@ -324,20 +285,6 @@ version = '0.6.0'
 crates-io = true
 status = 'transitive'
 features = ['std']
-
-[[target-package]]
-name = 'object'
-version = '0.36.2'
-crates-io = true
-status = 'transitive'
-features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned', 'xcoff']
-
-[[target-package]]
-name = 'once_cell'
-version = '1.19.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
 
 [[target-package]]
 name = 'pin-utils'
@@ -382,13 +329,6 @@ version = '0.8.4'
 crates-io = true
 status = 'transitive'
 features = ['std']
-
-[[target-package]]
-name = 'rustc-demangle'
-version = '0.1.24'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'serde'
@@ -439,140 +379,6 @@ crates-io = true
 status = 'transitive'
 features = ['codec', 'default', 'io']
 
-[[target-package]]
-name = 'tracing'
-version = '0.1.40'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.32'
-crates-io = true
-status = 'transitive'
-features = ['once_cell', 'std']
-optional-deps = ['once_cell']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wasi'
-version = '0.11.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['winsock2', 'ws2ipdef']
-
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows-sys'
-version = '0.52.0'
-crates-io = true
-status = 'transitive'
-features = ['Wdk', 'Wdk_Foundation', 'Wdk_Storage', 'Wdk_Storage_FileSystem', 'Wdk_System', 'Wdk_System_IO', 'Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Pipes', 'Win32_System_SystemInformation', 'Win32_System_WindowsProgramming', 'default']
-
-[[target-package]]
-name = 'windows-targets'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_aarch64_gnullvm'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_aarch64_msvc'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_i686_gnu'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_i686_gnullvm'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_i686_msvc'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_gnu'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_gnullvm'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_msvc'
-version = '0.52.6'
-crates-io = true
-status = 'transitive'
-features = []
-
 [[host-package]]
 name = 'async-stream-impl'
 version = '0.3.5'
@@ -583,13 +389,6 @@ features = []
 [[host-package]]
 name = 'autocfg'
 version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'cc'
-version = '1.1.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -607,13 +406,6 @@ version = '1.0.36'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'serde_derive'
-version = '1.0.204'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'syn'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
@@ -2,16 +2,16 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'standard'
+resolver = '3'
+include-dev = true
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'armv7-linux-androideabi'
+target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-ohos'
-target-features = 'all'
+spec = 'any'
 
 [[metadata.features-only]]
 name = 'hyper-util'
@@ -57,11 +57,18 @@ status = 'direct'
 features = []
 
 [[target-package]]
+name = 'http-body-util'
+version = '0.1.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
 name = 'hyper'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
-features = ['client', 'default', 'http1', 'http2', 'server']
+features = ['client', 'default', 'full', 'http1', 'http2', 'server']
 optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
 
 [[target-package]]
@@ -72,11 +79,91 @@ status = 'direct'
 features = []
 
 [[target-package]]
+name = 'pnet_datalink'
+version = '0.35.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'pretty_env_logger'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tokio'
+version = '1.39.2'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'default', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'signal', 'signal-hook-registry', 'socket2', 'sync', 'test-util', 'time', 'tokio-macros', 'windows-sys']
+optional-deps = ['bytes', 'libc', 'mio', 'signal-hook-registry', 'tokio-macros', 'windows-sys']
+
+[[target-package]]
+name = 'tokio-test'
+version = '0.4.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'addr2line'
+version = '0.22.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'adler'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'aho-corasick'
+version = '1.1.3'
+crates-io = true
+status = 'transitive'
+features = ['perf-literal', 'std']
+optional-deps = ['memchr']
+
+[[target-package]]
+name = 'async-stream'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'atomic-waker'
 version = '1.1.2'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'backtrace'
+version = '0.3.73'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'env_logger'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = ['auto-color', 'color', 'default', 'humantime', 'regex']
+optional-deps = ['humantime', 'is-terminal', 'regex', 'termcolor']
 
 [[target-package]]
 name = 'equivalent'
@@ -121,6 +208,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'gimli'
+version = '0.29.0'
+crates-io = true
+status = 'transitive'
+features = ['read', 'read-core']
+
+[[target-package]]
 name = 'h2'
 version = '0.4.5'
 crates-io = true
@@ -133,6 +227,13 @@ version = '0.14.5'
 crates-io = true
 status = 'transitive'
 features = ['raw']
+
+[[target-package]]
+name = 'hermit-abi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[target-package]]
 name = 'httparse'
@@ -149,6 +250,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'humantime'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'indexmap'
 version = '2.2.6'
 crates-io = true
@@ -156,11 +264,75 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
+name = 'ipnetwork'
+version = '0.20.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'is-terminal'
+version = '0.4.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'itoa'
 version = '1.0.11'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.155'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'log'
+version = '0.4.22'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'memchr'
+version = '2.7.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'miniz_oxide'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mio'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['net', 'os-ext', 'os-poll']
+
+[[target-package]]
+name = 'no-std-net'
+version = '0.6.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'object'
+version = '0.36.2'
+crates-io = true
+status = 'transitive'
+features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned', 'xcoff']
 
 [[target-package]]
 name = 'once_cell'
@@ -172,6 +344,64 @@ features = ['alloc', 'default', 'race', 'std']
 [[target-package]]
 name = 'pin-utils'
 version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pnet_base'
+version = '0.35.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'pnet_sys'
+version = '0.35.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.10.5'
+crates-io = true
+status = 'transitive'
+features = ['perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std']
+optional-deps = ['aho-corasick', 'memchr']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.4.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax']
+optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.8.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rustc-demangle'
+version = '0.1.24'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.204'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.4.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -191,12 +421,18 @@ status = 'transitive'
 features = ['const_generics', 'const_new']
 
 [[target-package]]
-name = 'tokio'
-version = '1.39.2'
+name = 'termcolor'
+version = '1.4.1'
 crates-io = true
 status = 'transitive'
-features = ['bytes', 'default', 'io-util', 'sync']
-optional-deps = ['bytes']
+features = []
+
+[[target-package]]
+name = 'tokio-stream'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = ['default', 'time']
 
 [[target-package]]
 name = 'tokio-util'
@@ -234,9 +470,171 @@ crates-io = true
 status = 'transitive'
 features = []
 
+[[target-package]]
+name = 'wasi'
+version = '0.11.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['winsock2', 'ws2ipdef']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows-sys'
+version = '0.52.0'
+crates-io = true
+status = 'transitive'
+features = ['Wdk', 'Wdk_Foundation', 'Wdk_Storage', 'Wdk_Storage_FileSystem', 'Wdk_System', 'Wdk_System_IO', 'Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Pipes', 'Win32_System_SystemInformation', 'Win32_System_SystemServices', 'Win32_System_WindowsProgramming', 'default']
+
+[[target-package]]
+name = 'windows-targets'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_gnullvm'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_msvc'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnu'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnullvm'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_msvc'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnu'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnullvm'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_msvc'
+version = '0.52.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'async-stream-impl'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
 [[host-package]]
 name = 'autocfg'
 version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cc'
+version = '1.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.86'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.36'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'serde_derive'
+version = '1.0.204'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'syn'
+version = '2.0.72'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'visit-mut']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'tokio-macros'
+version = '2.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-ident'
+version = '1.0.12'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/hyper_util_7afb1ed-4.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-4.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'standard'
+resolver = '2'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'always'
@@ -33,7 +33,7 @@ workspace-path = ''
 features = ['__internal_happy_eyeballs_tests', 'client', 'client-legacy', 'default', 'full', 'http1', 'http2', 'server', 'server-auto', 'server-graceful', 'service', 'tokio']
 optional-deps = ['futures-channel', 'socket2', 'tokio', 'tower', 'tower-service', 'tracing']
 
-[[target-package]]
+[[host-package]]
 name = 'hyper-util'
 version = '0.1.6'
 workspace-path = ''
@@ -41,289 +41,45 @@ status = 'initial'
 features = ['__internal_happy_eyeballs_tests', 'client', 'client-legacy', 'default', 'full', 'http1', 'http2', 'server', 'server-auto', 'server-graceful', 'service', 'tokio']
 optional-deps = ['futures-channel', 'socket2', 'tokio', 'tower', 'tower-service', 'tracing']
 
-[[target-package]]
+[[host-package]]
 name = 'bytes'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'http'
 version = '1.1.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'http-body'
 version = '1.0.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
-name = 'http-body-util'
-version = '0.1.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'hyper'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
-features = ['client', 'default', 'full', 'http1', 'http2', 'server']
+features = ['client', 'default', 'http1', 'http2', 'server']
 optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
 
-[[target-package]]
+[[host-package]]
 name = 'pin-project-lite'
 version = '0.2.14'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
-name = 'pretty_env_logger'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tokio'
-version = '1.39.2'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'default', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'signal', 'signal-hook-registry', 'socket2', 'sync', 'test-util', 'time', 'tokio-macros', 'windows-sys']
-optional-deps = ['bytes', 'libc', 'mio', 'signal-hook-registry', 'tokio-macros', 'windows-sys']
-
-[[target-package]]
-name = 'tokio-test'
-version = '0.4.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'aho-corasick'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = ['perf-literal', 'std']
-optional-deps = ['memchr']
-
-[[target-package]]
-name = 'async-stream'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'atomic-waker'
 version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'env_logger'
-version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = ['auto-color', 'color', 'default', 'humantime', 'regex']
-optional-deps = ['humantime', 'is-terminal', 'regex', 'termcolor']
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'futures-channel'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-core'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-sink'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'h2'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'httparse'
-version = '1.9.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'httpdate'
-version = '1.0.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'is-terminal'
-version = '0.4.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itoa'
-version = '1.0.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'log'
-version = '0.4.22'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'memchr'
-version = '2.7.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'mio'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['net', 'os-ext', 'os-poll']
-
-[[target-package]]
-name = 'once_cell'
-version = '1.19.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[target-package]]
-name = 'regex'
-version = '1.10.5'
-crates-io = true
-status = 'transitive'
-features = ['perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std']
-optional-deps = ['aho-corasick', 'memchr']
-
-[[target-package]]
-name = 'regex-automata'
-version = '0.4.7'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax']
-optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.8.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'slab'
-version = '0.4.9'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'smallvec'
-version = '1.13.2'
-crates-io = true
-status = 'transitive'
-features = ['const_generics', 'const_new']
-
-[[target-package]]
-name = 'termcolor'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-stream'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['default', 'time']
-
-[[target-package]]
-name = 'tokio-util'
-version = '0.7.11'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default', 'io']
-
-[[target-package]]
-name = 'tracing'
-version = '0.1.40'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.32'
-crates-io = true
-status = 'transitive'
-features = ['once_cell', 'std']
-optional-deps = ['once_cell']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'async-stream-impl'
-version = '0.3.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -336,37 +92,122 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'proc-macro2'
-version = '1.0.86'
+name = 'fnv'
+version = '1.0.7'
 crates-io = true
 status = 'transitive'
-features = ['default', 'proc-macro']
+features = ['default', 'std']
 
 [[host-package]]
-name = 'quote'
-version = '1.0.36'
+name = 'futures-channel'
+version = '0.3.30'
 crates-io = true
 status = 'transitive'
-features = ['default', 'proc-macro']
+features = ['alloc', 'default', 'std']
 
 [[host-package]]
-name = 'syn'
-version = '2.0.72'
+name = 'futures-core'
+version = '0.3.30'
 crates-io = true
 status = 'transitive'
-features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'visit-mut']
-optional-deps = ['quote']
+features = ['alloc', 'default', 'std']
 
 [[host-package]]
-name = 'tokio-macros'
-version = '2.4.0'
+name = 'futures-sink'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'h2'
+version = '0.4.5'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'unicode-ident'
-version = '1.0.12'
+name = 'httparse'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'httpdate'
+version = '1.0.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'once_cell'
+version = '1.19.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'slab'
+version = '0.4.9'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'smallvec'
+version = '1.13.2'
+crates-io = true
+status = 'transitive'
+features = ['const_generics', 'const_new']
+
+[[host-package]]
+name = 'tokio'
+version = '1.39.2'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'default', 'io-util', 'sync']
+optional-deps = ['bytes']
+
+[[host-package]]
+name = 'tokio-util'
+version = '0.7.11'
+crates-io = true
+status = 'transitive'
+features = ['codec', 'default', 'io']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.40'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.32'
+crates-io = true
+status = 'transitive'
+features = ['once_cell', 'std']
+optional-deps = ['once_cell']
+
+[[host-package]]
+name = 'try-lock'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'want'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 triple = 'thumbv6m-nuttx-eabi'
@@ -30,374 +30,93 @@ version = '0.1.6'
 workspace-path = ''
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'hyper-util'
 version = '0.1.6'
 workspace-path = ''
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'bytes'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'futures-util'
 version = '0.3.30'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'http'
 version = '1.1.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'http-body'
 version = '1.0.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
-name = 'http-body-util'
-version = '0.1.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'hyper'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
-features = ['client', 'default', 'full', 'http1', 'http2', 'server']
-optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
+features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'pin-project-lite'
 version = '0.2.14'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
-name = 'pretty_env_logger'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'tokio'
 version = '1.39.2'
 crates-io = true
 status = 'direct'
-features = ['bytes', 'default', 'io-util', 'libc', 'macros', 'mio', 'rt', 'signal', 'signal-hook-registry', 'sync', 'test-util', 'time', 'tokio-macros', 'windows-sys']
-optional-deps = ['bytes', 'libc', 'mio', 'signal-hook-registry', 'tokio-macros', 'windows-sys']
+features = ['default', 'sync']
 
-[[target-package]]
-name = 'tokio-test'
-version = '0.4.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'aho-corasick'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = ['perf-literal', 'std']
-optional-deps = ['memchr']
-
-[[target-package]]
-name = 'async-stream'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atomic-waker'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'env_logger'
-version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = ['auto-color', 'color', 'default', 'humantime', 'regex']
-optional-deps = ['humantime', 'is-terminal', 'regex', 'termcolor']
-
-[[target-package]]
-name = 'equivalent'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'fnv'
 version = '1.0.7'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
 
-[[target-package]]
-name = 'futures-channel'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
+[[host-package]]
 name = 'futures-core'
 version = '0.3.30'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'std']
+features = []
 
-[[target-package]]
-name = 'futures-sink'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
+[[host-package]]
 name = 'futures-task'
 version = '0.3.30'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[target-package]]
-name = 'h2'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hashbrown'
-version = '0.14.5'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[target-package]]
-name = 'httparse'
-version = '1.9.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'httpdate'
-version = '1.0.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'humantime'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'indexmap'
-version = '2.2.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'is-terminal'
-version = '0.4.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'itoa'
 version = '1.0.11'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[target-package]]
-name = 'memchr'
-version = '2.7.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'mio'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['net', 'os-ext', 'os-poll']
-
-[[target-package]]
-name = 'once_cell'
-version = '1.19.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[target-package]]
+[[host-package]]
 name = 'pin-utils'
 version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex'
-version = '1.10.5'
-crates-io = true
-status = 'transitive'
-features = ['perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std']
-optional-deps = ['aho-corasick', 'memchr']
-
-[[target-package]]
-name = 'regex-automata'
-version = '0.4.7'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax']
-optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.8.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'slab'
-version = '0.4.9'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'smallvec'
-version = '1.13.2'
-crates-io = true
-status = 'transitive'
-features = ['const_generics', 'const_new']
-
-[[target-package]]
-name = 'termcolor'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-stream'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['default', 'time']
-
-[[target-package]]
-name = 'tokio-util'
-version = '0.7.11'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default', 'io']
-
-[[target-package]]
-name = 'tracing'
-version = '0.1.40'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.32'
-crates-io = true
-status = 'transitive'
-features = ['once_cell', 'std']
-optional-deps = ['once_cell']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'async-stream-impl'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'autocfg'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'proc-macro2'
-version = '1.0.86'
-crates-io = true
-status = 'transitive'
-features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'quote'
-version = '1.0.36'
-crates-io = true
-status = 'transitive'
-features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'syn'
-version = '2.0.72'
-crates-io = true
-status = 'transitive'
-features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'visit-mut']
-optional-deps = ['quote']
-
-[[host-package]]
-name = 'tokio-macros'
-version = '2.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'unicode-ident'
-version = '1.0.12'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'always'
@@ -34,7 +34,7 @@ workspace-path = ''
 features = ['__internal_happy_eyeballs_tests', 'client', 'client-legacy', 'default', 'full', 'http1', 'http2', 'server', 'server-auto', 'server-graceful', 'service', 'tokio']
 optional-deps = ['futures-channel', 'socket2', 'tokio', 'tower', 'tower-service', 'tracing']
 
-[[target-package]]
+[[host-package]]
 name = 'hyper-util'
 version = '0.1.6'
 workspace-path = ''
@@ -42,35 +42,35 @@ status = 'initial'
 features = ['__internal_happy_eyeballs_tests', 'client', 'client-legacy', 'default', 'full', 'http1', 'http2', 'server', 'server-auto', 'server-graceful', 'service', 'tokio']
 optional-deps = ['futures-channel', 'socket2', 'tokio', 'tower', 'tower-service', 'tracing']
 
-[[target-package]]
+[[host-package]]
 name = 'bytes'
 version = '1.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'futures-util'
 version = '0.3.30'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'http'
 version = '1.1.0'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'http-body'
 version = '1.0.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'hyper'
 version = '1.4.1'
 crates-io = true
@@ -78,157 +78,16 @@ status = 'direct'
 features = ['client', 'default', 'http1', 'http2', 'server']
 optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
 
-[[target-package]]
+[[host-package]]
 name = 'pin-project-lite'
 version = '0.2.14'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'atomic-waker'
 version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'equivalent'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.7'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'futures-channel'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-core'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-sink'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-task'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'h2'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hashbrown'
-version = '0.14.5'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[target-package]]
-name = 'httparse'
-version = '1.9.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'indexmap'
-version = '2.2.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'itoa'
-version = '1.0.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'once_cell'
-version = '1.19.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[target-package]]
-name = 'pin-utils'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slab'
-version = '0.4.9'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'smallvec'
-version = '1.13.2'
-crates-io = true
-status = 'transitive'
-features = ['const_generics', 'const_new']
-
-[[target-package]]
-name = 'tokio-util'
-version = '0.7.11'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default', 'io']
-
-[[target-package]]
-name = 'tracing'
-version = '0.1.40'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.32'
-crates-io = true
-status = 'transitive'
-features = ['once_cell', 'std']
-optional-deps = ['once_cell']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -236,6 +95,147 @@ features = []
 [[host-package]]
 name = 'autocfg'
 version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'equivalent'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'futures-channel'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-core'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-sink'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-task'
+version = '0.3.30'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'h2'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hashbrown'
+version = '0.14.5'
+crates-io = true
+status = 'transitive'
+features = ['raw']
+
+[[host-package]]
+name = 'httparse'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'indexmap'
+version = '2.2.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'itoa'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'once_cell'
+version = '1.19.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'slab'
+version = '0.4.9'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'smallvec'
+version = '1.13.2'
+crates-io = true
+status = 'transitive'
+features = ['const_generics', 'const_new']
+
+[[host-package]]
+name = 'tokio-util'
+version = '0.7.11'
+crates-io = true
+status = 'transitive'
+features = ['codec', 'default', 'io']
+
+[[host-package]]
+name = 'tracing'
+version = '0.1.40'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.32'
+crates-io = true
+status = 'transitive'
+features = ['once_cell', 'std']
+optional-deps = ['once_cell']
+
+[[host-package]]
+name = 'try-lock'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'want'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
@@ -2,26 +2,20 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture hyper_util_7afb1ed
 
 [metadata]
-resolver = 'install'
-include-dev = true
+resolver = '2'
+include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-hermit'
+triple = 'powerpc64le-unknown-linux-musl'
 target-features = 'all'
 flags = ['flag-test', 'test-flag']
 
 [metadata.target-platform]
-triple = 'armv7a-kmc-solid_asp3-eabi'
-target-features = 'all'
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'libc'
-version = '0.2.155'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
+name = 'ipnetwork'
+version = '0.20.0'
 crates-io = true
 
 [[metadata.features-only]]
@@ -66,98 +60,17 @@ status = 'direct'
 features = []
 
 [[host-package]]
-name = 'http-body-util'
-version = '0.1.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
 name = 'hyper'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
-features = ['client', 'default', 'full', 'http1', 'http2', 'server']
-optional-deps = ['futures-channel', 'futures-util', 'h2', 'httparse', 'httpdate', 'itoa', 'pin-project-lite', 'smallvec', 'want']
+features = ['default']
 
 [[host-package]]
 name = 'pin-project-lite'
 version = '0.2.14'
 crates-io = true
 status = 'direct'
-features = []
-
-[[host-package]]
-name = 'pretty_env_logger'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tokio'
-version = '1.39.2'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'default', 'io-util', 'libc', 'macros', 'mio', 'rt', 'signal', 'signal-hook-registry', 'sync', 'test-util', 'time', 'tokio-macros', 'windows-sys']
-optional-deps = ['bytes', 'libc', 'mio', 'signal-hook-registry', 'tokio-macros', 'windows-sys']
-
-[[host-package]]
-name = 'tokio-test'
-version = '0.4.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'aho-corasick'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = ['perf-literal', 'std']
-optional-deps = ['memchr']
-
-[[host-package]]
-name = 'async-stream'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'async-stream-impl'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'atomic-waker'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'autocfg'
-version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'env_logger'
-version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = ['auto-color', 'color', 'default', 'humantime', 'regex']
-optional-deps = ['humantime', 'is-terminal', 'regex', 'termcolor']
-
-[[host-package]]
-name = 'equivalent'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
 features = []
 
 [[host-package]]
@@ -168,85 +81,15 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'futures-channel'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
 name = 'futures-core'
 version = '0.3.30'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-sink'
-version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
+features = []
 
 [[host-package]]
 name = 'futures-task'
 version = '0.3.30'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'h2'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hashbrown'
-version = '0.14.5'
-crates-io = true
-status = 'transitive'
-features = ['raw']
-
-[[host-package]]
-name = 'hermit-abi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'httparse'
-version = '1.9.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'httpdate'
-version = '1.0.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'humantime'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'indexmap'
-version = '2.2.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'is-terminal'
-version = '0.4.12'
 crates-io = true
 status = 'transitive'
 features = []
@@ -259,34 +102,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'log'
-version = '0.4.22'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'memchr'
-version = '2.7.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[host-package]]
-name = 'mio'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['net', 'os-ext', 'os-poll']
-
-[[host-package]]
-name = 'once_cell'
-version = '1.19.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[host-package]]
 name = 'pin-utils'
 version = '0.1.0'
 crates-io = true
@@ -294,124 +109,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'proc-macro2'
-version = '1.0.86'
+name = 'tokio'
+version = '1.39.2'
 crates-io = true
 status = 'transitive'
-features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'quote'
-version = '1.0.36'
-crates-io = true
-status = 'transitive'
-features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'regex'
-version = '1.10.5'
-crates-io = true
-status = 'transitive'
-features = ['perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std']
-optional-deps = ['aho-corasick', 'memchr']
-
-[[host-package]]
-name = 'regex-automata'
-version = '0.4.7'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax']
-optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.8.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'slab'
-version = '0.4.9'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'smallvec'
-version = '1.13.2'
-crates-io = true
-status = 'transitive'
-features = ['const_generics', 'const_new']
-
-[[host-package]]
-name = 'syn'
-version = '2.0.72'
-crates-io = true
-status = 'transitive'
-features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'visit-mut']
-optional-deps = ['quote']
-
-[[host-package]]
-name = 'termcolor'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-macros'
-version = '2.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-stream'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = ['default', 'time']
-
-[[host-package]]
-name = 'tokio-util'
-version = '0.7.11'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default', 'io']
-
-[[host-package]]
-name = 'tracing'
-version = '0.1.40'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'tracing-core'
-version = '0.1.32'
-crates-io = true
-status = 'transitive'
-features = ['once_cell', 'std']
-optional-deps = ['once_cell']
-
-[[host-package]]
-name = 'try-lock'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'unicode-ident'
-version = '1.0.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'want'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['default', 'sync']

--- a/fixtures/large/summaries/metadata_libra-0.toml
+++ b/fixtures/large/summaries/metadata_libra-0.toml
@@ -2,26 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'proc-macros-on-target'
+resolver = '2'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-netbsd'
-target-features = ['xsaves']
-flags = ['foo']
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'always'
-[[metadata.omitted-packages.ids]]
-name = 'cmake'
-version = '0.1.42'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
+triple = 'x86_64-win7-windows-msvc'
+target-features = 'all'
+flags = ['bar', 'foo']
 
 [[metadata.features-only]]
 name = 'admission-control-proto'
@@ -35,21 +26,21 @@ version = '0.1.0'
 workspace-path = 'language/vm/vm-genesis'
 features = ['default', 'fuzzing']
 
-[[target-package]]
+[[host-package]]
 name = 'ir-to-bytecode'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode'
 status = 'initial'
 features = ['default', 'fuzzing']
 
-[[target-package]]
+[[host-package]]
 name = 'ir-to-bytecode-syntax'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'initial'
 features = ['default', 'fuzzing']
 
-[[target-package]]
+[[host-package]]
 name = 'libradb'
 version = '0.1.0'
 workspace-path = 'storage/libradb'
@@ -57,14 +48,14 @@ status = 'initial'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
 optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'memsocket'
 version = '0.1.0'
 workspace-path = 'network/memsocket'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'storage-service'
 version = '0.1.0'
 workspace-path = 'storage/storage-service'
@@ -72,63 +63,63 @@ status = 'initial'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'transaction-builder'
 version = '0.1.0'
 workspace-path = 'language/transaction-builder'
 status = 'initial'
 features = ['default', 'fuzzing']
 
-[[target-package]]
+[[host-package]]
 name = 'accumulator'
 version = '0.1.0'
 workspace-path = 'storage/accumulator'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'bytecode-source-map'
 version = '0.1.0'
 workspace-path = 'language/compiler/bytecode-source-map'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'bytecode-verifier'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'crash-handler'
 version = '0.1.0'
 workspace-path = 'common/crash-handler'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'debug-interface'
 version = '0.1.0'
 workspace-path = 'common/debug-interface'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'executable-helpers'
 version = '0.1.0'
 workspace-path = 'common/executable-helpers'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'grpc-helpers'
 version = '0.1.0'
 workspace-path = 'common/grpc-helpers'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'jellyfish-merkle'
 version = '0.1.0'
 workspace-path = 'storage/jellyfish-merkle'
@@ -136,1523 +127,27 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest', 'proptest-derive']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
 status = 'workspace'
 features = ['cloneable-private-keys', 'default', 'fuzzing', 'proptest', 'proptest-derive', 'std', 'u64_backend']
 optional-deps = ['proptest', 'proptest-derive']
-
-[[target-package]]
-name = 'libra-failure-ext'
-version = '0.1.0'
-workspace-path = 'common/failure-ext'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-failure-macros'
-version = '0.1.0'
-workspace-path = 'common/failure-ext/failure-macros'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-logger'
-version = '0.1.0'
-workspace-path = 'common/logger'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-metrics'
-version = '0.1.0'
-workspace-path = 'common/metrics'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-nibble'
-version = '0.1.0'
-workspace-path = 'common/nibble'
-status = 'workspace'
-features = ['default', 'fuzzing', 'proptest']
-optional-deps = ['proptest']
-
-[[target-package]]
-name = 'libra-proptest-helpers'
-version = '0.1.0'
-workspace-path = 'common/proptest-helpers'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-prost-ext'
-version = '0.1.0'
-workspace-path = 'common/prost-ext'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-state-view'
-version = '0.1.0'
-workspace-path = 'storage/state-view'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'libra-tools'
-version = '0.1.0'
-workspace-path = 'common/tools'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-types'
-version = '0.1.0'
-workspace-path = 'types'
-status = 'workspace'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[target-package]]
-name = 'schemadb'
-version = '0.1.0'
-workspace-path = 'storage/schemadb'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'scratchpad'
-version = '0.1.0'
-workspace-path = 'storage/scratchpad'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'stdlib'
-version = '0.1.0'
-workspace-path = 'language/stdlib'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'storage-client'
-version = '0.1.0'
-workspace-path = 'storage/storage-client'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'storage-proto'
-version = '0.1.0'
-workspace-path = 'storage/storage-proto'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'vm'
-version = '0.1.0'
-workspace-path = 'language/vm'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'vm-runtime-types'
-version = '0.1.0'
-workspace-path = 'language/vm/vm-runtime/vm-runtime-types'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'arc-swap'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'backtrace'
-version = '0.3.37'
-crates-io = true
-status = 'direct'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
-optional-deps = ['backtrace-sys', 'serde']
-
-[[target-package]]
-name = 'bech32'
-version = '0.6.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'bincode'
-version = '1.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'byteorder'
-version = '1.3.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'i128', 'std']
-
-[[target-package]]
-name = 'bytes'
-version = '0.4.12'
-crates-io = true
-status = 'direct'
-features = ['either']
-optional-deps = ['either']
-
-[[target-package]]
-name = 'chrono'
-version = '0.4.9'
-crates-io = true
-status = 'direct'
-features = ['clock', 'default', 'time']
-optional-deps = ['time']
-
-[[target-package]]
-name = 'codespan'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = ['serde', 'serde_derive', 'serialization']
-optional-deps = ['serde', 'serde_derive']
-
-[[target-package]]
-name = 'codespan-reporting'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'crossbeam'
-version = '0.7.2'
-crates-io = true
-status = 'direct'
-features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
-
-[[target-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
-status = 'direct'
-features = ['alloc', 'std', 'u64_backend']
-
-[[target-package]]
-name = 'digest'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[target-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
-status = 'direct'
-features = ['serde', 'std', 'u64_backend']
-optional-deps = ['serde']
-
-[[target-package]]
-name = 'failure'
-version = '0.1.5'
-crates-io = true
-status = 'direct'
-features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
-optional-deps = ['backtrace', 'failure_derive']
-
-[[target-package]]
-name = 'futures'
-version = '0.1.29'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std', 'with-deprecated']
-
-[[target-package]]
-name = 'futures-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'compat', 'default', 'std']
-
-[[target-package]]
-name = 'get_if_addrs'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'grpcio'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'prost', 'prost-codec']
-optional-deps = ['bytes', 'prost']
-
-[[target-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hyper'
-version = '0.12.34'
-crates-io = true
-status = 'direct'
-features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'itertools'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[target-package]]
-name = 'mirai-annotations'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.8'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'num_enum'
-version = '0.4.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[target-package]]
-name = 'parity-multiaddr'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'petgraph'
-version = '0.4.13'
-crates-io = true
-status = 'direct'
-features = ['default', 'graphmap', 'ordermap', 'stable_graph']
-optional-deps = ['ordermap']
-
-[[target-package]]
-name = 'prometheus'
-version = '0.7.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'proptest'
-version = '0.9.4'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[target-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
-
-[[target-package]]
-name = 'radix_trie'
-version = '0.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[target-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'direct'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'rocksdb'
-version = '0.3.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[target-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'serde_json'
-version = '1.0.40'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'sha2'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'slog'
-version = '2.5.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
-
-[[target-package]]
-name = 'slog-async'
-version = '2.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'slog-envlogger'
-version = '2.2.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'regex']
-optional-deps = ['regex']
-
-[[target-package]]
-name = 'slog-scope'
-version = '4.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'slog-term'
-version = '2.4.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'structopt'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'strum'
-version = '0.15.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'thread-id'
-version = '3.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'keccak']
-
-[[target-package]]
-name = 'toml'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
-
-[[target-package]]
-name = 'aho-corasick'
-version = '0.7.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'arrayref'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arrayvec'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atty'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'backtrace-sys'
-version = '0.1.31'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit-set'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bitflags'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'blake2'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'block-buffer'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'block-padding'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bs58'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'byte-tools'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bzip2-sys'
-version = '0.1.7'
-source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cfg-if'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clap'
-version = '2.33.0'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'clear_on_drop'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crc'
-version = '1.8.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'crossbeam-channel'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-deque'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-epoch'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crossbeam-queue'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.6.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[target-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'data-encoding'
-version = '2.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'dirs'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'either'
-version = '1.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'endian-type'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fake-simd'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fixedbitset'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-channel-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'futures-sink-preview', 'sink', 'std']
-optional-deps = ['futures-sink-preview']
-
-[[target-package]]
-name = 'futures-core-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'futures-cpupool'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'futures-executor-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['num_cpus', 'std']
-optional-deps = ['num_cpus']
-
-[[target-package]]
-name = 'futures-io-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'futures-sink-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'futures-util-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'channel', 'compat', 'futures-channel-preview', 'futures-io-preview', 'futures-sink-preview', 'futures_01', 'io', 'memchr', 'sink', 'slab', 'std']
-optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'slab']
-
-[[target-package]]
-name = 'generic-array'
-version = '0.12.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'getrandom'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'grpcio-sys'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'h2'
-version = '0.1.26'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http'
-version = '0.1.18'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http-body'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'idna'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'indexmap'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'iovec'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itoa'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'keccak'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libc'
-version = '0.2.62'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'librocksdb_sys'
-version = '0.1.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'libtitan_sys'
-version = '0.0.1'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'libz-sys'
-version = '1.0.25'
-crates-io = true
-status = 'transitive'
-features = ['static']
-
-[[target-package]]
-name = 'lock_api'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['owning_ref']
-optional-deps = ['owning_ref']
-
-[[target-package]]
-name = 'lz4-sys'
-version = '1.8.0'
-source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'memoffset'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memsec'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc', 'mach_o_sys', 'winapi']
-
-[[target-package]]
-name = 'mio'
-version = '0.6.19'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[target-package]]
-name = 'nibble_vec'
-version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nodrop'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-integer'
-version = '0.1.41'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.10.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ordermap'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'owning_ref'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parity-multihash'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'quick-error'
-version = '1.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-optional-deps = ['libc']
-
-[[target-package]]
-name = 'rand'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
-optional-deps = ['getrandom_package']
-
-[[target-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[target-package]]
-name = 'rand_hc'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.12'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustc-demangle'
-version = '0.1.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ryu'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'sha-1'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slog-stdlog'
-version = '4.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'smallvec'
-version = '0.6.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'snappy-sys'
-version = '0.1.0'
-source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'spin'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'stable_deref_trait'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'string'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'default']
-optional-deps = ['bytes']
-
-[[target-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'subtle'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'subtle'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'take_mut'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'term'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'termcolor'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio'
-version = '0.1.22'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'tokio-buf'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'either', 'util']
-optional-deps = ['either']
-
-[[target-package]]
-name = 'tokio-current-thread'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-executor'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-io'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-reactor'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-sync'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-tcp'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-threadpool'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-timer'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'typenum'
-version = '1.11.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-normalization'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-width'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unsigned-varint'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'url'
-version = '1.7.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vec_map'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'zstd-sys'
-version = '1.4.13+zstd.1.4.3'
-source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
-status = 'transitive'
-features = ['default', 'legacy']
 
 [[host-package]]
 name = 'libra-crypto-derive'
@@ -1676,12 +171,252 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'libra-logger'
+version = '0.1.0'
+workspace-path = 'common/logger'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-metrics'
+version = '0.1.0'
+workspace-path = 'common/metrics'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-nibble'
+version = '0.1.0'
+workspace-path = 'common/nibble'
+status = 'workspace'
+features = ['default', 'fuzzing', 'proptest']
+optional-deps = ['proptest']
+
+[[host-package]]
+name = 'libra-proptest-helpers'
+version = '0.1.0'
+workspace-path = 'common/proptest-helpers'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-prost-ext'
+version = '0.1.0'
+workspace-path = 'common/prost-ext'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-state-view'
+version = '0.1.0'
+workspace-path = 'storage/state-view'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'libra-tools'
+version = '0.1.0'
+workspace-path = 'common/tools'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-types'
+version = '0.1.0'
+workspace-path = 'types'
+status = 'workspace'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[host-package]]
+name = 'schemadb'
+version = '0.1.0'
+workspace-path = 'storage/schemadb'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'scratchpad'
+version = '0.1.0'
+workspace-path = 'storage/scratchpad'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'stdlib'
+version = '0.1.0'
+workspace-path = 'language/stdlib'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'storage-client'
+version = '0.1.0'
+workspace-path = 'storage/storage-client'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'storage-proto'
+version = '0.1.0'
+workspace-path = 'storage/storage-proto'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'vm'
+version = '0.1.0'
+workspace-path = 'language/vm'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'vm-runtime-types'
+version = '0.1.0'
+workspace-path = 'language/vm/vm-runtime/vm-runtime-types'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'arc-swap'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'backtrace'
+version = '0.3.37'
+crates-io = true
+status = 'direct'
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
+optional-deps = ['backtrace-sys', 'serde']
+
+[[host-package]]
+name = 'bech32'
+version = '0.6.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'bincode'
+version = '1.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'byteorder'
+version = '1.3.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'i128', 'std']
+
+[[host-package]]
+name = 'bytes'
+version = '0.4.12'
+crates-io = true
+status = 'direct'
+features = ['either']
+optional-deps = ['either']
+
+[[host-package]]
+name = 'chrono'
+version = '0.4.9'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'time']
+optional-deps = ['time']
+
+[[host-package]]
+name = 'codespan'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = ['serde', 'serde_derive', 'serialization']
+optional-deps = ['serde', 'serde_derive']
+
+[[host-package]]
+name = 'codespan-reporting'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'crossbeam'
+version = '0.7.2'
+crates-io = true
+status = 'direct'
+features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
+
+[[host-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
+status = 'direct'
+features = ['alloc', 'std', 'u64_backend']
+
+[[host-package]]
+name = 'digest'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[host-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
+status = 'direct'
+features = ['serde', 'std', 'u64_backend']
+optional-deps = ['serde']
+
+[[host-package]]
 name = 'failure'
 version = '0.1.5'
 crates-io = true
 status = 'direct'
 features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
 optional-deps = ['backtrace', 'failure_derive']
+
+[[host-package]]
+name = 'futures'
+version = '0.1.29'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std', 'with-deprecated']
+
+[[host-package]]
+name = 'futures-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'compat', 'default', 'std']
+
+[[host-package]]
+name = 'get_if_addrs'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'grpcio'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'prost', 'prost-codec']
+optional-deps = ['bytes', 'prost']
 
 [[host-package]]
 name = 'grpcio-compiler'
@@ -1692,11 +427,97 @@ features = ['prost', 'prost-build', 'prost-codec', 'prost-types']
 optional-deps = ['prost', 'prost-build', 'prost-types']
 
 [[host-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hyper'
+version = '0.12.34'
+crates-io = true
+status = 'direct'
+features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'itertools'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'log'
+version = '0.4.8'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[host-package]]
+name = 'mirai-annotations'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'num-derive'
 version = '0.2.5'
 crates-io = true
 status = 'direct'
 features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.8'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'num_enum'
+version = '0.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[host-package]]
+name = 'parity-multiaddr'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'petgraph'
+version = '0.4.13'
+crates-io = true
+status = 'direct'
+features = ['default', 'graphmap', 'ordermap', 'stable_graph']
+optional-deps = ['ordermap']
 
 [[host-package]]
 name = 'proc-macro2'
@@ -1706,11 +527,34 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'prometheus'
+version = '0.7.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'proptest'
+version = '0.9.4'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[host-package]]
 name = 'proptest-derive'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
+
+[[host-package]]
+name = 'prost'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -1725,6 +569,123 @@ version = '1.0.2'
 crates-io = true
 status = 'direct'
 features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'radix_trie'
+version = '0.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[host-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'direct'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'rocksdb'
+version = '0.3.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.101'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.40'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'sha2'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'slog'
+version = '2.5.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
+
+[[host-package]]
+name = 'slog-async'
+version = '2.3.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'slog-envlogger'
+version = '2.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'regex']
+optional-deps = ['regex']
+
+[[host-package]]
+name = 'slog-scope'
+version = '4.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'slog-term'
+version = '2.4.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'structopt'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'strum'
+version = '0.15.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'strum_macros'
@@ -1742,6 +703,41 @@ features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', '
 optional-deps = ['quote']
 
 [[host-package]]
+name = 'thread-id'
+version = '3.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'keccak']
+
+[[host-package]]
+name = 'toml'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[host-package]]
 name = 'aho-corasick'
 version = '0.7.6'
 crates-io = true
@@ -1749,19 +745,32 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'autocfg'
-version = '0.1.6'
+name = 'arrayref'
+version = '0.3.5'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'backtrace'
-version = '0.3.37'
+name = 'arrayvec'
+version = '0.4.11'
 crates-io = true
 status = 'transitive'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
-optional-deps = ['backtrace-sys', 'serde']
+features = []
+
+[[host-package]]
+name = 'atty'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'backtrace-sys'
@@ -1778,8 +787,50 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
 name = 'bitflags'
 version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'blake2'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'block-padding'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bs58'
+version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = ['default']
@@ -1792,27 +843,25 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'byteorder'
-version = '1.3.2'
+name = 'byte-tools'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'i128', 'std']
+features = []
 
 [[host-package]]
-name = 'bytes'
-version = '0.4.12'
-crates-io = true
+name = 'bzip2-sys'
+version = '0.1.7'
+source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
 status = 'transitive'
-features = ['either']
-optional-deps = ['either']
+features = []
 
 [[host-package]]
-name = 'c2-chacha'
-version = '0.2.2'
+name = 'c_linked_list'
+version = '1.1.1'
 crates-io = true
 status = 'transitive'
-features = ['lazy_static', 'simd', 'std']
-optional-deps = ['lazy_static']
+features = []
 
 [[host-package]]
 name = 'cc'
@@ -1845,8 +894,88 @@ features = ['clang_6_0', 'gte_clang_3_6', 'gte_clang_3_7', 'gte_clang_3_8', 'gte
 optional-deps = ['libloading']
 
 [[host-package]]
+name = 'clap'
+version = '2.33.0'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
+
+[[host-package]]
 name = 'clear_on_drop'
 version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cmake'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc'
+version = '1.8.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'crossbeam-channel'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-deque'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-epoch'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crossbeam-queue'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-utils'
+version = '0.6.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[host-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'data-encoding'
+version = '2.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1866,11 +995,11 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'digest'
-version = '0.8.1'
+name = 'dirs'
+version = '1.0.5'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = []
 
 [[host-package]]
 name = 'either'
@@ -1880,8 +1009,29 @@ status = 'transitive'
 features = ['default', 'use_std']
 
 [[host-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'failure_derive'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'fake-simd'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1892,6 +1042,65 @@ version = '0.1.9'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-channel-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink-preview', 'sink', 'std']
+optional-deps = ['futures-sink-preview']
+
+[[host-package]]
+name = 'futures-core-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'futures-cpupool'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
+name = 'futures-executor-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['num_cpus', 'std']
+optional-deps = ['num_cpus']
+
+[[host-package]]
+name = 'futures-io-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'futures-sink-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[host-package]]
+name = 'futures-util-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'channel', 'compat', 'futures-channel-preview', 'futures-io-preview', 'futures-sink-preview', 'futures_01', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'slab']
 
 [[host-package]]
 name = 'generic-array'
@@ -1915,8 +1124,64 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'grpcio-sys'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'h2'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'heck'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http'
+version = '0.1.18'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http-body'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'idna'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'indexmap'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1929,11 +1194,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'itertools'
-version = '0.8.0'
+name = 'itoa'
+version = '0.4.4'
 crates-io = true
 status = 'transitive'
-features = ['default', 'use_std']
+features = ['default', 'std']
 
 [[host-package]]
 name = 'jobserver'
@@ -1943,8 +1208,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
+name = 'keccak'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1964,11 +1229,47 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'log'
-version = '0.4.8'
+name = 'librocksdb_sys'
+version = '0.1.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'libtitan_sys'
+version = '0.0.1'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'libz-sys'
+version = '1.0.25'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['static']
+
+[[host-package]]
+name = 'lock_api'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = ['owning_ref']
+optional-deps = ['owning_ref']
+
+[[host-package]]
+name = 'lz4-sys'
+version = '1.8.0'
+source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'memchr'
@@ -1978,8 +1279,51 @@ status = 'transitive'
 features = ['default', 'use_std']
 
 [[host-package]]
+name = 'memoffset'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memsec'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom']
+
+[[host-package]]
+name = 'mio'
+version = '0.6.19'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
 name = 'multimap'
 version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[host-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nodrop'
+version = '0.1.13'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1990,6 +1334,13 @@ version = '4.2.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'std', 'verbose-errors']
+
+[[host-package]]
+name = 'num-integer'
+version = '0.1.41'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'num_cpus'
@@ -2006,8 +1357,43 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'ordermap'
 version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'owning_ref'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parity-multihash'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.4.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2020,12 +1406,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'petgraph'
-version = '0.4.13'
+name = 'percent-encoding'
+version = '1.0.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'graphmap', 'ordermap', 'stable_graph']
-optional-deps = ['ordermap']
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'pkg-config'
@@ -2033,13 +1425,6 @@ version = '0.3.15'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'ppv-lite86'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default', 'simd', 'std']
 
 [[host-package]]
 name = 'proc-macro-crate'
@@ -2084,14 +1469,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
-
-[[host-package]]
 name = 'prost-derive'
 version = '0.5.0'
 crates-io = true
@@ -2113,11 +1490,25 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'quick-error'
+version = '1.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
 
 [[host-package]]
 name = 'rand'
@@ -2128,11 +1519,25 @@ features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
 optional-deps = ['getrandom_package']
 
 [[host-package]]
-name = 'rand_chacha'
-version = '0.2.1'
+name = 'rand04'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'simd', 'std']
+features = ['std']
+
+[[host-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'rand_core'
@@ -2157,12 +1562,46 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'regex'
-version = '1.3.1'
+name = 'rand_hc'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+features = []
+
+[[host-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'regex-syntax'
@@ -2200,8 +1639,29 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'ryu'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'same-file'
 version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2221,19 +1681,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'transitive'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.99'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[host-package]]
+name = 'sha-1'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'shlex'
@@ -2243,8 +1702,72 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'slog-stdlog'
+version = '4.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'smallvec'
+version = '0.6.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'snappy-sys'
+version = '0.1.0'
+source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'string'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'default']
+optional-deps = ['bytes']
+
+[[host-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'structopt-derive'
 version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'subtle'
+version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2272,8 +1795,36 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'take_mut'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'tempfile'
 version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'term'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'termcolor'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.11.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2286,15 +1837,108 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'toml'
-version = '0.5.3'
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'tokio-buf'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'either', 'util']
+optional-deps = ['either']
+
+[[host-package]]
+name = 'tokio-current-thread'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-executor'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-io'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-reactor'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-sync'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-tcp'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-threadpool'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-timer'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'try-lock'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'typenum'
+version = '1.11.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'typenum'
-version = '1.11.2'
+name = 'unicode-normalization'
+version = '0.1.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2305,6 +1949,13 @@ version = '1.3.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -2321,8 +1972,36 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'unsigned-varint'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'url'
+version = '1.7.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vec_map'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2335,8 +2014,22 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'want'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'which'
 version = '2.0.1'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'zstd-sys'
+version = '1.4.13+zstd.1.4.3'
+source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
+status = 'transitive'
+features = ['default', 'legacy']

--- a/fixtures/large/summaries/metadata_libra-1.toml
+++ b/fixtures/large/summaries/metadata_libra-1.toml
@@ -2,27 +2,15 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'i686-uwp-windows-gnu'
-target-features = 'unknown'
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'aarch64-pc-windows-msvc'
-target-features = ['sha', 'ssse3', 'xsaves']
-flags = ['abc', 'bar']
-[[metadata.omitted-packages.ids]]
-name = 'dirs-sys'
-version = '0.3.4'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'tokio-io'
-version = '0.1.12'
-crates-io = true
+spec = 'any'
 
 [[metadata.features-only]]
 name = 'debug-interface'
@@ -30,7 +18,7 @@ version = '0.1.0'
 workspace-path = 'common/debug-interface'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'network'
 version = '0.1.0'
 workspace-path = 'network'
@@ -38,1760 +26,55 @@ status = 'initial'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
 optional-deps = ['libra-proptest-helpers', 'proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'admission-control-proto'
 version = '0.1.0'
 workspace-path = 'admission_control/admission-control-proto'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'bounded-executor'
 version = '0.1.0'
 workspace-path = 'common/bounded-executor'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'channel'
 version = '0.1.0'
 workspace-path = 'common/channel'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'futures-semaphore'
 version = '0.1.0'
 workspace-path = 'common/futures-semaphore'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
 status = 'workspace'
 features = ['cloneable-private-keys', 'default', 'fuzzing', 'proptest', 'proptest-derive', 'std', 'u64_backend']
 optional-deps = ['proptest', 'proptest-derive']
-
-[[target-package]]
-name = 'libra-failure-ext'
-version = '0.1.0'
-workspace-path = 'common/failure-ext'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-failure-macros'
-version = '0.1.0'
-workspace-path = 'common/failure-ext/failure-macros'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-logger'
-version = '0.1.0'
-workspace-path = 'common/logger'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-mempool-shared-proto'
-version = '0.1.0'
-workspace-path = 'mempool/mempool-shared-proto'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-metrics'
-version = '0.1.0'
-workspace-path = 'common/metrics'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-nibble'
-version = '0.1.0'
-workspace-path = 'common/nibble'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'libra-proptest-helpers'
-version = '0.1.0'
-workspace-path = 'common/proptest-helpers'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-prost-ext'
-version = '0.1.0'
-workspace-path = 'common/prost-ext'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-tools'
-version = '0.1.0'
-workspace-path = 'common/tools'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'libra-types'
-version = '0.1.0'
-workspace-path = 'types'
-status = 'workspace'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[target-package]]
-name = 'memsocket'
-version = '0.1.0'
-workspace-path = 'network/memsocket'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'netcore'
-version = '0.1.0'
-workspace-path = 'network/netcore'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'noise'
-version = '0.1.0'
-workspace-path = 'network/noise'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'socket-bench-server'
-version = '0.1.0'
-workspace-path = 'network/socket-bench-server'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'backtrace'
-version = '0.3.37'
-crates-io = true
-status = 'direct'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
-optional-deps = ['backtrace-sys', 'serde']
-
-[[target-package]]
-name = 'bech32'
-version = '0.6.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'byteorder'
-version = '1.3.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'i128', 'std']
-
-[[target-package]]
-name = 'bytes'
-version = '0.4.12'
-crates-io = true
-status = 'direct'
-features = ['either']
-optional-deps = ['either']
-
-[[target-package]]
-name = 'chrono'
-version = '0.4.9'
-crates-io = true
-status = 'direct'
-features = ['clock', 'default', 'time']
-optional-deps = ['time']
-
-[[target-package]]
-name = 'criterion'
-version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'crossbeam'
-version = '0.7.2'
-crates-io = true
-status = 'direct'
-features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
-
-[[target-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
-status = 'direct'
-features = ['alloc', 'std', 'u64_backend']
-
-[[target-package]]
-name = 'digest'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[target-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
-status = 'direct'
-features = ['serde', 'std', 'u64_backend']
-optional-deps = ['serde']
-
-[[target-package]]
-name = 'failure'
-version = '0.1.5'
-crates-io = true
-status = 'direct'
-features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
-optional-deps = ['backtrace', 'failure_derive']
-
-[[target-package]]
-name = 'futures'
-version = '0.1.29'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std', 'with-deprecated']
-
-[[target-package]]
-name = 'futures-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'async-await', 'compat', 'default', 'io-compat', 'std']
-
-[[target-package]]
-name = 'get_if_addrs'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'grpcio'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'prost', 'prost-codec']
-optional-deps = ['bytes', 'prost']
-
-[[target-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hyper'
-version = '0.12.34'
-crates-io = true
-status = 'direct'
-features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'itertools'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = ['spin', 'spin_no_std']
-optional-deps = ['spin']
-
-[[target-package]]
-name = 'mirai-annotations'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'num_enum'
-version = '0.4.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[target-package]]
-name = 'parity-multiaddr'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'pin-project'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'prometheus'
-version = '0.7.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'proptest'
-version = '0.9.4'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[target-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
-
-[[target-package]]
-name = 'radix_trie'
-version = '0.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[target-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'serde_json'
-version = '1.0.40'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'sha2'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'slog'
-version = '2.5.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
-
-[[target-package]]
-name = 'slog-async'
-version = '2.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'slog-envlogger'
-version = '2.2.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'regex']
-optional-deps = ['regex']
-
-[[target-package]]
-name = 'slog-scope'
-version = '4.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'slog-term'
-version = '2.4.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'snow'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
-optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
-
-[[target-package]]
-name = 'thread-id'
-version = '3.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'keccak']
-
-[[target-package]]
-name = 'tokio'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
-optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
-
-[[target-package]]
-name = 'tokio-retry'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tokio-sync'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['async-traits', 'futures-sink-preview']
-optional-deps = ['futures-sink-preview']
-
-[[target-package]]
-name = 'toml'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
-
-[[target-package]]
-name = 'yamux'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'aho-corasick'
-version = '0.7.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'arc-swap'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arrayref'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arrayvec'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atty'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'backtrace-sys'
-version = '0.1.31'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit-set'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bitflags'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'blake2'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'blake2-rfc'
-version = '0.2.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'block-buffer'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'block-padding'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bs58'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'bstr'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
-
-[[target-package]]
-name = 'byte-tools'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'c2-chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['lazy_static', 'simd', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cast'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'cfg-if'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'chacha20-poly1305-aead'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clap'
-version = '2.33.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clear_on_drop'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'constant_time_eq'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'criterion-plot'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-channel'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-deque'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-epoch'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crossbeam-queue'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.6.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[target-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'csv'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'csv-core'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc']
-
-[[target-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std', 'u64_backend']
-
-[[target-package]]
-name = 'data-encoding'
-version = '2.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'dirs'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'either'
-version = '1.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'endian-type'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fake-simd'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-channel-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'futures-sink-preview', 'sink', 'std']
-optional-deps = ['futures-sink-preview']
-
-[[target-package]]
-name = 'futures-core-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-cpupool'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'futures-executor-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['num_cpus', 'std']
-optional-deps = ['num_cpus']
-
-[[target-package]]
-name = 'futures-io-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'futures-sink-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-util-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'async-await', 'channel', 'compat', 'default', 'futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'io', 'io-compat', 'join-macro', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'select-macro', 'sink', 'slab', 'std', 'tokio-io']
-optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
-
-[[target-package]]
-name = 'generic-array'
-version = '0.12.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'getrandom'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'grpcio-sys'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'h2'
-version = '0.1.26'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http'
-version = '0.1.18'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http-body'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'idna'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'indexmap'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'iovec'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itoa'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'keccak'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libc'
-version = '0.2.62'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'lock_api'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['owning_ref']
-optional-deps = ['owning_ref']
-
-[[target-package]]
-name = 'lock_api'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'use_std']
-optional-deps = ['libc']
-
-[[target-package]]
-name = 'memoffset'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memsec'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'winapi']
-
-[[target-package]]
-name = 'mio'
-version = '0.6.19'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[target-package]]
-name = 'nibble_vec'
-version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nodrop'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nohash-hasher'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-integer'
-version = '0.1.41'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.10.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'owning_ref'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parity-multihash'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.6.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.9.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ppv-lite86'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default', 'simd', 'std']
-
-[[target-package]]
-name = 'proc-macro-nested'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'quick-error'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'quick-error'
-version = '1.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-
-[[target-package]]
-name = 'rand'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
-optional-deps = ['winapi']
-
-[[target-package]]
-name = 'rand'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
-optional-deps = ['getrandom_package']
-
-[[target-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'simd', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[target-package]]
-name = 'rand_hc'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_os'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xoshiro'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon-core'
-version = '1.6.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'regex-automata'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.12'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ring'
-version = '0.16.9'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
-
-[[target-package]]
-name = 'rustc-demangle'
-version = '0.1.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[target-package]]
-name = 'ryu'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'same-file'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'sha-1'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slog-stdlog'
-version = '4.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'smallvec'
-version = '0.6.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'spin'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'stable_deref_trait'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'string'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'default']
-optional-deps = ['bytes']
-
-[[target-package]]
-name = 'subtle'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'subtle'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'i128', 'std']
-
-[[target-package]]
-name = 'take_mut'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'term'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tinytemplate'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio'
-version = '0.1.22'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'tokio-buf'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'either', 'util']
-optional-deps = ['either']
-
-[[target-package]]
-name = 'tokio-codec'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-codec'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-current-thread'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-executor'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-executor'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync']
-
-[[target-package]]
-name = 'tokio-fs'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-io'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['memchr', 'pin-project', 'util']
-optional-deps = ['memchr', 'pin-project']
-
-[[target-package]]
-name = 'tokio-net'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'udp', 'uds']
-optional-deps = ['bytes', 'futures-sink-preview', 'iovec']
-
-[[target-package]]
-name = 'tokio-reactor'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-sync'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-tcp'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-threadpool'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-timer'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-timer'
-version = '0.3.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['async-traits']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'typenum'
-version = '1.11.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-normalization'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-width'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unsigned-varint'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'untrusted'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'url'
-version = '1.7.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'walkdir'
-version = '2.2.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'u64_backend']
 
 [[host-package]]
 name = 'libra-crypto-derive'
@@ -1801,12 +84,201 @@ status = 'workspace'
 features = []
 
 [[host-package]]
+name = 'libra-failure-ext'
+version = '0.1.0'
+workspace-path = 'common/failure-ext'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-failure-macros'
+version = '0.1.0'
+workspace-path = 'common/failure-ext/failure-macros'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-logger'
+version = '0.1.0'
+workspace-path = 'common/logger'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-mempool-shared-proto'
+version = '0.1.0'
+workspace-path = 'mempool/mempool-shared-proto'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-metrics'
+version = '0.1.0'
+workspace-path = 'common/metrics'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-nibble'
+version = '0.1.0'
+workspace-path = 'common/nibble'
+status = 'workspace'
+features = ['default']
+
+[[host-package]]
+name = 'libra-proptest-helpers'
+version = '0.1.0'
+workspace-path = 'common/proptest-helpers'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-prost-ext'
+version = '0.1.0'
+workspace-path = 'common/prost-ext'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-tools'
+version = '0.1.0'
+workspace-path = 'common/tools'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'libra-types'
+version = '0.1.0'
+workspace-path = 'types'
+status = 'workspace'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[host-package]]
+name = 'memsocket'
+version = '0.1.0'
+workspace-path = 'network/memsocket'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'netcore'
+version = '0.1.0'
+workspace-path = 'network/netcore'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'noise'
+version = '0.1.0'
+workspace-path = 'network/noise'
+status = 'workspace'
+features = []
+
+[[host-package]]
+name = 'backtrace'
+version = '0.3.37'
+crates-io = true
+status = 'direct'
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
+optional-deps = ['backtrace-sys', 'serde']
+
+[[host-package]]
+name = 'bech32'
+version = '0.6.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'byteorder'
+version = '1.3.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'i128', 'std']
+
+[[host-package]]
+name = 'bytes'
+version = '0.4.12'
+crates-io = true
+status = 'direct'
+features = ['either']
+optional-deps = ['either']
+
+[[host-package]]
+name = 'chrono'
+version = '0.4.9'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'time']
+optional-deps = ['time']
+
+[[host-package]]
+name = 'crossbeam'
+version = '0.7.2'
+crates-io = true
+status = 'direct'
+features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
+
+[[host-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
+status = 'direct'
+features = ['alloc', 'std', 'u64_backend']
+
+[[host-package]]
+name = 'digest'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[host-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
+status = 'direct'
+features = ['serde', 'std', 'u64_backend']
+optional-deps = ['serde']
+
+[[host-package]]
 name = 'failure'
 version = '0.1.5'
 crates-io = true
 status = 'direct'
-features = ['backtrace', 'std']
-optional-deps = ['backtrace']
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[host-package]]
+name = 'futures'
+version = '0.1.29'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std', 'with-deprecated']
+
+[[host-package]]
+name = 'futures-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'compat', 'default', 'io-compat', 'std']
+
+[[host-package]]
+name = 'get_if_addrs'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'grpcio'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'prost', 'prost-codec']
+optional-deps = ['bytes', 'prost']
 
 [[host-package]]
 name = 'grpcio-compiler'
@@ -1817,6 +289,77 @@ features = ['prost', 'prost-build', 'prost-codec', 'prost-types']
 optional-deps = ['prost', 'prost-build', 'prost-types']
 
 [[host-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hyper'
+version = '0.12.34'
+crates-io = true
+status = 'direct'
+features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'itertools'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mirai-annotations'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'num_enum'
+version = '0.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[host-package]]
+name = 'parity-multiaddr'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'pin-project'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'proc-macro2'
 version = '1.0.2'
 crates-io = true
@@ -1824,11 +367,34 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'prometheus'
+version = '0.7.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'proptest'
+version = '0.9.4'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[host-package]]
 name = 'proptest-derive'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
+
+[[host-package]]
+name = 'prost'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -1845,12 +411,165 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'radix_trie'
+version = '0.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.101'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.40'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'sha2'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'slog'
+version = '2.5.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
+
+[[host-package]]
+name = 'slog-async'
+version = '2.3.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'slog-envlogger'
+version = '2.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'regex']
+optional-deps = ['regex']
+
+[[host-package]]
+name = 'slog-scope'
+version = '4.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'slog-term'
+version = '2.4.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'snow'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
+optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
+
+[[host-package]]
 name = 'syn'
 version = '1.0.5'
 crates-io = true
 status = 'direct'
 features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
 optional-deps = ['quote']
+
+[[host-package]]
+name = 'thread-id'
+version = '3.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'keccak']
+
+[[host-package]]
+name = 'tokio'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
+optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
+
+[[host-package]]
+name = 'tokio-retry'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tokio-sync'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['async-traits', 'futures-sink-preview']
+optional-deps = ['futures-sink-preview']
+
+[[host-package]]
+name = 'toml'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[host-package]]
+name = 'yamux'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'aho-corasick'
@@ -1860,19 +579,39 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'autocfg'
-version = '0.1.6'
+name = 'arc-swap'
+version = '0.4.2'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'backtrace'
-version = '0.3.37'
+name = 'arrayref'
+version = '0.3.5'
 crates-io = true
 status = 'transitive'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'std']
-optional-deps = ['backtrace-sys']
+features = []
+
+[[host-package]]
+name = 'arrayvec'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'atty'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'backtrace-sys'
@@ -1889,6 +628,20 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
 name = 'bitflags'
 version = '1.1.0'
 crates-io = true
@@ -1896,26 +649,53 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'byteorder'
-version = '1.3.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'i128', 'std']
-
-[[host-package]]
-name = 'bytes'
-version = '0.4.12'
+name = 'blake2'
+version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'c2-chacha'
-version = '0.2.2'
+name = 'blake2-rfc'
+version = '0.2.18'
 crates-io = true
 status = 'transitive'
-features = ['lazy_static', 'simd', 'std']
-optional-deps = ['lazy_static']
+features = ['default', 'std']
+
+[[host-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'block-padding'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bs58'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'byte-tools'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'c_linked_list'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'cc'
@@ -1934,6 +714,13 @@ features = []
 [[host-package]]
 name = 'cfg-if'
 version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'chacha20-poly1305-aead'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1961,6 +748,78 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'constant_time_eq'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-channel'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-deque'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-epoch'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crossbeam-queue'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-utils'
+version = '0.6.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[host-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std', 'u64_backend']
+
+[[host-package]]
+name = 'data-encoding'
+version = '2.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'derivative'
 version = '1.0.3'
 crates-io = true
@@ -1975,8 +834,8 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'digest'
-version = '0.8.1'
+name = 'dirs'
+version = '1.0.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1984,6 +843,20 @@ features = []
 [[host-package]]
 name = 'either'
 version = '1.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.2.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1996,11 +869,62 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'fake-simd'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'fixedbitset'
 version = '0.1.9'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-channel-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink-preview', 'sink', 'std']
+optional-deps = ['futures-sink-preview']
+
+[[host-package]]
+name = 'futures-core-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-cpupool'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
+name = 'futures-executor-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['num_cpus', 'std']
+optional-deps = ['num_cpus']
+
+[[host-package]]
+name = 'futures-io-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['std']
 
 [[host-package]]
 name = 'futures-join-macro-preview'
@@ -2015,6 +939,21 @@ version = '0.3.0-alpha.19'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'futures-sink-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-util-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'channel', 'compat', 'default', 'futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'io', 'io-compat', 'join-macro', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'select-macro', 'sink', 'slab', 'std', 'tokio-io']
+optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
 
 [[host-package]]
 name = 'generic-array'
@@ -2038,8 +977,64 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'grpcio-sys'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'h2'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'heck'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http'
+version = '0.1.18'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http-body'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'idna'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'indexmap'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2052,15 +1047,15 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'itertools'
-version = '0.8.0'
+name = 'itoa'
+version = '0.4.4'
 crates-io = true
 status = 'transitive'
-features = ['default', 'use_std']
+features = ['default', 'std']
 
 [[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
+name = 'keccak'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2080,8 +1075,30 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'lock_api'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = ['owning_ref']
+optional-deps = ['owning_ref']
+
+[[host-package]]
+name = 'lock_api'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'log'
 version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'matches'
+version = '0.1.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2094,8 +1111,58 @@ status = 'transitive'
 features = ['default', 'use_std']
 
 [[host-package]]
+name = 'memoffset'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memsec'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom']
+
+[[host-package]]
+name = 'mio'
+version = '0.6.19'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
 name = 'multimap'
 version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[host-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nodrop'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nohash-hasher'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2108,6 +1175,27 @@ status = 'transitive'
 features = ['alloc', 'default', 'std', 'verbose-errors']
 
 [[host-package]]
+name = 'num-integer'
+version = '0.1.41'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.8'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'num_cpus'
+version = '1.10.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'num_enum_derive'
 version = '0.4.1'
 crates-io = true
@@ -2115,8 +1203,78 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'owning_ref'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parity-multihash'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.6.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'peeking_take_while'
 version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'percent-encoding'
+version = '1.0.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2136,18 +1294,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'pkg-config'
-version = '0.3.15'
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'ppv-lite86'
-version = '0.2.5'
+name = 'pkg-config'
+version = '0.3.15'
 crates-io = true
 status = 'transitive'
-features = ['default', 'simd', 'std']
+features = []
 
 [[host-package]]
 name = 'proc-macro-crate'
@@ -2159,6 +1317,13 @@ features = []
 [[host-package]]
 name = 'proc-macro-hack'
 version = '0.5.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2185,14 +1350,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
-
-[[host-package]]
 name = 'prost-derive'
 version = '0.5.0'
 crates-io = true
@@ -2214,11 +1371,39 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'quick-error'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'quick-error'
+version = '1.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
+
+[[host-package]]
+name = 'rand'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
 
 [[host-package]]
 name = 'rand'
@@ -2229,18 +1414,32 @@ features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
 optional-deps = ['getrandom_package']
 
 [[host-package]]
-name = 'rand_chacha'
-version = '0.2.1'
+name = 'rand04'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'simd', 'std']
+features = ['std']
+
+[[host-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'rand_core'
 version = '0.3.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['alloc', 'std']
 
 [[host-package]]
 name = 'rand_core'
@@ -2258,6 +1457,48 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
+name = 'rand_hc'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'regex'
 version = '1.3.1'
 crates-io = true
@@ -2270,7 +1511,7 @@ name = 'regex-syntax'
 version = '0.6.12'
 crates-io = true
 status = 'transitive'
-features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[host-package]]
 name = 'remove_dir_all'
@@ -2278,6 +1519,13 @@ version = '0.5.2'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'ring'
+version = '0.16.9'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
 
 [[host-package]]
 name = 'rustc-demangle'
@@ -2301,8 +1549,37 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[host-package]]
+name = 'ryu'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'same-file'
 version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2322,18 +1599,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.99'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[host-package]]
+name = 'sha-1'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'shlex'
@@ -2343,11 +1620,61 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'slog-stdlog'
+version = '4.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'smallvec'
+version = '0.6.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'string'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'default']
+optional-deps = ['bytes']
+
+[[host-package]]
+name = 'subtle'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'subtle'
 version = '2.1.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['default', 'i128', 'std']
 
 [[host-package]]
 name = 'syn'
@@ -2365,11 +1692,25 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'take_mut'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'tempfile'
 version = '3.1.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'term'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'thread_local'
@@ -2379,6 +1720,87 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'tokio-buf'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'either', 'util']
+optional-deps = ['either']
+
+[[host-package]]
+name = 'tokio-codec'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-codec'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-current-thread'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-executor'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-executor'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync']
+
+[[host-package]]
+name = 'tokio-fs'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-io'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-io'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['memchr', 'pin-project', 'util']
+optional-deps = ['memchr', 'pin-project']
+
+[[host-package]]
 name = 'tokio-macros'
 version = '0.2.0-alpha.6'
 crates-io = true
@@ -2386,15 +1808,86 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'toml'
-version = '0.5.3'
+name = 'tokio-net'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'udp', 'uds']
+optional-deps = ['bytes', 'futures-sink-preview', 'iovec']
+
+[[host-package]]
+name = 'tokio-reactor'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-sync'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-tcp'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-threadpool'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-timer'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-timer'
+version = '0.3.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['async-traits']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'try-lock'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'typenum'
+version = '1.11.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'typenum'
-version = '1.11.2'
+name = 'unicode-normalization'
+version = '0.1.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2421,8 +1914,36 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'unsigned-varint'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'untrusted'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'url'
+version = '1.7.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2435,6 +1956,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'want'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'which'
 version = '2.0.1'
 crates-io = true
@@ -2442,29 +1970,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'winapi'
-version = '0.2.8'
+name = 'x25519-dalek'
+version = '0.5.2'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'libloaderapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['default', 'std', 'u64_backend']

--- a/fixtures/large/summaries/metadata_libra-2.toml
+++ b/fixtures/large/summaries/metadata_libra-2.toml
@@ -2,31 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'host'
+resolver = '3'
+include-dev = true
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32imac-unknown-xous-elf'
-target-features = 'unknown'
-flags = ['foo']
+triple = 'armv7a-none-eabi'
+target-features = ['bmi1', 'bmi2', 'fma', 'sha', 'sse2', 'ssse3']
+flags = ['flag-test', 'foo']
 
 [metadata.target-platform]
 spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'bytecode-to-boogie'
-version = '0.1.0'
-workspace-path = 'language/stackless-bytecode/bytecode-to-boogie'
-
-[[metadata.omitted-packages.ids]]
-name = 'futures-util-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
 
 [[metadata.features-only]]
 name = 'functional_tests'
@@ -40,21 +26,21 @@ version = '0.1.0'
 workspace-path = 'crypto/crypto-derive'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'accumulator'
 version = '0.1.0'
 workspace-path = 'storage/accumulator'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'admission-control-proto'
 version = '0.1.0'
 workspace-path = 'admission_control/admission-control-proto'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'admission-control-service'
 version = '0.1.0'
 workspace-path = 'admission_control/admission-control-service'
@@ -62,84 +48,85 @@ status = 'initial'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
 optional-deps = ['libra-proptest-helpers', 'proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'benchmark'
 version = '0.1.0'
 workspace-path = 'benchmark'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'bounded-executor'
 version = '0.1.0'
 workspace-path = 'common/bounded-executor'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-source-map'
 version = '0.1.0'
 workspace-path = 'language/compiler/bytecode-source-map'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-to-boogie'
 version = '0.1.0'
 workspace-path = 'language/stackless-bytecode/bytecode-to-boogie'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-verifier'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode_verifier_tests'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier/bytecode_verifier_tests'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'channel'
 version = '0.1.0'
 workspace-path = 'common/channel'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'client'
 version = '0.1.0'
 workspace-path = 'client'
 status = 'initial'
-features = ['default']
+features = ['default', 'fuzzing', 'proptest']
+optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'cluster-test'
 version = '0.1.0'
 workspace-path = 'testsuite/cluster-test'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'compiler'
 version = '0.1.0'
 workspace-path = 'language/compiler'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'config-builder'
 version = '0.1.0'
 workspace-path = 'config/config-builder'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'consensus'
 version = '0.1.0'
 workspace-path = 'consensus'
@@ -147,7 +134,7 @@ status = 'initial'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'consensus-types'
 version = '0.1.0'
 workspace-path = 'consensus/consensus-types'
@@ -155,98 +142,98 @@ status = 'initial'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'cost-synthesis'
 version = '0.1.0'
 workspace-path = 'language/tools/cost-synthesis'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'crash-handler'
 version = '0.1.0'
 workspace-path = 'common/crash-handler'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'datatest-stable'
 version = '0.1.0'
 workspace-path = 'common/datatest-stable'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'debug-interface'
 version = '0.1.0'
 workspace-path = 'common/debug-interface'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'executable-helpers'
 version = '0.1.0'
 workspace-path = 'common/executable-helpers'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'executor'
 version = '0.1.0'
 workspace-path = 'executor'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'functional_tests'
 version = '0.1.0'
 workspace-path = 'language/functional_tests'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'futures-semaphore'
 version = '0.1.0'
 workspace-path = 'common/futures-semaphore'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'generate-keypair'
 version = '0.1.0'
 workspace-path = 'config/generate-keypair'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'grpc-helpers'
 version = '0.1.0'
 workspace-path = 'common/grpc-helpers'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'invalid-mutations'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier/invalid-mutations'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode-syntax'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'jellyfish-merkle'
 version = '0.1.0'
 workspace-path = 'storage/jellyfish-merkle'
@@ -254,41 +241,3035 @@ status = 'initial'
 features = ['default', 'fuzzing', 'proptest', 'proptest-derive']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'language-e2e-tests'
 version = '0.1.0'
 workspace-path = 'language/e2e-tests'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'language_benchmarks'
 version = '0.1.0'
 workspace-path = 'language/benchmarks'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'initial'
 features = ['default', 'fuzzing']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
 status = 'initial'
 features = ['cloneable-private-keys', 'default', 'fuzzing', 'proptest', 'proptest-derive', 'std', 'u64_backend']
 optional-deps = ['proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'libra-crypto-derive'
+version = '0.1.0'
+workspace-path = 'crypto/crypto-derive'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-failure-ext'
+version = '0.1.0'
+workspace-path = 'common/failure-ext'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-failure-macros'
+version = '0.1.0'
+workspace-path = 'common/failure-ext/failure-macros'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-fuzzer'
+version = '0.1.0'
+workspace-path = 'testsuite/libra-fuzzer'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-logger'
+version = '0.1.0'
+workspace-path = 'common/logger'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-mempool'
+version = '0.1.0'
+workspace-path = 'mempool'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'libra-mempool-shared-proto'
+version = '0.1.0'
+workspace-path = 'mempool/mempool-shared-proto'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-metrics'
+version = '0.1.0'
+workspace-path = 'common/metrics'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-nibble'
+version = '0.1.0'
+workspace-path = 'common/nibble'
+status = 'initial'
+features = ['default', 'fuzzing', 'proptest']
+optional-deps = ['proptest']
+
+[[target-package]]
+name = 'libra-node'
+version = '0.1.0'
+workspace-path = 'libra-node'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'libra-proptest-helpers'
+version = '0.1.0'
+workspace-path = 'common/proptest-helpers'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-prost-ext'
+version = '0.1.0'
+workspace-path = 'common/prost-ext'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-state-view'
+version = '0.1.0'
+workspace-path = 'storage/state-view'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'libra-swarm'
+version = '0.1.0'
+workspace-path = 'libra-swarm'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-tools'
+version = '0.1.0'
+workspace-path = 'common/tools'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'libra-types'
+version = '0.1.0'
+workspace-path = 'types'
+status = 'initial'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'libra-wallet'
+version = '0.1.0'
+workspace-path = 'client/libra_wallet'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'libradb'
+version = '0.1.0'
+workspace-path = 'storage/libradb'
+status = 'initial'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'memsocket'
+version = '0.1.0'
+workspace-path = 'network/memsocket'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'netcore'
+version = '0.1.0'
+workspace-path = 'network/netcore'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'network'
+version = '0.1.0'
+workspace-path = 'network'
+status = 'initial'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
+optional-deps = ['libra-proptest-helpers', 'proptest']
+
+[[target-package]]
+name = 'noise'
+version = '0.1.0'
+workspace-path = 'network/noise'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'safety-rules'
+version = '0.1.0'
+workspace-path = 'consensus/safety-rules'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'schemadb'
+version = '0.1.0'
+workspace-path = 'storage/schemadb'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'scratchpad'
+version = '0.1.0'
+workspace-path = 'storage/scratchpad'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'secret-service'
+version = '0.1.0'
+workspace-path = 'crypto/secret-service'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'serializer_tests'
+version = '0.1.0'
+workspace-path = 'language/vm/serializer_tests'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'socket-bench-server'
+version = '0.1.0'
+workspace-path = 'network/socket-bench-server'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'stackless-bytecode-generator'
+version = '0.1.0'
+workspace-path = 'language/stackless-bytecode/generator'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'state-synchronizer'
+version = '0.1.0'
+workspace-path = 'state-synchronizer'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'stdlib'
+version = '0.1.0'
+workspace-path = 'language/stdlib'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'storage-client'
+version = '0.1.0'
+workspace-path = 'storage/storage-client'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'storage-proto'
+version = '0.1.0'
+workspace-path = 'storage/storage-proto'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'storage-service'
+version = '0.1.0'
+workspace-path = 'storage/storage-service'
+status = 'initial'
+features = ['default', 'fuzzing', 'proptest']
+optional-deps = ['proptest']
+
+[[target-package]]
+name = 'test-generation'
+version = '0.1.0'
+workspace-path = 'language/tools/test-generation'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'testsuite'
+version = '0.1.0'
+workspace-path = 'testsuite'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'transaction-builder'
+version = '0.1.0'
+workspace-path = 'language/transaction-builder'
+status = 'initial'
+features = ['default', 'fuzzing']
+
+[[target-package]]
+name = 'tree_heap'
+version = '0.1.0'
+workspace-path = 'language/stackless-bytecode/tree_heap'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'vm'
+version = '0.1.0'
+workspace-path = 'language/vm'
+status = 'initial'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'vm-cache-map'
+version = '0.1.0'
+workspace-path = 'language/vm/vm-runtime/vm-cache-map'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'vm-genesis'
+version = '0.1.0'
+workspace-path = 'language/vm/vm-genesis'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'vm-runtime'
+version = '0.1.0'
+workspace-path = 'language/vm/vm-runtime'
+status = 'initial'
+features = ['default', 'instruction_synthesis']
+
+[[target-package]]
+name = 'vm-runtime-types'
+version = '0.1.0'
+workspace-path = 'language/vm/vm-runtime/vm-runtime-types'
+status = 'initial'
+features = ['default', 'fuzzing', 'proptest']
+optional-deps = ['proptest']
+
+[[target-package]]
+name = 'vm-validator'
+version = '0.1.0'
+workspace-path = 'vm-validator'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'x'
+version = '0.1.0'
+workspace-path = 'x'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'anyhow'
+version = '1.0.17'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'arc-swap'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'assert_approx_eq'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'assert_matches'
+version = '1.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'backoff'
+version = '0.1.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'backtrace'
+version = '0.3.37'
+crates-io = true
+status = 'direct'
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
+optional-deps = ['backtrace-sys', 'serde']
+
+[[target-package]]
+name = 'bech32'
+version = '0.6.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bincode'
+version = '1.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bitvec'
+version = '0.10.2'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'bytes'
+version = '0.4.12'
+crates-io = true
+status = 'direct'
+features = ['either']
+optional-deps = ['either']
+
+[[target-package]]
+name = 'cached'
+version = '0.9.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'chashmap'
+version = '2.2.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'chrono'
+version = '0.4.9'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'serde', 'time']
+optional-deps = ['serde', 'time']
+
+[[target-package]]
+name = 'codespan'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = ['serde', 'serde_derive', 'serialization']
+optional-deps = ['serde', 'serde_derive']
+
+[[target-package]]
+name = 'codespan-reporting'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'criterion'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'crossbeam'
+version = '0.7.2'
+crates-io = true
+status = 'direct'
+features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
+
+[[target-package]]
+name = 'csv'
+version = '1.1.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ctrlc'
+version = '3.1.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
+status = 'direct'
+features = ['alloc', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'digest'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[target-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
+status = 'direct'
+features = ['serde', 'std', 'u64_backend']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'env_logger'
+version = '0.6.2'
+crates-io = true
+status = 'direct'
+features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
+optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
+
+[[target-package]]
+name = 'failure'
+version = '0.1.5'
+crates-io = true
+status = 'direct'
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[target-package]]
+name = 'filecheck'
+version = '0.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'flate2'
+version = '1.0.11'
+crates-io = true
+status = 'direct'
+features = ['miniz_oxide', 'rust_backend']
+optional-deps = ['miniz_oxide']
+
+[[target-package]]
+name = 'futures'
+version = '0.1.29'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std', 'with-deprecated']
+
+[[target-package]]
+name = 'futures-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'compat', 'default', 'io-compat', 'std']
+
+[[target-package]]
+name = 'get_if_addrs'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'grpcio'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'prost', 'prost-codec', 'protobuf', 'protobuf-codec']
+optional-deps = ['bytes', 'prost', 'protobuf']
+
+[[target-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hyper'
+version = '0.12.34'
+crates-io = true
+status = 'direct'
+features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+
+[[target-package]]
+name = 'itertools'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'jemallocator'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = ['background_threads_runtime_support', 'default', 'profiling', 'unprefixed_malloc_on_supported_platforms']
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = ['spin', 'spin_no_std']
+optional-deps = ['spin']
+
+[[target-package]]
+name = 'log'
+version = '0.4.8'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[target-package]]
+name = 'lru-cache'
+version = '0.1.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mirai-annotations'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'num'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'num-bigint', 'std']
+optional-deps = ['num-bigint']
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.8'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'num_cpus'
+version = '1.10.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'num_enum'
+version = '0.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[target-package]]
+name = 'parity-multiaddr'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'petgraph'
+version = '0.4.13'
+crates-io = true
+status = 'direct'
+features = ['default', 'graphmap', 'ordermap', 'stable_graph']
+optional-deps = ['ordermap']
+
+[[target-package]]
+name = 'pin-project'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'proc-macro2'
+version = '1.0.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'proc-macro']
+
+[[target-package]]
+name = 'prometheus'
+version = '0.7.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'proptest'
+version = '0.9.4'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[target-package]]
+name = 'prost'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
+
+[[target-package]]
+name = 'quote'
+version = '1.0.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'proc-macro']
+
+[[target-package]]
+name = 'radix_trie'
+version = '0.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rand_core'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rayon'
+version = '1.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'direct'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[target-package]]
+name = 'rental'
+version = '0.5.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'reqwest'
+version = '0.9.22'
+crates-io = true
+status = 'direct'
+features = ['hyper-rustls', 'rustls', 'rustls-tls', 'tls', 'tokio-rustls', 'webpki-roots']
+optional-deps = ['hyper-rustls', 'rustls', 'tokio-rustls', 'webpki-roots']
+
+[[target-package]]
+name = 'retry'
+version = '0.5.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ripemd160'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'rmp-serde'
+version = '0.13.7'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rocksdb'
+version = '0.3.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'rusoto_core'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['hyper-rustls', 'rustls']
+optional-deps = ['hyper-rustls']
+
+[[target-package]]
+name = 'rusoto_ec2'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['rustls']
+
+[[target-package]]
+name = 'rusoto_ecr'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['rustls']
+
+[[target-package]]
+name = 'rusoto_ecs'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['rustls']
+
+[[target-package]]
+name = 'rusoto_kinesis'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['rustls']
+
+[[target-package]]
+name = 'rusoto_logs'
+version = '0.41.0'
+crates-io = true
+status = 'direct'
+features = ['rustls']
+
+[[target-package]]
+name = 'rust-crypto'
+version = '0.2.36'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rust_decimal'
+version = '1.0.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'rustyline'
+version = '5.0.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'dirs', 'with-dirs']
+optional-deps = ['dirs']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.101'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'serde_json'
+version = '1.0.40'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'sha-1'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'sha2'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'signal-hook'
+version = '0.1.10'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'siphasher'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'slog'
+version = '2.5.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'max_level_debug', 'max_level_trace', 'release_max_level_debug', 'std']
+
+[[target-package]]
+name = 'slog-async'
+version = '2.3.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'slog-envlogger'
+version = '2.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'regex']
+optional-deps = ['regex']
+
+[[target-package]]
+name = 'slog-scope'
+version = '4.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'slog-term'
+version = '2.4.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'snow'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
+optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
+
+[[target-package]]
+name = 'statistical'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'stats_alloc'
+version = '0.1.8'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'structopt'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'strum'
+version = '0.15.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'syn'
+version = '1.0.5'
+crates-io = true
+status = 'direct'
+features = ['clone-impls', 'default', 'derive', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'termcolor'
+version = '1.0.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'termion'
+version = '1.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'thread-id'
+version = '3.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'threadpool'
+version = '1.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'keccak']
+
+[[target-package]]
+name = 'tokio'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
+optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
+
+[[target-package]]
+name = 'tokio-retry'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tokio-sync'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['async-traits', 'futures-sink-preview']
+optional-deps = ['futures-sink-preview']
+
+[[target-package]]
+name = 'toml'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'ttl_cache'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'typed-arena'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'walkdir'
+version = '2.2.9'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[target-package]]
+name = 'yamux'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'adler32'
+version = '1.0.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'aho-corasick'
+version = '0.7.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'arrayref'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'arrayvec'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atty'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'backtrace-sys'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'base64'
+version = '0.10.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'blake2'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'blake2-rfc'
+version = '0.2.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'blake2b_simd'
+version = '0.5.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'block-padding'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bs58'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'bstr'
+version = '0.2.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
+optional-deps = ['lazy_static', 'regex-automata', 'serde']
+
+[[target-package]]
+name = 'byte-tools'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bzip2-sys'
+version = '0.1.7'
+source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'c2-chacha'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['lazy_static', 'simd', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'c_linked_list'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cast'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'chacha20-poly1305-aead'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '2.33.0'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+
+[[target-package]]
+name = 'clear_on_drop'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cloudabi'
+version = '0.0.3'
+crates-io = true
+status = 'transitive'
+features = ['bitflags', 'default']
+optional-deps = ['bitflags']
+
+[[target-package]]
+name = 'constant_time_eq'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cookie'
+version = '0.12.0'
+crates-io = true
+status = 'transitive'
+features = ['percent-encode', 'url']
+optional-deps = ['url']
+
+[[target-package]]
+name = 'cookie_store'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crc'
+version = '1.8.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'crc32fast'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'criterion-plot'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-channel'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-deque'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-epoch'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crossbeam-queue'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-utils'
+version = '0.6.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[target-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'csv-core'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc']
+
+[[target-package]]
+name = 'ct-logs'
+version = '0.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'data-encoding'
+version = '2.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dirs'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dirs'
+version = '2.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dirs-sys'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'dtoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'either'
+version = '1.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'encoding_rs'
+version = '0.8.19'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno-dragonfly'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'error-chain'
+version = '0.12.1'
+crates-io = true
+status = 'transitive'
+features = ['backtrace', 'default', 'example_generated']
+optional-deps = ['backtrace']
+
+[[target-package]]
+name = 'fake-simd'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fixedbitset'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fuchsia-cprng'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fuchsia-zircon'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fuchsia-zircon-sys'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-channel-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink-preview', 'sink', 'std']
+optional-deps = ['futures-sink-preview']
+
+[[target-package]]
+name = 'futures-core-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-cpupool'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[target-package]]
+name = 'futures-executor-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['num_cpus', 'std']
+optional-deps = ['num_cpus']
+
+[[target-package]]
+name = 'futures-io-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-sink-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-util-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'channel', 'compat', 'default', 'futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'io', 'io-compat', 'join-macro', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'select-macro', 'sink', 'slab', 'std', 'tokio-io']
+optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
+
+[[target-package]]
+name = 'generic-array'
+version = '0.12.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'get_if_addrs-sys'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'grpcio-sys'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'h2'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http'
+version = '0.1.18'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http-body'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'humantime'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hyper-rustls'
+version = '0.17.1'
+crates-io = true
+status = 'transitive'
+features = ['ct-logs', 'default', 'tokio-runtime', 'webpki-roots']
+optional-deps = ['ct-logs', 'webpki-roots']
+
+[[target-package]]
+name = 'idna'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'indexmap'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'iovec'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'jemalloc-sys'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = ['background_threads_runtime_support', 'profiling', 'unprefixed_malloc_on_supported_platforms']
+
+[[target-package]]
+name = 'js-sys'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'keccak'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'kernel32-sys'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.62'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'librocksdb_sys'
+version = '0.1.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'libtitan_sys'
+version = '0.0.1'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'libz-sys'
+version = '1.0.25'
+crates-io = true
+status = 'transitive'
+features = ['static']
+
+[[target-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lock_api'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = ['owning_ref']
+optional-deps = ['owning_ref']
+
+[[target-package]]
+name = 'lock_api'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lz4-sys'
+version = '1.8.0'
+source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mach_o_sys'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'md5'
+version = '0.6.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'use_std']
+optional-deps = ['libc']
+
+[[target-package]]
+name = 'memoffset'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memsec'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom', 'libc', 'mach_o_sys', 'winapi']
+
+[[target-package]]
+name = 'mime'
+version = '0.3.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mime_guess'
+version = '2.0.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'rev-mappings']
+
+[[target-package]]
+name = 'miniz_oxide'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mio'
+version = '0.6.19'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[target-package]]
+name = 'mio-named-pipes'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mio-uds'
+version = '0.6.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'miow'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'miow'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[target-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nix'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nodrop'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nohash-hasher'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-bigint'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num-complex'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num-integer'
+version = '0.1.41'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num-iter'
+version = '0.1.39'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num-rational'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['bigint', 'num-bigint', 'std']
+optional-deps = ['num-bigint']
+
+[[target-package]]
+name = 'numtoa'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'once_cell'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'parking_lot']
+optional-deps = ['parking_lot']
+
+[[target-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ordermap'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'owning_ref'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'owning_ref'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parity-multihash'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parking_lot'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+optional-deps = ['owning_ref']
+
+[[target-package]]
+name = 'parking_lot'
+version = '0.6.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[target-package]]
+name = 'parking_lot'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[target-package]]
+name = 'parking_lot'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'parking_lot_core'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parking_lot_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parking_lot_core'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parking_lot_core'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'simd', 'std']
+
+[[target-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'protobuf'
+version = '2.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'publicsuffix'
+version = '1.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'quick-error'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.3.23'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
+optional-deps = ['libc']
+
+[[target-package]]
+name = 'rand'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
+optional-deps = ['cloudabi', 'fuchsia-cprng', 'libc', 'winapi']
+
+[[target-package]]
+name = 'rand'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
+optional-deps = ['getrandom_package']
+
+[[target-package]]
+name = 'rand04'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'simd', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_os'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xoshiro'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rayon-core'
+version = '1.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rdrand'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.1.56'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_termios'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_users'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.12'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ring'
+version = '0.16.9'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'rmp'
+version = '0.8.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusoto_credential'
+version = '0.41.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rust-argon2'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustc-demangle'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustc-serialize'
+version = '0.3.24'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustls'
+version = '0.16.0'
+crates-io = true
+status = 'transitive'
+features = ['dangerous_configuration', 'default', 'log', 'logging']
+optional-deps = ['log']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sct'
+version = '0.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde_urlencoded'
+version = '0.5.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'shlex'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slog-stdlog'
+version = '4.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '0.6.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'snappy-sys'
+version = '0.1.0'
+source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'socket2'
+version = '0.3.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'string'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'default']
+optional-deps = ['bytes']
+
+[[target-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'subtle'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'subtle'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'take_mut'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'term'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tinytemplate'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'codec', 'default', 'fs', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp', 'tokio-uds', 'udp', 'uds']
+optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp', 'tokio-uds']
+
+[[target-package]]
+name = 'tokio-buf'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'either', 'util']
+optional-deps = ['either']
+
+[[target-package]]
+name = 'tokio-codec'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-codec'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-current-thread'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-executor'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-executor'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync', 'tracing']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync', 'tracing']
+
+[[target-package]]
+name = 'tokio-fs'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-fs'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-io'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-io'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['memchr', 'pin-project', 'util']
+optional-deps = ['memchr', 'pin-project']
+
+[[target-package]]
+name = 'tokio-net'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'tracing', 'udp', 'uds']
+optional-deps = ['bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tracing']
+
+[[target-package]]
+name = 'tokio-process'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-reactor'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-rustls'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-signal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-sync'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-tcp'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-threadpool'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-timer'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-timer'
+version = '0.3.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['async-traits']
+
+[[target-package]]
+name = 'tokio-udp'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-uds'
+version = '0.2.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = ['default', 'log', 'std']
+optional-deps = ['log']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'try-lock'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'try_from'
+version = '0.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'typenum'
+version = '1.11.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicase'
+version = '2.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-normalization'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-segmentation'
+version = '1.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-width'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-xid'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unsigned-varint'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'untrusted'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'url'
+version = '1.7.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'url'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'rand', 'std', 'v4']
+optional-deps = ['rand']
+
+[[target-package]]
+name = 'vec_map'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'want'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wasi'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'wasm-bindgen'
+version = '0.2.51'
+crates-io = true
+status = 'transitive'
+features = ['default', 'spans', 'std']
+
+[[target-package]]
+name = 'web-sys'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['Crypto', 'Window']
+
+[[target-package]]
+name = 'webpki'
+version = '0.21.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'trust_anchor_util']
+
+[[target-package]]
+name = 'webpki-roots'
+version = '0.17.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi'
+version = '0.2.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'impl-debug', 'impl-default', 'ioapiset', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winreg', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wincolor'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winreg'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ws2_32-sys'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'xml-rs'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'zstd-sys'
+version = '1.4.13+zstd.1.4.3'
+source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
+status = 'transitive'
+features = ['default', 'legacy']
 
 [[host-package]]
 name = 'libra-crypto-derive'
@@ -312,518 +3293,12 @@ status = 'initial'
 features = []
 
 [[host-package]]
-name = 'libra-fuzzer'
-version = '0.1.0'
-workspace-path = 'testsuite/libra-fuzzer'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-logger'
-version = '0.1.0'
-workspace-path = 'common/logger'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-mempool'
-version = '0.1.0'
-workspace-path = 'mempool'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'libra-mempool-shared-proto'
-version = '0.1.0'
-workspace-path = 'mempool/mempool-shared-proto'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-metrics'
-version = '0.1.0'
-workspace-path = 'common/metrics'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-nibble'
-version = '0.1.0'
-workspace-path = 'common/nibble'
-status = 'initial'
-features = ['default', 'fuzzing', 'proptest']
-optional-deps = ['proptest']
-
-[[host-package]]
-name = 'libra-node'
-version = '0.1.0'
-workspace-path = 'libra-node'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'libra-proptest-helpers'
-version = '0.1.0'
-workspace-path = 'common/proptest-helpers'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-prost-ext'
-version = '0.1.0'
-workspace-path = 'common/prost-ext'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-state-view'
-version = '0.1.0'
-workspace-path = 'storage/state-view'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'libra-swarm'
-version = '0.1.0'
-workspace-path = 'libra-swarm'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-tools'
-version = '0.1.0'
-workspace-path = 'common/tools'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'libra-types'
-version = '0.1.0'
-workspace-path = 'types'
-status = 'initial'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[host-package]]
-name = 'libra-wallet'
-version = '0.1.0'
-workspace-path = 'client/libra_wallet'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'libradb'
-version = '0.1.0'
-workspace-path = 'storage/libradb'
-status = 'initial'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[host-package]]
-name = 'memsocket'
-version = '0.1.0'
-workspace-path = 'network/memsocket'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'netcore'
-version = '0.1.0'
-workspace-path = 'network/netcore'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'network'
-version = '0.1.0'
-workspace-path = 'network'
-status = 'initial'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
-optional-deps = ['libra-proptest-helpers', 'proptest']
-
-[[host-package]]
-name = 'noise'
-version = '0.1.0'
-workspace-path = 'network/noise'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'safety-rules'
-version = '0.1.0'
-workspace-path = 'consensus/safety-rules'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'schemadb'
-version = '0.1.0'
-workspace-path = 'storage/schemadb'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'scratchpad'
-version = '0.1.0'
-workspace-path = 'storage/scratchpad'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'secret-service'
-version = '0.1.0'
-workspace-path = 'crypto/secret-service'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'serializer_tests'
-version = '0.1.0'
-workspace-path = 'language/vm/serializer_tests'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'socket-bench-server'
-version = '0.1.0'
-workspace-path = 'network/socket-bench-server'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'stackless-bytecode-generator'
-version = '0.1.0'
-workspace-path = 'language/stackless-bytecode/generator'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'state-synchronizer'
-version = '0.1.0'
-workspace-path = 'state-synchronizer'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'stdlib'
-version = '0.1.0'
-workspace-path = 'language/stdlib'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'storage-client'
-version = '0.1.0'
-workspace-path = 'storage/storage-client'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'storage-proto'
-version = '0.1.0'
-workspace-path = 'storage/storage-proto'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'storage-service'
-version = '0.1.0'
-workspace-path = 'storage/storage-service'
-status = 'initial'
-features = ['default', 'fuzzing', 'proptest']
-optional-deps = ['proptest']
-
-[[host-package]]
-name = 'test-generation'
-version = '0.1.0'
-workspace-path = 'language/tools/test-generation'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'testsuite'
-version = '0.1.0'
-workspace-path = 'testsuite'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'transaction-builder'
-version = '0.1.0'
-workspace-path = 'language/transaction-builder'
-status = 'initial'
-features = ['default', 'fuzzing']
-
-[[host-package]]
-name = 'tree_heap'
-version = '0.1.0'
-workspace-path = 'language/stackless-bytecode/tree_heap'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'vm'
-version = '0.1.0'
-workspace-path = 'language/vm'
-status = 'initial'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[host-package]]
-name = 'vm-cache-map'
-version = '0.1.0'
-workspace-path = 'language/vm/vm-runtime/vm-cache-map'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'vm-genesis'
-version = '0.1.0'
-workspace-path = 'language/vm/vm-genesis'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'vm-runtime'
-version = '0.1.0'
-workspace-path = 'language/vm/vm-runtime'
-status = 'initial'
-features = ['default', 'instruction_synthesis']
-
-[[host-package]]
-name = 'vm-runtime-types'
-version = '0.1.0'
-workspace-path = 'language/vm/vm-runtime/vm-runtime-types'
-status = 'initial'
-features = ['default', 'fuzzing', 'proptest']
-optional-deps = ['proptest']
-
-[[host-package]]
-name = 'vm-validator'
-version = '0.1.0'
-workspace-path = 'vm-validator'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'x'
-version = '0.1.0'
-workspace-path = 'x'
-status = 'initial'
-features = []
-
-[[host-package]]
-name = 'anyhow'
-version = '1.0.17'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'arc-swap'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'backoff'
-version = '0.1.5'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'backtrace'
-version = '0.3.37'
-crates-io = true
-status = 'direct'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
-optional-deps = ['backtrace-sys', 'serde']
-
-[[host-package]]
-name = 'bech32'
-version = '0.6.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'bincode'
-version = '1.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'i128', 'std']
-
-[[host-package]]
-name = 'bytes'
-version = '0.4.12'
-crates-io = true
-status = 'direct'
-features = ['either']
-optional-deps = ['either']
-
-[[host-package]]
-name = 'chashmap'
-version = '2.2.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'chrono'
-version = '0.4.9'
-crates-io = true
-status = 'direct'
-features = ['clock', 'default', 'serde', 'time']
-optional-deps = ['serde', 'time']
-
-[[host-package]]
-name = 'codespan'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = ['serde', 'serde_derive', 'serialization']
-optional-deps = ['serde', 'serde_derive']
-
-[[host-package]]
-name = 'codespan-reporting'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'criterion'
-version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'crossbeam'
-version = '0.7.2'
-crates-io = true
-status = 'direct'
-features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
-
-[[host-package]]
-name = 'csv'
-version = '1.1.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'ctrlc'
-version = '3.1.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
-status = 'direct'
-features = ['alloc', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'digest'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[host-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
-status = 'direct'
-features = ['serde', 'std', 'u64_backend']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'env_logger'
-version = '0.6.2'
-crates-io = true
-status = 'direct'
-features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
-optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
-
-[[host-package]]
 name = 'failure'
 version = '0.1.5'
 crates-io = true
 status = 'direct'
 features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
 optional-deps = ['backtrace', 'failure_derive']
-
-[[host-package]]
-name = 'filecheck'
-version = '0.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'flate2'
-version = '1.0.11'
-crates-io = true
-status = 'direct'
-features = ['miniz_oxide', 'rust_backend']
-optional-deps = ['miniz_oxide']
-
-[[host-package]]
-name = 'futures'
-version = '0.1.29'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std', 'with-deprecated']
-
-[[host-package]]
-name = 'futures-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'async-await', 'compat', 'default', 'io-compat', 'std']
-
-[[host-package]]
-name = 'get_if_addrs'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'grpcio'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'prost', 'prost-codec', 'protobuf', 'protobuf-codec']
-optional-deps = ['bytes', 'prost', 'protobuf']
 
 [[host-package]]
 name = 'grpcio-compiler'
@@ -834,131 +3309,8 @@ features = ['prost', 'prost-build', 'prost-codec', 'prost-types']
 optional-deps = ['prost', 'prost-build', 'prost-types']
 
 [[host-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hyper'
-version = '0.12.34'
-crates-io = true
-status = 'direct'
-features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-
-[[host-package]]
-name = 'itertools'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
-
-[[host-package]]
-name = 'jemallocator'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = ['background_threads_runtime_support', 'default', 'profiling', 'unprefixed_malloc_on_supported_platforms']
-
-[[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = ['spin', 'spin_no_std']
-optional-deps = ['spin']
-
-[[host-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[host-package]]
-name = 'lru-cache'
-version = '0.1.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'mirai-annotations'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'num'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'num-bigint', 'std']
-optional-deps = ['num-bigint']
-
-[[host-package]]
 name = 'num-derive'
 version = '0.2.5'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.8'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'num_cpus'
-version = '1.10.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'num_enum'
-version = '0.4.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[host-package]]
-name = 'parity-multiaddr'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'petgraph'
-version = '0.4.13'
-crates-io = true
-status = 'direct'
-features = ['default', 'graphmap', 'ordermap', 'stable_graph']
-optional-deps = ['ordermap']
-
-[[host-package]]
-name = 'pin-project'
-version = '0.4.2'
 crates-io = true
 status = 'direct'
 features = []
@@ -971,34 +3323,11 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'prometheus'
-version = '0.7.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'proptest'
-version = '0.9.4'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[host-package]]
 name = 'proptest-derive'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
-
-[[host-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -1015,268 +3344,6 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'radix_trie'
-version = '0.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rand_core'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'std']
-
-[[host-package]]
-name = 'rayon'
-version = '1.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'direct'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[host-package]]
-name = 'rental'
-version = '0.5.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'reqwest'
-version = '0.9.22'
-crates-io = true
-status = 'direct'
-features = ['hyper-rustls', 'rustls', 'rustls-tls', 'tls', 'tokio-rustls', 'webpki-roots']
-optional-deps = ['hyper-rustls', 'rustls', 'tokio-rustls', 'webpki-roots']
-
-[[host-package]]
-name = 'retry'
-version = '0.5.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rmp-serde'
-version = '0.13.7'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rocksdb'
-version = '0.3.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'rusoto_core'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['hyper-rustls', 'rustls']
-optional-deps = ['hyper-rustls']
-
-[[host-package]]
-name = 'rusoto_ec2'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['rustls']
-
-[[host-package]]
-name = 'rusoto_ecr'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['rustls']
-
-[[host-package]]
-name = 'rusoto_ecs'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['rustls']
-
-[[host-package]]
-name = 'rusoto_kinesis'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['rustls']
-
-[[host-package]]
-name = 'rusoto_logs'
-version = '0.41.0'
-crates-io = true
-status = 'direct'
-features = ['rustls']
-
-[[host-package]]
-name = 'rust-crypto'
-version = '0.2.36'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rust_decimal'
-version = '1.0.3'
-crates-io = true
-status = 'direct'
-features = ['default', 'serde']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'rustyline'
-version = '5.0.3'
-crates-io = true
-status = 'direct'
-features = ['default', 'dirs', 'with-dirs']
-optional-deps = ['dirs']
-
-[[host-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
-name = 'serde_json'
-version = '1.0.40'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'sha-1'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'sha2'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'signal-hook'
-version = '0.1.10'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'siphasher'
-version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'slog'
-version = '2.5.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'max_level_debug', 'max_level_trace', 'release_max_level_debug', 'std']
-
-[[host-package]]
-name = 'slog-async'
-version = '2.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'slog-envlogger'
-version = '2.2.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'regex']
-optional-deps = ['regex']
-
-[[host-package]]
-name = 'slog-scope'
-version = '4.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'slog-term'
-version = '2.4.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'snow'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
-optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
-
-[[host-package]]
-name = 'structopt'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'strum'
-version = '0.15.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
 name = 'strum_macros'
 version = '0.15.0'
 crates-io = true
@@ -1288,122 +3355,8 @@ name = 'syn'
 version = '1.0.5'
 crates-io = true
 status = 'direct'
-features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
 optional-deps = ['quote']
-
-[[host-package]]
-name = 'termcolor'
-version = '1.0.5'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'termion'
-version = '1.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'thread-id'
-version = '3.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'threadpool'
-version = '1.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'keccak']
-
-[[host-package]]
-name = 'tokio'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
-optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
-
-[[host-package]]
-name = 'tokio-retry'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tokio-sync'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['async-traits', 'futures-sink-preview']
-optional-deps = ['futures-sink-preview']
-
-[[host-package]]
-name = 'toml'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'ttl_cache'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'typed-arena'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'walkdir'
-version = '2.2.9'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
-
-[[host-package]]
-name = 'yamux'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'adler32'
-version = '1.0.3'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'aho-corasick'
@@ -1413,34 +3366,6 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'arrayref'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'arrayvec'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'atty'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'autocfg'
 version = '0.1.6'
 crates-io = true
@@ -1448,15 +3373,16 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'backtrace-sys'
-version = '0.1.31'
+name = 'backtrace'
+version = '0.3.37'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'std']
+optional-deps = ['backtrace-sys']
 
 [[host-package]]
-name = 'base64'
-version = '0.10.1'
+name = 'backtrace-sys'
+version = '0.1.31'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1469,68 +3395,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'bit-set'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
 name = 'bitflags'
 version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'blake2'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'blake2-rfc'
-version = '0.2.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'block-buffer'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'block-padding'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bs58'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'bstr'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
 
 [[host-package]]
 name = 'build_const'
@@ -1540,16 +3409,23 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'byte-tools'
-version = '0.3.1'
+name = 'bumpalo'
+version = '2.6.0'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['collections', 'default', 'std']
 
 [[host-package]]
-name = 'bzip2-sys'
-version = '0.1.7'
-source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
+name = 'byteorder'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'i128', 'std']
+
+[[host-package]]
+name = 'bytes'
+version = '0.4.12'
+crates-io = true
 status = 'transitive'
 features = []
 
@@ -1560,20 +3436,6 @@ crates-io = true
 status = 'transitive'
 features = ['lazy_static', 'simd', 'std']
 optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'cast'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'cc'
@@ -1598,27 +3460,12 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'chacha20-poly1305-aead'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'clang-sys'
 version = '0.28.1'
 crates-io = true
 status = 'transitive'
 features = ['clang_6_0', 'gte_clang_3_6', 'gte_clang_3_7', 'gte_clang_3_8', 'gte_clang_3_9', 'gte_clang_4_0', 'gte_clang_5_0', 'gte_clang_6_0', 'libloading', 'runtime']
 optional-deps = ['libloading']
-
-[[host-package]]
-name = 'clap'
-version = '2.33.0'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
 
 [[host-package]]
 name = 'clear_on_drop'
@@ -1630,128 +3477,6 @@ features = []
 [[host-package]]
 name = 'cmake'
 version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'constant_time_eq'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'cookie'
-version = '0.12.0'
-crates-io = true
-status = 'transitive'
-features = ['percent-encode', 'url']
-optional-deps = ['url']
-
-[[host-package]]
-name = 'cookie_store'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crc'
-version = '1.8.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'crc32fast'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'criterion-plot'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-channel'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-deque'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-epoch'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crossbeam-queue'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-utils'
-version = '0.6.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[host-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'csv-core'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc']
-
-[[host-package]]
-name = 'ct-logs'
-version = '0.6.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'data-encoding'
-version = '2.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1771,29 +3496,8 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'dirs'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'dirs'
-version = '2.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'dirs-sys'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'dtoa'
-version = '0.4.4'
+name = 'digest'
+version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1803,47 +3507,11 @@ name = 'either'
 version = '1.5.2'
 crates-io = true
 status = 'transitive'
-features = ['default', 'use_std']
-
-[[host-package]]
-name = 'encoding_rs'
-version = '0.8.19'
-crates-io = true
-status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'endian-type'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'error-chain'
-version = '0.12.1'
-crates-io = true
-status = 'transitive'
-features = ['backtrace', 'default', 'example_generated']
-optional-deps = ['backtrace']
 
 [[host-package]]
 name = 'failure_derive'
 version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fake-simd'
-version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1856,13 +3524,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'fs_extra'
 version = '1.1.0'
 crates-io = true
@@ -1870,48 +3531,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'futures-channel-preview'
+name = 'futures-join-macro-preview'
 version = '0.3.0-alpha.19'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'futures-sink-preview', 'sink']
-optional-deps = ['futures-sink-preview']
+features = []
 
 [[host-package]]
-name = 'futures-core-preview'
+name = 'futures-select-macro-preview'
 version = '0.3.0-alpha.19'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-cpupool'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[host-package]]
-name = 'futures-executor-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['num_cpus', 'std']
-optional-deps = ['num_cpus']
-
-[[host-package]]
-name = 'futures-io-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'futures-sink-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
+features = []
 
 [[host-package]]
 name = 'gcc'
@@ -1942,86 +3573,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'grpcio-sys'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'h2'
-version = '0.1.26'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'heck'
 version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http'
-version = '0.1.18'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http-body'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'humantime'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hyper-rustls'
-version = '0.17.1'
-crates-io = true
-status = 'transitive'
-features = ['ct-logs', 'default', 'tokio-runtime', 'webpki-roots']
-optional-deps = ['ct-logs', 'webpki-roots']
-
-[[host-package]]
-name = 'idna'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'idna'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'indexmap'
-version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2034,18 +3587,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'itoa'
-version = '0.4.4'
+name = 'itertools'
+version = '0.8.0'
 crates-io = true
 status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'jemalloc-sys'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = ['background_threads_runtime_support', 'profiling', 'unprefixed_malloc_on_supported_platforms']
+features = ['default', 'use_std']
 
 [[host-package]]
 name = 'jobserver'
@@ -2055,8 +3601,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'keccak'
-version = '0.1.0'
+name = 'lazy_static'
+version = '1.4.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2076,65 +3622,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'librocksdb_sys'
-version = '0.1.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'libtitan_sys'
-version = '0.0.1'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'libz-sys'
-version = '1.0.25'
-crates-io = true
-status = 'transitive'
-features = ['static']
-
-[[host-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lock_api'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['owning_ref']
-optional-deps = ['owning_ref']
-
-[[host-package]]
-name = 'lock_api'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lz4-sys'
-version = '1.8.0'
-source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'md5'
-version = '0.6.1'
+name = 'log'
+version = '0.4.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2144,83 +3633,11 @@ name = 'memchr'
 version = '2.2.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'libc', 'use_std']
-optional-deps = ['libc']
-
-[[host-package]]
-name = 'memoffset'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memsec'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom']
-
-[[host-package]]
-name = 'mime'
-version = '0.3.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'mime_guess'
-version = '2.0.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'rev-mappings']
-
-[[host-package]]
-name = 'miniz_oxide'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'mio'
-version = '0.6.19'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
+features = ['default', 'use_std']
 
 [[host-package]]
 name = 'multimap'
 version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[host-package]]
-name = 'nibble_vec'
-version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'nodrop'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'nohash-hasher'
-version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2233,40 +3650,11 @@ status = 'transitive'
 features = ['alloc', 'default', 'std', 'verbose-errors']
 
 [[host-package]]
-name = 'num-bigint'
-version = '0.2.3'
+name = 'num_cpus'
+version = '1.10.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num-complex'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num-integer'
-version = '0.1.41'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num-iter'
-version = '0.1.39'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num-rational'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['bigint', 'num-bigint', 'std']
-optional-deps = ['num-bigint']
+features = []
 
 [[host-package]]
 name = 'num_enum_derive'
@@ -2276,105 +3664,6 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
-name = 'numtoa'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ordermap'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'owning_ref'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'owning_ref'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parity-multihash'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parking_lot'
-version = '0.4.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-optional-deps = ['owning_ref']
-
-[[host-package]]
-name = 'parking_lot'
-version = '0.6.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[host-package]]
-name = 'parking_lot'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[host-package]]
-name = 'parking_lot'
-version = '0.9.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'parking_lot_core'
-version = '0.2.14'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parking_lot_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parking_lot_core'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parking_lot_core'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'peeking_take_while'
 version = '0.1.2'
 crates-io = true
@@ -2382,8 +3671,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'percent-encoding'
-version = '2.1.0'
+name = 'petgraph'
+version = '0.4.13'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2452,6 +3741,14 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'prost'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
+
+[[host-package]]
 name = 'prost-derive'
 version = '0.5.0'
 crates-io = true
@@ -2473,27 +3770,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'publicsuffix'
-version = '1.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'quick-error'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'quick-error'
-version = '1.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -2502,46 +3778,11 @@ features = ['default', 'proc-macro']
 
 [[host-package]]
 name = 'rand'
-version = '0.3.23'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-
-[[host-package]]
-name = 'rand'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
-
-[[host-package]]
-name = 'rand'
 version = '0.7.0'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
 optional-deps = ['getrandom_package']
-
-[[host-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'rand_chacha'
@@ -2555,6 +3796,13 @@ name = 'rand_core'
 version = '0.3.1'
 crates-io = true
 status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'rand_core'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
 features = ['alloc', 'std']
 
 [[host-package]]
@@ -2566,81 +3814,19 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'rand_hc'
-version = '0.1.0'
+name = 'regex'
+version = '1.3.1'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_os'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xoshiro'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rayon-core'
-version = '1.6.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'regex-automata'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
 
 [[host-package]]
 name = 'regex-syntax'
 version = '0.6.12'
 crates-io = true
 status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[host-package]]
 name = 'remove_dir_all'
@@ -2652,27 +3838,6 @@ features = []
 [[host-package]]
 name = 'rental-impl'
 version = '0.5.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ring'
-version = '0.16.9'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
-
-[[host-package]]
-name = 'rmp'
-version = '0.8.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rusoto_credential'
-version = '0.41.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2692,13 +3857,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'rustc-serialize'
-version = '0.3.24'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'rustc_version'
 version = '0.2.3'
 crates-io = true
@@ -2706,44 +3864,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'rustls'
-version = '0.16.0'
-crates-io = true
-status = 'transitive'
-features = ['dangerous_configuration', 'default', 'log', 'logging']
-optional-deps = ['log']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'same-file'
 version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'scopeguard'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'scopeguard'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'sct'
-version = '0.6.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2763,18 +3885,18 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'serde'
+version = '1.0.101'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'serde_derive'
 version = '1.0.99'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'serde_urlencoded'
-version = '0.5.5'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'shlex'
@@ -2784,65 +3906,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'signal-hook-registry'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'slog-stdlog'
-version = '4.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'smallvec'
-version = '0.6.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'snappy-sys'
-version = '0.1.0'
-source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'spin'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'stable_deref_trait'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'string'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'default']
-optional-deps = ['bytes']
-
-[[host-package]]
-name = 'strsim'
-version = '0.8.0'
+name = 'sourcefile'
+version = '0.1.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2856,17 +3921,10 @@ features = []
 
 [[host-package]]
 name = 'subtle'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'subtle'
 version = '2.1.1'
 crates-io = true
 status = 'transitive'
-features = ['default', 'i128', 'std']
+features = ['std']
 
 [[host-package]]
 name = 'syn'
@@ -2884,29 +3942,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'take_mut'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'tempfile'
 version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'term'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'textwrap'
-version = '0.11.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2919,101 +3956,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tinytemplate'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio'
-version = '0.1.22'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'codec', 'default', 'fs', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp', 'tokio-uds', 'udp', 'uds']
-optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp']
-
-[[host-package]]
-name = 'tokio-buf'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'either', 'util']
-optional-deps = ['either']
-
-[[host-package]]
-name = 'tokio-codec'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-codec'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-current-thread'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-executor'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-executor'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync']
-
-[[host-package]]
-name = 'tokio-fs'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-fs'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-io'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-io'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['memchr', 'pin-project', 'util']
-optional-deps = ['memchr', 'pin-project']
-
-[[host-package]]
 name = 'tokio-macros'
 version = '0.2.0-alpha.6'
 crates-io = true
@@ -3021,93 +3963,15 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'tokio-net'
-version = '0.2.0-alpha.6'
+name = 'toml'
+version = '0.5.3'
 crates-io = true
 status = 'transitive'
-features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'udp', 'uds']
-optional-deps = ['bytes', 'futures-sink-preview', 'iovec']
+features = ['default']
 
 [[host-package]]
-name = 'tokio-process'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-reactor'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-rustls'
-version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-sync'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-tcp'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-threadpool'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-timer'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tokio-timer'
-version = '0.3.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['async-traits']
-
-[[host-package]]
-name = 'tokio-udp'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tracing-core'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'try-lock'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'try_from'
-version = '0.3.2'
+name = 'tracing-attributes'
+version = '0.1.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3127,32 +3991,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'unicode-normalization'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'unicode-segmentation'
 version = '1.3.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'unicode-width'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -3169,49 +4012,6 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'unsigned-varint'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'untrusted'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'url'
-version = '1.7.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'url'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'uuid'
-version = '0.7.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'rand', 'std', 'v4']
-optional-deps = ['rand']
-
-[[host-package]]
-name = 'vec_map'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'version_check'
 version = '0.1.5'
 crates-io = true
@@ -3219,29 +4019,50 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
+name = 'walkdir'
+version = '2.2.9'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'want'
-version = '0.2.0'
+name = 'wasm-bindgen-backend'
+version = '0.2.51'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-macro'
+version = '0.2.51'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-macro-support'
+version = '0.2.51'
+crates-io = true
+status = 'transitive'
+features = ['spans']
+
+[[host-package]]
+name = 'wasm-bindgen-shared'
+version = '0.2.51'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'webpki'
-version = '0.21.0'
+name = 'wasm-bindgen-webidl'
+version = '0.2.51'
 crates-io = true
 status = 'transitive'
-features = ['default', 'std', 'trust_anchor_util']
+features = []
 
 [[host-package]]
-name = 'webpki-roots'
-version = '0.17.0'
+name = 'weedle'
+version = '0.10.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3254,22 +4075,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'xml-rs'
-version = '0.8.0'
+name = 'winapi-build'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'zstd-sys'
-version = '1.4.13+zstd.1.4.3'
-source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
-status = 'transitive'
-features = ['default', 'legacy']

--- a/fixtures/large/summaries/metadata_libra-5.toml
+++ b/fixtures/large/summaries/metadata_libra-5.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 triple = 'aarch64-unknown-openbsd'
@@ -14,28 +14,28 @@ flags = ['flag-test']
 [metadata.target-platform]
 spec = 'any'
 
-[[target-package]]
+[[host-package]]
 name = 'channel'
 version = '0.1.0'
 workspace-path = 'common/channel'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'debug-interface'
 version = '0.1.0'
 workspace-path = 'common/debug-interface'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-fuzzer'
 version = '0.1.0'
 workspace-path = 'testsuite/libra-fuzzer'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'network'
 version = '0.1.0'
 workspace-path = 'network'
@@ -43,7 +43,7 @@ status = 'initial'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
 optional-deps = ['libra-proptest-helpers', 'proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'storage-service'
 version = '0.1.0'
 workspace-path = 'storage/storage-service'
@@ -51,28 +51,28 @@ status = 'initial'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'vm-genesis'
 version = '0.1.0'
 workspace-path = 'language/vm/vm-genesis'
 status = 'initial'
 features = ['default', 'fuzzing']
 
-[[target-package]]
+[[host-package]]
 name = 'accumulator'
 version = '0.1.0'
 workspace-path = 'storage/accumulator'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'admission-control-proto'
 version = '0.1.0'
 workspace-path = 'admission_control/admission-control-proto'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'admission-control-service'
 version = '0.1.0'
 workspace-path = 'admission_control/admission-control-service'
@@ -80,35 +80,35 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest']
 optional-deps = ['libra-proptest-helpers', 'proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'bounded-executor'
 version = '0.1.0'
 workspace-path = 'common/bounded-executor'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'bytecode-source-map'
 version = '0.1.0'
 workspace-path = 'language/compiler/bytecode-source-map'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'bytecode-verifier'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'config-builder'
 version = '0.1.0'
 workspace-path = 'config/config-builder'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'consensus'
 version = '0.1.0'
 workspace-path = 'consensus'
@@ -116,7 +116,7 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'consensus-types'
 version = '0.1.0'
 workspace-path = 'consensus/consensus-types'
@@ -124,63 +124,63 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'crash-handler'
 version = '0.1.0'
 workspace-path = 'common/crash-handler'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'executable-helpers'
 version = '0.1.0'
 workspace-path = 'common/executable-helpers'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'executor'
 version = '0.1.0'
 workspace-path = 'executor'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'futures-semaphore'
 version = '0.1.0'
 workspace-path = 'common/futures-semaphore'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'generate-keypair'
 version = '0.1.0'
 workspace-path = 'config/generate-keypair'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'grpc-helpers'
 version = '0.1.0'
 workspace-path = 'common/grpc-helpers'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'ir-to-bytecode'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'ir-to-bytecode-syntax'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'jellyfish-merkle'
 version = '0.1.0'
 workspace-path = 'storage/jellyfish-merkle'
@@ -188,21 +188,21 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest', 'proptest-derive']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
@@ -210,49 +210,56 @@ status = 'workspace'
 features = ['cloneable-private-keys', 'default', 'fuzzing', 'proptest', 'proptest-derive', 'std', 'u64_backend']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
+name = 'libra-crypto-derive'
+version = '0.1.0'
+workspace-path = 'crypto/crypto-derive'
+status = 'workspace'
+features = []
+
+[[host-package]]
 name = 'libra-failure-ext'
 version = '0.1.0'
 workspace-path = 'common/failure-ext'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-failure-macros'
 version = '0.1.0'
 workspace-path = 'common/failure-ext/failure-macros'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-logger'
 version = '0.1.0'
 workspace-path = 'common/logger'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-mempool'
 version = '0.1.0'
 workspace-path = 'mempool'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-mempool-shared-proto'
 version = '0.1.0'
 workspace-path = 'mempool/mempool-shared-proto'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-metrics'
 version = '0.1.0'
 workspace-path = 'common/metrics'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-nibble'
 version = '0.1.0'
 workspace-path = 'common/nibble'
@@ -260,35 +267,35 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-proptest-helpers'
 version = '0.1.0'
 workspace-path = 'common/proptest-helpers'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-prost-ext'
 version = '0.1.0'
 workspace-path = 'common/prost-ext'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-state-view'
 version = '0.1.0'
 workspace-path = 'storage/state-view'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'libra-tools'
 version = '0.1.0'
 workspace-path = 'common/tools'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'libra-types'
 version = '0.1.0'
 workspace-path = 'types'
@@ -296,7 +303,7 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
 optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'libradb'
 version = '0.1.0'
 workspace-path = 'storage/libradb'
@@ -304,84 +311,84 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
 optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'memsocket'
 version = '0.1.0'
 workspace-path = 'network/memsocket'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'netcore'
 version = '0.1.0'
 workspace-path = 'network/netcore'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'noise'
 version = '0.1.0'
 workspace-path = 'network/noise'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'safety-rules'
 version = '0.1.0'
 workspace-path = 'consensus/safety-rules'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'schemadb'
 version = '0.1.0'
 workspace-path = 'storage/schemadb'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'scratchpad'
 version = '0.1.0'
 workspace-path = 'storage/scratchpad'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'state-synchronizer'
 version = '0.1.0'
 workspace-path = 'state-synchronizer'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'stdlib'
 version = '0.1.0'
 workspace-path = 'language/stdlib'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'storage-client'
 version = '0.1.0'
 workspace-path = 'storage/storage-client'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'storage-proto'
 version = '0.1.0'
 workspace-path = 'storage/storage-proto'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'transaction-builder'
 version = '0.1.0'
 workspace-path = 'language/transaction-builder'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'vm'
 version = '0.1.0'
 workspace-path = 'language/vm'
@@ -389,21 +396,21 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
 optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
 
-[[target-package]]
+[[host-package]]
 name = 'vm-cache-map'
 version = '0.1.0'
 workspace-path = 'language/vm/vm-runtime/vm-cache-map'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'vm-runtime'
 version = '0.1.0'
 workspace-path = 'language/vm/vm-runtime'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'vm-runtime-types'
 version = '0.1.0'
 workspace-path = 'language/vm/vm-runtime/vm-runtime-types'
@@ -411,28 +418,28 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest']
 optional-deps = ['proptest']
 
-[[target-package]]
+[[host-package]]
 name = 'vm-validator'
 version = '0.1.0'
 workspace-path = 'vm-validator'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'arc-swap'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'backoff'
 version = '0.1.5'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'backtrace'
 version = '0.3.37'
 crates-io = true
@@ -440,35 +447,35 @@ status = 'direct'
 features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
 optional-deps = ['backtrace-sys', 'serde']
 
-[[target-package]]
+[[host-package]]
 name = 'bech32'
 version = '0.6.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'bincode'
 version = '1.1.4'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'bit-vec'
 version = '0.6.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'byteorder'
 version = '1.3.2'
 crates-io = true
 status = 'direct'
 features = ['default', 'i128', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'bytes'
 version = '0.4.12'
 crates-io = true
@@ -476,14 +483,14 @@ status = 'direct'
 features = ['either']
 optional-deps = ['either']
 
-[[target-package]]
+[[host-package]]
 name = 'chashmap'
 version = '2.2.2'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'chrono'
 version = '0.4.9'
 crates-io = true
@@ -491,7 +498,7 @@ status = 'direct'
 features = ['clock', 'default', 'time']
 optional-deps = ['time']
 
-[[target-package]]
+[[host-package]]
 name = 'codespan'
 version = '0.2.1'
 crates-io = true
@@ -499,14 +506,14 @@ status = 'direct'
 features = ['serde', 'serde_derive', 'serialization']
 optional-deps = ['serde', 'serde_derive']
 
-[[target-package]]
+[[host-package]]
 name = 'codespan-reporting'
 version = '0.2.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'crossbeam'
 version = '0.7.2'
 crates-io = true
@@ -514,21 +521,21 @@ status = 'direct'
 features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
 optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
 
-[[target-package]]
+[[host-package]]
 name = 'curve25519-dalek'
 version = '1.2.3'
 source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
 status = 'direct'
 features = ['alloc', 'std', 'u64_backend']
 
-[[target-package]]
+[[host-package]]
 name = 'digest'
 version = '0.8.1'
 crates-io = true
 status = 'direct'
 features = ['std']
 
-[[target-package]]
+[[host-package]]
 name = 'ed25519-dalek'
 version = '1.0.0-pre.1'
 source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
@@ -536,7 +543,7 @@ status = 'direct'
 features = ['serde', 'std', 'u64_backend']
 optional-deps = ['serde']
 
-[[target-package]]
+[[host-package]]
 name = 'failure'
 version = '0.1.5'
 crates-io = true
@@ -544,1855 +551,34 @@ status = 'direct'
 features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
 optional-deps = ['backtrace', 'failure_derive']
 
-[[target-package]]
+[[host-package]]
 name = 'futures'
 version = '0.1.29'
 crates-io = true
 status = 'direct'
 features = ['default', 'use_std', 'with-deprecated']
 
-[[target-package]]
+[[host-package]]
 name = 'futures-preview'
 version = '0.3.0-alpha.19'
 crates-io = true
 status = 'direct'
 features = ['alloc', 'async-await', 'compat', 'default', 'io-compat', 'std']
 
-[[target-package]]
+[[host-package]]
 name = 'get_if_addrs'
 version = '0.5.3'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'grpcio'
 version = '0.5.0-alpha.4'
 crates-io = true
 status = 'direct'
 features = ['bytes', 'prost', 'prost-codec', 'protobuf', 'protobuf-codec']
 optional-deps = ['bytes', 'prost', 'protobuf']
-
-[[target-package]]
-name = 'hex'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'hyper'
-version = '0.12.34'
-crates-io = true
-status = 'direct'
-features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'itertools'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = ['spin', 'spin_no_std']
-optional-deps = ['spin']
-
-[[target-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[target-package]]
-name = 'lru-cache'
-version = '0.1.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'mirai-annotations'
-version = '1.4.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.8'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'num_cpus'
-version = '1.10.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'num_enum'
-version = '0.4.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[target-package]]
-name = 'parity-multiaddr'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'petgraph'
-version = '0.4.13'
-crates-io = true
-status = 'direct'
-features = ['default', 'graphmap', 'ordermap', 'stable_graph']
-optional-deps = ['ordermap']
-
-[[target-package]]
-name = 'pin-project'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'prometheus'
-version = '0.7.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'proptest'
-version = '0.9.4'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[target-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
-
-[[target-package]]
-name = 'radix_trie'
-version = '0.1.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[target-package]]
-name = 'rayon'
-version = '1.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'direct'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'rental'
-version = '0.5.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'rmp-serde'
-version = '0.13.7'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'rocksdb'
-version = '0.3.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[target-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'serde_json'
-version = '1.0.40'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'sha-1'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'sha2'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'siphasher'
-version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'slog'
-version = '2.5.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
-
-[[target-package]]
-name = 'slog-async'
-version = '2.3.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'slog-envlogger'
-version = '2.2.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'regex']
-optional-deps = ['regex']
-
-[[target-package]]
-name = 'slog-scope'
-version = '4.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'slog-term'
-version = '2.4.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'snow'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
-optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
-
-[[target-package]]
-name = 'structopt'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'strum'
-version = '0.15.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'termion'
-version = '1.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'thread-id'
-version = '3.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'keccak']
-
-[[target-package]]
-name = 'tokio'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
-optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
-
-[[target-package]]
-name = 'tokio-retry'
-version = '0.2.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tokio-sync'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'direct'
-features = ['async-traits', 'futures-sink-preview']
-optional-deps = ['futures-sink-preview']
-
-[[target-package]]
-name = 'toml'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'ttl_cache'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'typed-arena'
-version = '1.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
-
-[[target-package]]
-name = 'yamux'
-version = '0.2.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'aho-corasick'
-version = '0.7.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arrayref'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arrayvec'
-version = '0.4.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atty'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'backtrace-sys'
-version = '0.1.31'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'base64'
-version = '0.10.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit-set'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'bitflags'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'blake2'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'blake2-rfc'
-version = '0.2.18'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'blake2b_simd'
-version = '0.5.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'block-buffer'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'block-padding'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bs58'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'byte-tools'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bzip2-sys'
-version = '0.1.7'
-source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'c2-chacha'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['lazy_static', 'simd', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cfg-if'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'chacha20-poly1305-aead'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'clap'
-version = '2.33.0'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[target-package]]
-name = 'clear_on_drop'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'cloudabi'
-version = '0.0.3'
-crates-io = true
-status = 'transitive'
-features = ['bitflags', 'default']
-optional-deps = ['bitflags']
-
-[[target-package]]
-name = 'constant_time_eq'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crc'
-version = '1.8.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'crossbeam-channel'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-deque'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-epoch'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crossbeam-queue'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'crossbeam-utils'
-version = '0.6.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[target-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std', 'u64_backend']
-
-[[target-package]]
-name = 'data-encoding'
-version = '2.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'dirs'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'either'
-version = '1.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'endian-type'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'errno-dragonfly'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fake-simd'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fixedbitset'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fuchsia-cprng'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fuchsia-zircon'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fuchsia-zircon-sys'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-channel-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'futures-sink-preview', 'sink', 'std']
-optional-deps = ['futures-sink-preview']
-
-[[target-package]]
-name = 'futures-core-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-cpupool'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'futures-executor-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['num_cpus', 'std']
-optional-deps = ['num_cpus']
-
-[[target-package]]
-name = 'futures-io-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'futures-sink-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'futures-util-preview'
-version = '0.3.0-alpha.19'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'async-await', 'channel', 'compat', 'default', 'futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'io', 'io-compat', 'join-macro', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'select-macro', 'sink', 'slab', 'std', 'tokio-io']
-optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
-
-[[target-package]]
-name = 'generic-array'
-version = '0.12.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'get_if_addrs-sys'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'getrandom'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'grpcio-sys'
-version = '0.5.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'h2'
-version = '0.1.26'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http'
-version = '0.1.18'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'http-body'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'idna'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'indexmap'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'iovec'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'itoa'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'js-sys'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'keccak'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'libc'
-version = '0.2.62'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'librocksdb_sys'
-version = '0.1.0'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'libtitan_sys'
-version = '0.0.1'
-source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'libz-sys'
-version = '1.0.25'
-crates-io = true
-status = 'transitive'
-features = ['static']
-
-[[target-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lock_api'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = ['owning_ref']
-optional-deps = ['owning_ref']
-
-[[target-package]]
-name = 'lock_api'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lz4-sys'
-version = '1.8.0'
-source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'mach_o_sys'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'memoffset'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memsec'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc', 'mach_o_sys', 'winapi']
-
-[[target-package]]
-name = 'mio'
-version = '0.6.19'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'mio-uds'
-version = '0.6.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[target-package]]
-name = 'nibble_vec'
-version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nodrop'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nohash-hasher'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-integer'
-version = '0.1.41'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'numtoa'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ordermap'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'owning_ref'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'owning_ref'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parity-multihash'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.4.8'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-optional-deps = ['owning_ref']
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.6.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.7.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'owning_ref']
-
-[[target-package]]
-name = 'parking_lot'
-version = '0.9.0'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.2.14'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking_lot_core'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ppv-lite86'
-version = '0.2.5'
-crates-io = true
-status = 'transitive'
-features = ['default', 'simd', 'std']
-
-[[target-package]]
-name = 'proc-macro-nested'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'protobuf'
-version = '2.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'quick-error'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'quick-error'
-version = '1.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-optional-deps = ['libc']
-
-[[target-package]]
-name = 'rand'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
-optional-deps = ['cloudabi', 'fuchsia-cprng', 'libc', 'winapi']
-
-[[target-package]]
-name = 'rand'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
-optional-deps = ['getrandom_package']
-
-[[target-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_chacha'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'simd', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
-name = 'rand_core'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'getrandom', 'std']
-optional-deps = ['getrandom']
-
-[[target-package]]
-name = 'rand_hc'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[target-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rayon-core'
-version = '1.6.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rdrand'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.1.56'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_termios'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_users'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.12'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'remove_dir_all'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ring'
-version = '0.16.9'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[target-package]]
-name = 'rmp'
-version = '0.8.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rust-argon2'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustc-demangle'
-version = '0.1.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ryu'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scopeguard'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'slog-stdlog'
-version = '4.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'smallvec'
-version = '0.6.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'snappy-sys'
-version = '0.1.0'
-source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'spin'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'stable_deref_trait'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'string'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'default']
-optional-deps = ['bytes']
-
-[[target-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'subtle'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'subtle'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'i128', 'std']
-
-[[target-package]]
-name = 'take_mut'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'term'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'termcolor'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio'
-version = '0.1.22'
-crates-io = true
-status = 'transitive'
-features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
-
-[[target-package]]
-name = 'tokio-buf'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'either', 'util']
-optional-deps = ['either']
-
-[[target-package]]
-name = 'tokio-codec'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-codec'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-current-thread'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-executor'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-executor'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync', 'tracing']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync', 'tracing']
-
-[[target-package]]
-name = 'tokio-fs'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-io'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-io'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['memchr', 'pin-project', 'util']
-optional-deps = ['memchr', 'pin-project']
-
-[[target-package]]
-name = 'tokio-net'
-version = '0.2.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'tracing', 'udp', 'uds']
-optional-deps = ['bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tracing']
-
-[[target-package]]
-name = 'tokio-reactor'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-sync'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-tcp'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-threadpool'
-version = '0.1.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-timer'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-timer'
-version = '0.3.0-alpha.6'
-crates-io = true
-status = 'transitive'
-features = ['async-traits']
-
-[[target-package]]
-name = 'tracing'
-version = '0.1.9'
-crates-io = true
-status = 'transitive'
-features = ['default', 'log', 'std']
-optional-deps = ['log']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'try-lock'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'typenum'
-version = '1.11.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unicode-normalization'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'unicode-width'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'unsigned-varint'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'untrusted'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'url'
-version = '1.7.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vec_map'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'want'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wasi'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default']
-
-[[target-package]]
-name = 'wasm-bindgen'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = ['default', 'spans', 'std']
-
-[[target-package]]
-name = 'web-sys'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = ['Crypto', 'Window']
-
-[[target-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'knownfolders', 'memoryapi', 'minwinbase', 'minwindef', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'shlobj', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'wincolor'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'u64_backend']
-
-[[target-package]]
-name = 'zstd-sys'
-version = '1.4.13+zstd.1.4.3'
-source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
-status = 'transitive'
-features = ['default', 'legacy']
-
-[[host-package]]
-name = 'libra-crypto-derive'
-version = '0.1.0'
-workspace-path = 'crypto/crypto-derive'
-status = 'workspace'
-features = []
 
 [[host-package]]
 name = 'grpcio-compiler'
@@ -2403,8 +589,116 @@ features = ['prost', 'prost-build', 'prost-codec', 'prost-types']
 optional-deps = ['prost', 'prost-build', 'prost-types']
 
 [[host-package]]
+name = 'hex'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'hyper'
+version = '0.12.34'
+crates-io = true
+status = 'direct'
+features = ['__internal_flaky_tests', 'default', 'futures-cpupool', 'net2', 'runtime', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['futures-cpupool', 'net2', 'tokio', 'tokio-executor', 'tokio-reactor', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'itertools'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = ['spin', 'spin_no_std']
+optional-deps = ['spin']
+
+[[host-package]]
+name = 'log'
+version = '0.4.8'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[host-package]]
+name = 'lru-cache'
+version = '0.1.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'mirai-annotations'
+version = '1.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'num-derive'
 version = '0.2.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'num-traits'
+version = '0.2.8'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'num_cpus'
+version = '1.10.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'num_enum'
+version = '0.4.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[host-package]]
+name = 'parity-multiaddr'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'petgraph'
+version = '0.4.13'
+crates-io = true
+status = 'direct'
+features = ['default', 'graphmap', 'ordermap', 'stable_graph']
+optional-deps = ['ordermap']
+
+[[host-package]]
+name = 'pin-project'
+version = '0.4.2'
 crates-io = true
 status = 'direct'
 features = []
@@ -2417,11 +711,34 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'prometheus'
+version = '0.7.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'proptest'
+version = '0.9.4'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[host-package]]
 name = 'proptest-derive'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
+
+[[host-package]]
+name = 'prost'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -2438,6 +755,166 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'radix_trie'
+version = '0.1.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[host-package]]
+name = 'rayon'
+version = '1.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'direct'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'rental'
+version = '0.5.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'rmp-serde'
+version = '0.13.7'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'rocksdb'
+version = '0.3.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[host-package]]
+name = 'serde'
+version = '1.0.101'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[host-package]]
+name = 'serde_json'
+version = '1.0.40'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'sha-1'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'sha2'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'siphasher'
+version = '0.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'slog'
+version = '2.5.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'max_level_trace', 'release_max_level_debug', 'std']
+
+[[host-package]]
+name = 'slog-async'
+version = '2.3.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'slog-envlogger'
+version = '2.2.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'regex']
+optional-deps = ['regex']
+
+[[host-package]]
+name = 'slog-scope'
+version = '4.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'slog-term'
+version = '2.4.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'snow'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['blake2-rfc', 'chacha20-poly1305-aead', 'default', 'default-resolver', 'rand', 'ring', 'ring-accelerated', 'ring-resolver', 'sha2', 'x25519-dalek']
+optional-deps = ['blake2-rfc', 'chacha20-poly1305-aead', 'rand', 'ring', 'sha2', 'x25519-dalek']
+
+[[host-package]]
+name = 'structopt'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'strum'
+version = '0.15.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'strum_macros'
 version = '0.15.0'
 crates-io = true
@@ -2449,8 +926,94 @@ name = 'syn'
 version = '1.0.5'
 crates-io = true
 status = 'direct'
-features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
+features = ['clone-impls', 'default', 'derive', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
 optional-deps = ['quote']
+
+[[host-package]]
+name = 'termion'
+version = '1.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'thread-id'
+version = '3.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'keccak']
+
+[[host-package]]
+name = 'tokio'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['bytes', 'codec', 'default', 'fs', 'io', 'macros', 'net', 'num_cpus', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core', 'udp', 'uds']
+optional-deps = ['bytes', 'num_cpus', 'tokio-codec', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-macros', 'tokio-net', 'tokio-sync', 'tokio-timer', 'tracing-core']
+
+[[host-package]]
+name = 'tokio-retry'
+version = '0.2.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tokio-sync'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'direct'
+features = ['async-traits', 'futures-sink-preview']
+optional-deps = ['futures-sink-preview']
+
+[[host-package]]
+name = 'toml'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'ttl_cache'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
+name = 'typed-arena'
+version = '1.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[host-package]]
+name = 'yamux'
+version = '0.2.1'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'aho-corasick'
@@ -2460,19 +1023,39 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'autocfg'
-version = '0.1.6'
+name = 'ansi_term'
+version = '0.11.0'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'backtrace'
-version = '0.3.37'
+name = 'arrayref'
+version = '0.3.5'
 crates-io = true
 status = 'transitive'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'std']
-optional-deps = ['backtrace-sys']
+features = []
+
+[[host-package]]
+name = 'arrayvec'
+version = '0.4.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'atty'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'autocfg'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'backtrace-sys'
@@ -2489,8 +1072,57 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
 name = 'bitflags'
 version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'blake2'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'blake2-rfc'
+version = '0.2.18'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'block-padding'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bs58'
+version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = ['default']
@@ -2503,23 +1135,16 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'bumpalo'
-version = '2.6.0'
+name = 'byte-tools'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
-features = ['collections', 'default', 'std']
+features = []
 
 [[host-package]]
-name = 'byteorder'
-version = '1.3.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'i128', 'std']
-
-[[host-package]]
-name = 'bytes'
-version = '0.4.12'
-crates-io = true
+name = 'bzip2-sys'
+version = '0.1.7'
+source = 'git+https://github.com/alexcrichton/bzip2-rs.git#02096d6f16e6b78cde379ce2305e08d2933e23b7'
 status = 'transitive'
 features = []
 
@@ -2530,6 +1155,13 @@ crates-io = true
 status = 'transitive'
 features = ['lazy_static', 'simd', 'std']
 optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'c_linked_list'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'cc'
@@ -2554,12 +1186,27 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'chacha20-poly1305-aead'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'clang-sys'
 version = '0.28.1'
 crates-io = true
 status = 'transitive'
 features = ['clang_6_0', 'gte_clang_3_6', 'gte_clang_3_7', 'gte_clang_3_8', 'gte_clang_3_9', 'gte_clang_4_0', 'gte_clang_5_0', 'gte_clang_6_0', 'libloading', 'runtime']
 optional-deps = ['libloading']
+
+[[host-package]]
+name = 'clap'
+version = '2.33.0'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
 
 [[host-package]]
 name = 'clear_on_drop'
@@ -2571,6 +1218,85 @@ features = []
 [[host-package]]
 name = 'cmake'
 version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'constant_time_eq'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crc'
+version = '1.8.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'crossbeam-channel'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-deque'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-epoch'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crossbeam-queue'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'crossbeam-utils'
+version = '0.6.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[host-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std', 'u64_backend']
+
+[[host-package]]
+name = 'data-encoding'
+version = '2.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2590,8 +1316,8 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'digest'
-version = '0.8.1'
+name = 'dirs'
+version = '1.0.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2601,19 +1327,32 @@ name = 'either'
 version = '1.5.2'
 crates-io = true
 status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'failure'
-version = '0.1.5'
+name = 'errno'
+version = '0.2.4'
 crates-io = true
 status = 'transitive'
-features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
-optional-deps = ['backtrace', 'failure_derive']
+features = []
 
 [[host-package]]
 name = 'failure_derive'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'fake-simd'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2624,6 +1363,50 @@ version = '0.1.9'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'futures-channel-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink-preview', 'sink', 'std']
+optional-deps = ['futures-sink-preview']
+
+[[host-package]]
+name = 'futures-core-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-cpupool'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
+name = 'futures-executor-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['num_cpus', 'std']
+optional-deps = ['num_cpus']
+
+[[host-package]]
+name = 'futures-io-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['std']
 
 [[host-package]]
 name = 'futures-join-macro-preview'
@@ -2640,11 +1423,19 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'gcc'
-version = '0.3.55'
+name = 'futures-sink-preview'
+version = '0.3.0-alpha.19'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['alloc', 'default', 'std']
+
+[[host-package]]
+name = 'futures-util-preview'
+version = '0.3.0-alpha.19'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'channel', 'compat', 'default', 'futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'io', 'io-compat', 'join-macro', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'select-macro', 'sink', 'slab', 'std', 'tokio-io']
+optional-deps = ['futures-channel-preview', 'futures-io-preview', 'futures-join-macro-preview', 'futures-select-macro-preview', 'futures-sink-preview', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
 
 [[host-package]]
 name = 'generic-array'
@@ -2668,8 +1459,64 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'grpcio-sys'
+version = '0.5.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'h2'
+version = '0.1.26'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'heck'
 version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http'
+version = '0.1.18'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'http-body'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'idna'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'indexmap'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2682,11 +1529,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'itertools'
-version = '0.8.0'
+name = 'itoa'
+version = '0.4.4'
 crates-io = true
 status = 'transitive'
-features = ['default', 'use_std']
+features = ['default', 'std']
 
 [[host-package]]
 name = 'jobserver'
@@ -2696,8 +1543,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
+name = 'keccak'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2717,8 +1564,58 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'log'
-version = '0.4.8'
+name = 'librocksdb_sys'
+version = '0.1.0'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'libtitan_sys'
+version = '0.0.1'
+source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'libz-sys'
+version = '1.0.25'
+crates-io = true
+status = 'transitive'
+features = ['static']
+
+[[host-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lock_api'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = ['owning_ref']
+optional-deps = ['owning_ref']
+
+[[host-package]]
+name = 'lock_api'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lz4-sys'
+version = '1.8.0'
+source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#41509fea212e9ca55c1f6c53d4fd1ddf28cdf689'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'matches'
+version = '0.1.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2731,8 +1628,65 @@ status = 'transitive'
 features = ['default', 'use_std']
 
 [[host-package]]
+name = 'memoffset'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memsec'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom', 'libc']
+
+[[host-package]]
+name = 'mio'
+version = '0.6.19'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[host-package]]
+name = 'mio-uds'
+version = '0.6.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'multimap'
 version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[host-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nodrop'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nohash-hasher'
+version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2745,8 +1699,8 @@ status = 'transitive'
 features = ['alloc', 'default', 'std', 'verbose-errors']
 
 [[host-package]]
-name = 'num_cpus'
-version = '1.10.1'
+name = 'num-integer'
+version = '0.1.41'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2759,6 +1713,105 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
+name = 'numtoa'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ordermap'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'owning_ref'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'owning_ref'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parity-multihash'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+optional-deps = ['owning_ref']
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.6.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'owning_ref']
+
+[[host-package]]
+name = 'parking_lot'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'parking_lot_core'
+version = '0.6.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'peeking_take_while'
 version = '0.1.2'
 crates-io = true
@@ -2766,8 +1819,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'petgraph'
-version = '0.4.13'
+name = 'percent-encoding'
+version = '1.0.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2775,6 +1828,13 @@ features = []
 [[host-package]]
 name = 'pin-project-internal'
 version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2815,6 +1875,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'proc-macro2'
 version = '0.4.30'
 crates-io = true
@@ -2834,14 +1901,6 @@ version = '0.2.2'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'prost'
-version = '0.5.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-derive'
@@ -2865,6 +1924,20 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'quick-error'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'quick-error'
+version = '1.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'quote'
 version = '0.6.13'
 crates-io = true
@@ -2873,11 +1946,48 @@ features = ['default', 'proc-macro']
 
 [[host-package]]
 name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
+optional-deps = ['libc']
+
+[[host-package]]
+name = 'rand'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
+optional-deps = ['libc']
+
+[[host-package]]
+name = 'rand'
 version = '0.7.0'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'std']
 optional-deps = ['getrandom_package']
+
+[[host-package]]
+name = 'rand04'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'rand_chacha'
@@ -2891,7 +2001,7 @@ name = 'rand_core'
 version = '0.3.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['alloc', 'std']
 
 [[host-package]]
 name = 'rand_core'
@@ -2909,19 +2019,60 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'regex'
-version = '1.3.1'
+name = 'rand_hc'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+features = []
+
+[[host-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'rayon-core'
+version = '1.6.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'regex-syntax'
 version = '0.6.12'
 crates-io = true
 status = 'transitive'
-features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[host-package]]
 name = 'remove_dir_all'
@@ -2933,6 +2084,21 @@ features = []
 [[host-package]]
 name = 'rental-impl'
 version = '0.5.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'ring'
+version = '0.16.9'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[host-package]]
+name = 'rmp'
+version = '0.8.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2959,8 +2125,29 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'ryu'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'same-file'
 version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2980,13 +2167,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'serde'
-version = '1.0.101'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.99'
 crates-io = true
@@ -3001,8 +2181,58 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'sourcefile'
-version = '0.1.4'
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'slog-stdlog'
+version = '4.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'smallvec'
+version = '0.6.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'snappy-sys'
+version = '0.1.0'
+source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'stable_deref_trait'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'string'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'default']
+optional-deps = ['bytes']
+
+[[host-package]]
+name = 'strsim'
+version = '0.8.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3016,10 +2246,17 @@ features = []
 
 [[host-package]]
 name = 'subtle'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'subtle'
 version = '2.1.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = ['default', 'i128', 'std']
 
 [[host-package]]
 name = 'syn'
@@ -3037,8 +2274,36 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'take_mut'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'tempfile'
 version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'term'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'termcolor'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'textwrap'
+version = '0.11.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3051,6 +2316,87 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio'
+version = '0.1.22'
+crates-io = true
+status = 'transitive'
+features = ['bytes', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'timer', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-current-thread', 'tokio-executor', 'tokio-io', 'tokio-reactor', 'tokio-threadpool', 'tokio-timer']
+
+[[host-package]]
+name = 'tokio-buf'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'either', 'util']
+optional-deps = ['either']
+
+[[host-package]]
+name = 'tokio-codec'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-codec'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-current-thread'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-executor'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-executor'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['blocking', 'crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'current-thread', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'threadpool', 'tokio-sync']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'crossbeam-utils', 'futures-core-preview', 'lazy_static', 'num_cpus', 'slab', 'tokio-sync']
+
+[[host-package]]
+name = 'tokio-fs'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-io'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-io'
+version = '0.2.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['memchr', 'pin-project', 'util']
+optional-deps = ['memchr', 'pin-project']
+
+[[host-package]]
 name = 'tokio-macros'
 version = '0.2.0-alpha.6'
 crates-io = true
@@ -3058,15 +2404,65 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'toml'
-version = '0.5.3'
+name = 'tokio-net'
+version = '0.2.0-alpha.6'
 crates-io = true
 status = 'transitive'
-features = ['default']
+features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'udp', 'uds']
+optional-deps = ['bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds']
 
 [[host-package]]
-name = 'tracing-attributes'
-version = '0.1.4'
+name = 'tokio-reactor'
+version = '0.1.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-sync'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-tcp'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-threadpool'
+version = '0.1.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-timer'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'tokio-timer'
+version = '0.3.0-alpha.6'
+crates-io = true
+status = 'transitive'
+features = ['async-traits']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'try-lock'
+version = '0.2.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3079,11 +2475,32 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'unicode-normalization'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'unicode-segmentation'
 version = '1.3.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'unicode-width'
+version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -3100,8 +2517,43 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'unsigned-varint'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'untrusted'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'url'
+version = '1.7.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'vec_map'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'wait-timeout'
+version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3114,43 +2566,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'wasm-bindgen-backend'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-macro'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-macro-support'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = ['spans']
-
-[[host-package]]
-name = 'wasm-bindgen-shared'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wasm-bindgen-webidl'
-version = '0.2.51'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'weedle'
-version = '0.10.0'
+name = 'want'
+version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3163,8 +2580,15 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
+name = 'x25519-dalek'
+version = '0.5.2'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'std', 'u64_backend']
+
+[[host-package]]
+name = 'zstd-sys'
+version = '1.4.13+zstd.1.4.3'
+source = 'git+https://github.com/gyscos/zstd-rs.git#7f77d0984a746a944588f41045a14dd60b5f496b'
+status = 'transitive'
+features = ['default', 'legacy']

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-2.toml
@@ -2,25 +2,29 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra_9ffd93b
 
 [metadata]
-resolver = '1'
-include-dev = true
-initials-platform = 'host'
+resolver = 'install'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'arm64ec-pc-windows-msvc'
-target-features = 'unknown'
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-apple-darwin'
-target-features = 'unknown'
+triple = 'armv5te-none-eabi'
+target-features = ['bmi2', 'sse', 'sse4.2', 'xsaves']
 [[metadata.omitted-packages.ids]]
-name = 'multipart'
-version = '0.16.1'
+name = 'bytes'
+version = '0.5.4'
 crates-io = true
 
 [[metadata.omitted-packages.ids]]
-name = 'which'
-version = '3.1.0'
+name = 'ir-to-bytecode-syntax'
+version = '0.1.0'
+workspace-path = 'language/compiler/ir-to-bytecode/syntax'
+
+[[metadata.omitted-packages.ids]]
+name = 'snow'
+version = '0.6.2'
 crates-io = true
 
 [[metadata.features-only]]
@@ -41,22 +45,14 @@ version = '0.1.0'
 workspace-path = 'network/netcore'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'futures-semaphore'
 version = '0.1.0'
 workspace-path = 'common/futures-semaphore'
 status = 'initial'
 features = []
 
-[[host-package]]
-name = 'futures'
-version = '0.3.4'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
-optional-deps = ['futures-executor']
-
-[[host-package]]
+[[target-package]]
 name = 'tokio'
 version = '0.2.13'
 crates-io = true
@@ -64,115 +60,49 @@ status = 'direct'
 features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds', 'winapi']
 optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'libc', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'num_cpus', 'signal-hook-registry', 'slab', 'tokio-macros', 'winapi']
 
-[[host-package]]
-name = 'bytes'
-version = '0.5.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'serde', 'std']
-optional-deps = ['serde']
-
-[[host-package]]
+[[target-package]]
 name = 'cfg-if'
 version = '0.1.10'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'fnv'
 version = '1.0.6'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
-name = 'futures-channel'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
-optional-deps = ['futures-sink']
-
-[[host-package]]
+[[target-package]]
 name = 'futures-core'
 version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'std']
 
-[[host-package]]
-name = 'futures-executor'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'futures-io'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'futures-macro'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-sink'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-task'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[host-package]]
-name = 'futures-util'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
-optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
-
-[[host-package]]
+[[target-package]]
 name = 'iovec'
 version = '0.1.4'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
+[[target-package]]
 name = 'lazy_static'
 version = '1.4.0'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libc'
 version = '0.2.67'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
 
-[[host-package]]
+[[target-package]]
 name = 'log'
 version = '0.4.8'
 crates-io = true
@@ -180,79 +110,52 @@ status = 'transitive'
 features = ['serde', 'std']
 optional-deps = ['serde']
 
-[[host-package]]
+[[target-package]]
 name = 'memchr'
 version = '2.3.3'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std', 'use_std']
 
-[[host-package]]
+[[target-package]]
 name = 'mio'
 version = '0.6.21'
 crates-io = true
 status = 'transitive'
 features = ['default', 'with-deprecated']
 
-[[host-package]]
-name = 'mio-named-pipes'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
+[[target-package]]
 name = 'net2'
 version = '0.2.33'
 crates-io = true
 status = 'transitive'
 features = ['default', 'duration']
 
-[[host-package]]
+[[target-package]]
 name = 'num_cpus'
 version = '1.12.0'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'pin-project-lite'
 version = '0.1.4'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[host-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
+[[target-package]]
+name = 'serde'
+version = '1.0.104'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
 
-[[host-package]]
-name = 'proc-macro-hack'
-version = '0.5.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'proc-macro-nested'
-version = '0.1.3'
+[[target-package]]
+name = 'slab'
+version = '0.4.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -272,33 +175,11 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'serde'
-version = '1.0.104'
-crates-io = true
-status = 'transitive'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
 name = 'serde_derive'
 version = '1.0.104'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'socket2'
-version = '0.3.11'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'syn'
@@ -321,31 +202,3 @@ version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'libloaderapi', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'ntstatus', 'processenv', 'profileapi', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-3.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-3.toml
@@ -2,24 +2,28 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra_9ffd93b
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'host'
+initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'i586-pc-windows-msvc'
+target-features = 'unknown'
+flags = ['abc', 'test-flag']
 
 [metadata.target-platform]
-spec = 'always'
+triple = 'aarch64-unknown-linux-gnu'
+target-features = 'unknown'
+flags = ['cargo_web', 'test-flag']
 [[metadata.omitted-packages.ids]]
-name = 'proptest-derive'
-version = '0.1.2'
-crates-io = true
+name = 'jellyfish-merkle'
+version = '0.1.0'
+workspace-path = 'storage/jellyfish-merkle'
 
 [[metadata.omitted-packages.ids]]
-name = 'serializer_tests'
+name = 'unicode-xid'
 version = '0.1.0'
-workspace-path = 'language/vm/serializer_tests'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'libra-wallet'
@@ -34,14 +38,14 @@ workspace-path = 'language/move-vm/types'
 features = ['default', 'fuzzing', 'instruction_synthesis', 'proptest']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'cost-synthesis'
 version = '0.1.0'
 workspace-path = 'language/tools/cost-synthesis'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'move-vm-types'
 version = '0.1.0'
 workspace-path = 'language/move-vm/types'
@@ -49,91 +53,91 @@ status = 'initial'
 features = ['default', 'fuzzing', 'instruction_synthesis', 'proptest']
 optional-deps = ['proptest']
 
-[[host-package]]
+[[target-package]]
 name = 'x'
 version = '0.1.0'
 workspace-path = 'x'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'borrow-graph'
 version = '0.0.1'
 workspace-path = 'language/borrow-graph'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-source-map'
 version = '0.1.0'
 workspace-path = 'language/compiler/bytecode-source-map'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-verifier'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'compiler'
 version = '0.1.0'
 workspace-path = 'language/compiler'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'datatest-stable'
 version = '0.1.0'
 workspace-path = 'common/datatest-stable'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'debug-interface'
 version = '0.1.0'
 workspace-path = 'common/debug-interface'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode-syntax'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'language-e2e-tests'
 version = '0.1.0'
 workspace-path = 'language/e2e-tests'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
@@ -141,56 +145,49 @@ status = 'workspace'
 features = ['cloneable-private-keys', 'default', 'fuzzing', 'proptest', 'proptest-derive', 'std', 'u64_backend']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[host-package]]
-name = 'libra-crypto-derive'
-version = '0.1.0'
-workspace-path = 'crypto/crypto-derive'
-status = 'workspace'
-features = []
-
-[[host-package]]
+[[target-package]]
 name = 'libra-logger'
 version = '0.1.0'
 workspace-path = 'common/logger'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-metrics'
 version = '0.1.0'
 workspace-path = 'common/metrics'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-nibble'
 version = '0.1.0'
 workspace-path = 'common/nibble'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-proptest-helpers'
 version = '0.1.0'
 workspace-path = 'common/proptest-helpers'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-state-view'
 version = '0.1.0'
 workspace-path = 'storage/state-view'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-temppath'
 version = '0.1.0'
 workspace-path = 'common/temppath'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-types'
 version = '0.1.0'
 workspace-path = 'types'
@@ -198,14 +195,14 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
 optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-vm'
 version = '0.1.0'
 workspace-path = 'language/libra-vm'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'move-core-types'
 version = '0.1.0'
 workspace-path = 'language/move-core/types'
@@ -213,38 +210,1534 @@ status = 'workspace'
 features = ['default', 'fuzzing', 'proptest', 'proptest-derive']
 optional-deps = ['proptest', 'proptest-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'move-ir-types'
 version = '0.1.0'
 workspace-path = 'language/move-ir/types'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'move-lang'
 version = '0.0.1'
 workspace-path = 'language/move-lang'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'move-vm-cache'
 version = '0.1.0'
 workspace-path = 'language/move-vm/cache'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'move-vm-runtime'
 version = '0.1.0'
 workspace-path = 'language/move-vm/runtime'
 status = 'workspace'
 features = ['default', 'instruction_synthesis']
 
-[[host-package]]
+[[target-package]]
 name = 'move-vm-state'
 version = '0.1.0'
 workspace-path = 'language/move-vm/state'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'stdlib'
+version = '0.1.0'
+workspace-path = 'language/stdlib'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'transaction-builder'
+version = '0.1.0'
+workspace-path = 'language/transaction-builder'
+status = 'workspace'
+features = ['default', 'fuzzing']
+
+[[target-package]]
+name = 'utils'
+version = '0.1.0'
+workspace-path = 'language/tools/utils'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'vm'
+version = '0.1.0'
+workspace-path = 'language/vm'
+status = 'workspace'
+features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
+optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
+
+[[target-package]]
+name = 'vm-genesis'
+version = '0.1.0'
+workspace-path = 'language/tools/vm-genesis'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'anyhow'
+version = '1.0.26'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'bytes'
+version = '0.5.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'chrono'
+version = '0.4.11'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'std', 'time']
+optional-deps = ['time']
+
+[[target-package]]
+name = 'codespan'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['serde', 'serialization']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'codespan-reporting'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'crossbeam'
+version = '0.7.3'
+crates-io = true
+status = 'direct'
+features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
+
+[[target-package]]
+name = 'csv'
+version = '1.1.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
+status = 'direct'
+features = ['alloc', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'digest'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[target-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
+status = 'direct'
+features = ['serde', 'std', 'u64_backend']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'env_logger'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.4'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[target-package]]
+name = 'get_if_addrs'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hex'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hyper'
+version = '0.13.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'net2', 'runtime', 'stream', 'tcp']
+optional-deps = ['net2']
+
+[[target-package]]
+name = 'include_dir'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'itertools'
+version = '0.9.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'log'
+version = '0.4.8'
+crates-io = true
+status = 'direct'
+features = ['serde', 'std']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'mirai-annotations'
+version = '1.6.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'once_cell'
+version = '1.3.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[target-package]]
+name = 'parity-multiaddr'
+version = '0.7.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'petgraph'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'graphmap', 'matrix_graph', 'stable_graph']
+
+[[target-package]]
+name = 'prometheus'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'proptest'
+version = '0.9.5'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[target-package]]
+name = 'prost'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
+
+[[target-package]]
+name = 'radix_trie'
+version = '0.1.6'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[target-package]]
+name = 'rayon'
+version = '1.3.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ref-cast'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.3.4'
+crates-io = true
+status = 'direct'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[target-package]]
+name = 'rental'
+version = '0.5.5'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.104'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'serde_json'
+version = '1.0.48'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'sha2'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'structopt'
+version = '0.3.11'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'thiserror'
+version = '1.0.11'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tiny-keccak'
+version = '2.0.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'sha3']
+
+[[target-package]]
+name = 'tokio'
+version = '0.2.13'
+crates-io = true
+status = 'direct'
+features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds']
+optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'libc', 'memchr', 'mio', 'mio-uds', 'num_cpus', 'signal-hook-registry', 'slab', 'tokio-macros']
+
+[[target-package]]
+name = 'toml'
+version = '0.5.6'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'tonic'
+version = '0.1.1'
+crates-io = true
+status = 'direct'
+features = ['async-trait', 'codegen', 'default', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures', 'transport']
+optional-deps = ['async-trait', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures']
+
+[[target-package]]
+name = 'typed-arena'
+version = '2.0.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'walkdir'
+version = '2.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[target-package]]
+name = 'aho-corasick'
+version = '0.7.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'arc-swap'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'arrayref'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-stream'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'backtrace'
+version = '0.3.45'
+crates-io = true
+status = 'transitive'
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'std']
+optional-deps = ['backtrace-sys']
+
+[[target-package]]
+name = 'backtrace-sys'
+version = '0.1.33'
+crates-io = true
+status = 'transitive'
+features = ['backtrace-sys']
+
+[[target-package]]
+name = 'base64'
+version = '0.10.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'blake2'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'block-padding'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bs58'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'bstr'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
+optional-deps = ['lazy_static', 'regex-automata', 'serde']
+
+[[target-package]]
+name = 'byte-tools'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'c2-chacha'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'c_linked_list'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '2.33.0'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+
+[[target-package]]
+name = 'clear_on_drop'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-channel'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-deque'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-epoch'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crossbeam-queue'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'crossbeam-utils'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[target-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'csv-core'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'data-encoding'
+version = '2.2.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'either'
+version = '1.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'failure'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[target-package]]
+name = 'fake-simd'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fixedbitset'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-executor'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
+
+[[target-package]]
+name = 'generic-array'
+version = '0.12.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.14'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'glob'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'h2'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http-body'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'indexmap'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'iovec'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'keccak'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.67'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'maybe-uninit'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[target-package]]
+name = 'memoffset'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memsec'
+version = '0.5.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom', 'libc']
+
+[[target-package]]
+name = 'mio'
+version = '0.6.21'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[target-package]]
+name = 'mio-uds'
+version = '0.6.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[target-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-integer'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'num_cpus'
+version = '1.12.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parity-multihash'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.6'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
+optional-deps = ['libc']
+
+[[target-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
+optional-deps = ['getrandom_package', 'libc', 'rand_pcg']
+
+[[target-package]]
+name = 'rand04'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rayon-core'
+version = '1.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.16'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustc-demangle'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sha-1'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'static_assertions'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'subtle'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'subtle'
+version = '2.2.2'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'keccak']
+
+[[target-package]]
+name = 'tokio-util'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = ['codec', 'default']
+
+[[target-package]]
+name = 'tower'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'full', 'log']
+
+[[target-package]]
+name = 'tower-balance'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'log']
+
+[[target-package]]
+name = 'tower-buffer'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['log']
+
+[[target-package]]
+name = 'tower-discover'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-layer'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-limit'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-load'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-load-shed'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-make'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['connect', 'tokio']
+optional-deps = ['tokio']
+
+[[target-package]]
+name = 'tower-ready-cache'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-retry'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-service'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-timeout'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-util'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['call-all', 'default', 'futures-util']
+optional-deps = ['futures-util']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = ['attributes', 'default', 'log', 'std', 'tracing-attributes']
+optional-deps = ['log', 'tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'tracing-futures'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'pin-project', 'std', 'std-future']
+optional-deps = ['pin-project']
+
+[[target-package]]
+name = 'try-lock'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'typenum'
+version = '1.11.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-normalization'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-segmentation'
+version = '1.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-width'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unsigned-varint'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'url'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vec_map'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'want'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'libra-crypto-derive'
+version = '0.1.0'
+workspace-path = 'crypto/crypto-derive'
 status = 'workspace'
 features = []
 
@@ -256,236 +1749,11 @@ status = 'workspace'
 features = []
 
 [[host-package]]
-name = 'stdlib'
-version = '0.1.0'
-workspace-path = 'language/stdlib'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'transaction-builder'
-version = '0.1.0'
-workspace-path = 'language/transaction-builder'
-status = 'workspace'
-features = ['default', 'fuzzing']
-
-[[host-package]]
-name = 'utils'
-version = '0.1.0'
-workspace-path = 'language/tools/utils'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'vm'
-version = '0.1.0'
-workspace-path = 'language/vm'
-status = 'workspace'
-features = ['default', 'fuzzing', 'libra-proptest-helpers', 'proptest', 'proptest-derive']
-optional-deps = ['libra-proptest-helpers', 'proptest', 'proptest-derive']
-
-[[host-package]]
-name = 'vm-genesis'
-version = '0.1.0'
-workspace-path = 'language/tools/vm-genesis'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
 name = 'anyhow'
 version = '1.0.26'
 crates-io = true
 status = 'direct'
 features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'i128', 'std']
-
-[[host-package]]
-name = 'bytes'
-version = '0.5.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'chrono'
-version = '0.4.11'
-crates-io = true
-status = 'direct'
-features = ['clock', 'default', 'std', 'time']
-optional-deps = ['time']
-
-[[host-package]]
-name = 'codespan'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['serde', 'serialization']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'codespan-reporting'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'crossbeam'
-version = '0.7.3'
-crates-io = true
-status = 'direct'
-features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
-
-[[host-package]]
-name = 'csv'
-version = '1.1.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
-status = 'direct'
-features = ['alloc', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'difference'
-version = '2.0.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'digest'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[host-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
-status = 'direct'
-features = ['serde', 'std', 'u64_backend']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'env_logger'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'futures'
-version = '0.3.4'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
-optional-deps = ['futures-executor']
-
-[[host-package]]
-name = 'get_if_addrs'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hex'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hyper'
-version = '0.13.3'
-crates-io = true
-status = 'direct'
-features = ['default', 'net2', 'runtime', 'stream', 'tcp']
-optional-deps = ['net2']
-
-[[host-package]]
-name = 'include_dir'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'itertools'
-version = '0.9.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'direct'
-features = ['serde', 'std']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'mirai-annotations'
-version = '1.6.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'once_cell'
-version = '1.3.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[host-package]]
-name = 'parity-multiaddr'
-version = '0.7.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'petgraph'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'graphmap', 'matrix_graph', 'stable_graph']
 
 [[host-package]]
 name = 'proc-macro2'
@@ -495,27 +1763,11 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'prometheus'
-version = '0.8.0'
+name = 'proptest-derive'
+version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
-
-[[host-package]]
-name = 'proptest'
-version = '0.9.5'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[host-package]]
-name = 'prost'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -532,79 +1784,6 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'radix_trie'
-version = '0.1.6'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[host-package]]
-name = 'rayon'
-version = '1.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'ref-cast'
-version = '1.0.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'regex'
-version = '1.3.4'
-crates-io = true
-status = 'direct'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[host-package]]
-name = 'rental'
-version = '0.5.5'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'serde'
-version = '1.0.104'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
-name = 'serde_json'
-version = '1.0.48'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'sha2'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'structopt'
-version = '0.3.11'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
 name = 'syn'
 version = '1.0.16'
 crates-io = true
@@ -613,118 +1792,11 @@ features = ['clone-impls', 'default', 'derive', 'extra-traits', 'fold', 'full', 
 optional-deps = ['quote']
 
 [[host-package]]
-name = 'termcolor'
-version = '1.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'thiserror'
-version = '1.0.11'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tiny-keccak'
-version = '2.0.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'sha3']
-
-[[host-package]]
-name = 'tokio'
-version = '0.2.13'
-crates-io = true
-status = 'direct'
-features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds', 'winapi']
-optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'libc', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'num_cpus', 'signal-hook-registry', 'slab', 'tokio-macros', 'winapi']
-
-[[host-package]]
-name = 'toml'
-version = '0.5.6'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'tonic'
-version = '0.1.1'
-crates-io = true
-status = 'direct'
-features = ['async-trait', 'codegen', 'default', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures', 'transport']
-optional-deps = ['async-trait', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures']
-
-[[host-package]]
 name = 'tonic-build'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'rustfmt', 'transport']
-
-[[host-package]]
-name = 'typed-arena'
-version = '2.0.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
-
-[[host-package]]
-name = 'aho-corasick'
-version = '0.7.10'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'ansi_term'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'arc-swap'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'arrayref'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'async-stream'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'async-stream-impl'
@@ -736,13 +1808,6 @@ features = []
 [[host-package]]
 name = 'async-trait'
 version = '0.1.24'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'atty'
-version = '0.2.14'
 crates-io = true
 status = 'transitive'
 features = []
@@ -777,75 +1842,18 @@ status = 'transitive'
 features = ['backtrace-sys']
 
 [[host-package]]
-name = 'base64'
-version = '0.10.1'
+name = 'byteorder'
+version = '1.3.4'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['i128']
 
 [[host-package]]
-name = 'bit-set'
-version = '0.5.1'
+name = 'bytes'
+version = '0.5.4'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'bitflags'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'blake2'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'block-buffer'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'block-padding'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bs58'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'bstr'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
-
-[[host-package]]
-name = 'byte-tools'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'c2-chacha'
@@ -853,13 +1861,6 @@ version = '0.2.3'
 crates-io = true
 status = 'transitive'
 features = ['simd', 'std']
-
-[[host-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'cc'
@@ -876,14 +1877,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'clap'
-version = '2.33.0'
-crates-io = true
-status = 'transitive'
-features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
-
-[[host-package]]
 name = 'clear_on_drop'
 version = '0.2.3'
 crates-io = true
@@ -891,102 +1884,15 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'cloudabi'
-version = '0.0.3'
-crates-io = true
-status = 'transitive'
-features = ['bitflags', 'default']
-optional-deps = ['bitflags']
-
-[[host-package]]
-name = 'crossbeam-channel'
-version = '0.4.2'
+name = 'digest'
+version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'crossbeam-deque'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-epoch'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crossbeam-queue'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[host-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'csv-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'data-encoding'
-version = '2.2.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
 
 [[host-package]]
 name = 'either'
 version = '1.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'endian-type'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'errno-dragonfly'
-version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1007,13 +1913,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'fake-simd'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
@@ -1021,94 +1920,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fuchsia-cprng'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fuchsia-zircon'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'fuchsia-zircon-sys'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-channel'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
-optional-deps = ['futures-sink']
-
-[[host-package]]
-name = 'futures-core'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-executor'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'futures-io'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
 name = 'futures-macro'
 version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-sink'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-task'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[host-package]]
-name = 'futures-util'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
-optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
-
-[[host-package]]
-name = 'gcc'
-version = '0.3.55'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1121,13 +1934,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'get_if_addrs-sys'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'getrandom'
 version = '0.1.14'
 crates-io = true
@@ -1135,64 +1941,8 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
-name = 'glob'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'h2'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'heck'
 version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'hermit-abi'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http-body'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'idna'
-version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1212,46 +1962,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'iovec'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'itertools'
 version = '0.8.2'
 crates-io = true
 status = 'transitive'
 features = ['default', 'use_std']
-
-[[host-package]]
-name = 'itoa'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'keccak'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'libc'
@@ -1261,79 +1976,8 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'mach_o_sys'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'maybe-uninit'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memchr'
-version = '2.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std', 'use_std']
-
-[[host-package]]
-name = 'memoffset'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memsec'
-version = '0.5.7'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc', 'mach_o_sys', 'winapi']
-
-[[host-package]]
-name = 'mio'
-version = '0.6.21'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[host-package]]
-name = 'mio-named-pipes'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'mio-uds'
-version = '0.6.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'miow'
-version = '0.3.3'
+name = 'log'
+version = '0.4.8'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1346,71 +1990,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[host-package]]
-name = 'nibble_vec'
-version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num-integer'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'num_cpus'
-version = '1.12.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parity-multihash'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'percent-encoding'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-project'
-version = '0.4.8'
+name = 'petgraph'
+version = '0.5.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1418,20 +1999,6 @@ features = []
 [[host-package]]
 name = 'pin-project-internal'
 version = '0.4.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-project-lite'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1465,11 +2032,19 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'proc-macro-nested'
-version = '0.1.3'
+name = 'proc-macro2'
+version = '0.4.30'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'prost'
+version = '0.6.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-derive'
@@ -1486,48 +2061,19 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'quick-error'
-version = '1.2.3'
+name = 'quote'
+version = '0.6.13'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-optional-deps = ['libc']
+features = ['default', 'proc-macro']
 
 [[host-package]]
 name = 'rand'
 version = '0.7.3'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
-optional-deps = ['getrandom_package', 'libc', 'rand_pcg']
-
-[[host-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package']
 
 [[host-package]]
 name = 'rand_chacha'
@@ -1541,7 +2087,7 @@ name = 'rand_core'
 version = '0.3.1'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'std']
+features = ['std']
 
 [[host-package]]
 name = 'rand_core'
@@ -1559,102 +2105,11 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'rand_hc'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_hc'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_pcg'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rayon-core'
-version = '1.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rdrand'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'redox_syscall'
-version = '0.1.56'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ref-cast-impl'
 version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'regex-automata'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.6.16'
-crates-io = true
-status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[host-package]]
 name = 'remove_dir_all'
@@ -1685,35 +2140,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'scopeguard'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'semver'
 version = '0.9.0'
 crates-io = true
@@ -1735,85 +2161,8 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'sha-1'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'signal-hook-registry'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'slab'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'smallvec'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'socket2'
-version = '0.3.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'spin'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'stable_deref_trait'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'static_assertions'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'strsim'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'structopt-derive'
 version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'subtle'
-version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1824,6 +2173,14 @@ version = '2.2.2'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[host-package]]
+name = 'syn'
+version = '0.15.44'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit']
+optional-deps = ['quote']
 
 [[host-package]]
 name = 'syn-mid'
@@ -1847,39 +2204,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'textwrap'
-version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'thiserror-impl'
 version = '1.0.11'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'thread_local'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'keccak']
 
 [[host-package]]
 name = 'tokio-macros'
@@ -1889,146 +2218,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'tokio-util'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default']
-
-[[host-package]]
-name = 'tower'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'full', 'log']
-
-[[host-package]]
-name = 'tower-balance'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'log']
-
-[[host-package]]
-name = 'tower-buffer'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['log']
-
-[[host-package]]
-name = 'tower-discover'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-layer'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-limit'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-load'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-load-shed'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-make'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['connect', 'tokio']
-optional-deps = ['tokio']
-
-[[host-package]]
-name = 'tower-ready-cache'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-retry'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-service'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-timeout'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-util'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['call-all', 'default', 'futures-util']
-optional-deps = ['futures-util']
-
-[[host-package]]
-name = 'tracing'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = ['attributes', 'default', 'log', 'std', 'tracing-attributes']
-optional-deps = ['log', 'tracing-attributes']
-
-[[host-package]]
 name = 'tracing-attributes'
 version = '0.1.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tracing-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'tracing-futures'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'pin-project', 'std', 'std-future']
-optional-deps = ['pin-project']
-
-[[host-package]]
-name = 'try-lock'
-version = '0.2.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2041,32 +2232,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'unicode-normalization'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'unicode-segmentation'
 version = '1.6.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'unicode-width'
-version = '0.1.7'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'unicode-xid'
@@ -2076,53 +2246,11 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'unsigned-varint'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'url'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'vec_map'
-version = '0.8.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'version_check'
 version = '0.9.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'want'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'wasi'
-version = '0.9.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'which'
@@ -2133,49 +2261,7 @@ features = []
 
 [[host-package]]
 name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
 version = '0.3.8'
 crates-io = true
 status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'ioapiset', 'memoryapi', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'processenv', 'profileapi', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'winsock2', 'ws2def', 'ws2ipdef', 'ws2tcpip']
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-util'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['errhandlingapi', 'fileapi', 'handleapi', 'std', 'winbase', 'winerror']

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
@@ -2,29 +2,24 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra_9ffd93b
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'host'
+resolver = '3'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'arm-linux-androideabi'
-target-features = ['avx2', 'fma', 'rdrand', 'sha', 'sse2', 'ssse3', 'xsave']
+triple = 'armv7a-none-eabi'
+target-features = 'all'
 [[metadata.omitted-packages.ids]]
-name = 'libfuzzer-sys'
-version = '0.3.1'
+name = 'jemalloc-sys'
+version = '0.3.2'
 crates-io = true
 
 [[metadata.omitted-packages.ids]]
-name = 'libra-logger'
-version = '0.1.0'
-workspace-path = 'common/logger'
-
-[[metadata.omitted-packages.ids]]
-name = 'slab'
-version = '0.4.2'
+name = 'winapi'
+version = '0.2.8'
 crates-io = true
 
 [[metadata.features-only]]
@@ -39,110 +34,1739 @@ version = '0.1.0'
 workspace-path = 'state-synchronizer'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-verifier'
 version = '0.1.0'
 workspace-path = 'language/bytecode-verifier'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-dev'
 version = '0.1.0'
 workspace-path = 'client/libra-dev'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-proptest-helpers'
 version = '0.1.0'
 workspace-path = 'common/proptest-helpers'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-storage-inspector'
 version = '0.1.0'
 workspace-path = 'storage/inspector'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'test-utils'
 version = '0.1.0'
 workspace-path = 'language/move-prover/test-utils'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'accumulator'
 version = '0.1.0'
 workspace-path = 'storage/accumulator'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'borrow-graph'
 version = '0.0.1'
 workspace-path = 'language/borrow-graph'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'bytecode-source-map'
 version = '0.1.0'
 workspace-path = 'language/compiler/bytecode-source-map'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'datatest-stable'
 version = '0.1.0'
 workspace-path = 'common/datatest-stable'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'ir-to-bytecode-syntax'
 version = '0.1.0'
 workspace-path = 'language/compiler/ir-to-bytecode/syntax'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'jellyfish-merkle'
 version = '0.1.0'
 workspace-path = 'storage/jellyfish-merkle'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-canonical-serialization'
 version = '0.1.0'
 workspace-path = 'common/lcs'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'libra-config'
 version = '0.1.0'
 workspace-path = 'config'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'libra-crypto'
 version = '0.1.0'
 workspace-path = 'crypto/crypto'
 status = 'workspace'
 features = ['default', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'libra-logger'
+version = '0.1.0'
+workspace-path = 'common/logger'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'libra-metrics'
+version = '0.1.0'
+workspace-path = 'common/metrics'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'libra-nibble'
+version = '0.1.0'
+workspace-path = 'common/nibble'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'libra-temppath'
+version = '0.1.0'
+workspace-path = 'common/temppath'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'libra-types'
+version = '0.1.0'
+workspace-path = 'types'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'libradb'
+version = '0.1.0'
+workspace-path = 'storage/libradb'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'move-core-types'
+version = '0.1.0'
+workspace-path = 'language/move-core/types'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'move-ir-types'
+version = '0.1.0'
+workspace-path = 'language/move-ir/types'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'move-lang'
+version = '0.0.1'
+workspace-path = 'language/move-lang'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'move-vm-types'
+version = '0.1.0'
+workspace-path = 'language/move-vm/types'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'schemadb'
+version = '0.1.0'
+workspace-path = 'storage/schemadb'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'stdlib'
+version = '0.1.0'
+workspace-path = 'language/stdlib'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'storage-proto'
+version = '0.1.0'
+workspace-path = 'storage/storage-proto'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'transaction-builder'
+version = '0.1.0'
+workspace-path = 'language/transaction-builder'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'vm'
+version = '0.1.0'
+workspace-path = 'language/vm'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'anyhow'
+version = '1.0.26'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'arc-swap'
+version = '0.4.4'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bincode'
+version = '1.2.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.3.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'bytes'
+version = '0.5.4'
+crates-io = true
+status = 'direct'
+features = ['default', 'serde', 'std']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'chrono'
+version = '0.4.11'
+crates-io = true
+status = 'direct'
+features = ['clock', 'default', 'std', 'time']
+optional-deps = ['time']
+
+[[target-package]]
+name = 'codespan'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = ['serde', 'serialization']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'codespan-reporting'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'crossbeam'
+version = '0.7.3'
+crates-io = true
+status = 'direct'
+features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
+optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
+
+[[target-package]]
+name = 'curve25519-dalek'
+version = '1.2.3'
+source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
+status = 'direct'
+features = ['alloc', 'std', 'u64_backend']
+
+[[target-package]]
+name = 'difference'
+version = '2.0.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'digest'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['std']
+
+[[target-package]]
+name = 'ed25519-dalek'
+version = '1.0.0-pre.1'
+source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
+status = 'direct'
+features = ['serde', 'std', 'u64_backend']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'env_logger'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.4'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[target-package]]
+name = 'get_if_addrs'
+version = '0.5.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hex'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'hmac'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'hyper'
+version = '0.13.3'
+crates-io = true
+status = 'direct'
+features = ['default', 'net2', 'runtime', 'stream', 'tcp']
+optional-deps = ['net2']
+
+[[target-package]]
+name = 'include_dir'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'itertools'
+version = '0.9.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'libc'
+version = '0.2.67'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'log'
+version = '0.4.8'
+crates-io = true
+status = 'direct'
+features = ['serde', 'std']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'mirai-annotations'
+version = '1.6.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.11'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'once_cell'
+version = '1.3.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'pairing'
+version = '0.14.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'u128-support']
+
+[[target-package]]
+name = 'parity-multiaddr'
+version = '0.7.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'petgraph'
+version = '0.5.0'
+crates-io = true
+status = 'direct'
+features = ['default', 'graphmap', 'matrix_graph', 'stable_graph']
+
+[[target-package]]
+name = 'prettydiff'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'prometheus'
+version = '0.8.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'proptest'
+version = '0.9.5'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[target-package]]
+name = 'prost'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
+
+[[target-package]]
+name = 'radix_trie'
+version = '0.1.6'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.6.5'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
+optional-deps = ['rand_os']
+
+[[target-package]]
+name = 'ref-cast'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.3.4'
+crates-io = true
+status = 'direct'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[target-package]]
+name = 'rocksdb'
+version = '0.3.0'
+source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.104'
+crates-io = true
+status = 'direct'
+features = ['default', 'derive', 'rc', 'serde_derive', 'std']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'serde_json'
+version = '1.0.48'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'sha2'
+version = '0.8.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'static_assertions'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'structopt'
+version = '0.3.11'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'strum'
+version = '0.18.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'thiserror'
+version = '1.0.11'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'threshold_crypto'
+version = '0.3.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tiny-keccak'
+version = '2.0.1'
+crates-io = true
+status = 'direct'
+features = ['default', 'sha3']
+
+[[target-package]]
+name = 'tokio'
+version = '0.2.13'
+crates-io = true
+status = 'direct'
+features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds']
+optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'memchr', 'mio', 'num_cpus', 'slab', 'tokio-macros']
+
+[[target-package]]
+name = 'toml'
+version = '0.5.6'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tonic'
+version = '0.1.1'
+crates-io = true
+status = 'direct'
+features = ['async-trait', 'codegen', 'default', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures', 'transport']
+optional-deps = ['async-trait', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures']
+
+[[target-package]]
+name = 'walkdir'
+version = '2.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'x25519-dalek'
+version = '0.5.2'
+source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
+status = 'direct'
+features = ['std', 'u64_backend']
+
+[[target-package]]
+name = 'aho-corasick'
+version = '0.7.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'arrayref'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'async-stream'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'atty'
+version = '0.2.14'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'backtrace'
+version = '0.3.45'
+crates-io = true
+status = 'transitive'
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
+optional-deps = ['backtrace-sys', 'serde']
+
+[[target-package]]
+name = 'backtrace-sys'
+version = '0.1.33'
+crates-io = true
+status = 'transitive'
+features = ['backtrace-sys']
+
+[[target-package]]
+name = 'base64'
+version = '0.10.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'blake2'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'block-buffer'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'block-padding'
+version = '0.1.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bs58'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'bstr'
+version = '0.2.11'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
+optional-deps = ['lazy_static', 'regex-automata', 'serde']
+
+[[target-package]]
+name = 'byte-tools'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bzip2-sys'
+version = '0.1.8+1.0.8'
+source = 'git+https://github.com/alexcrichton/bzip2-rs.git#461d66916a5e6848e455c6d4fb9a5f70f4617efd'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'c2-chacha'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'c_linked_list'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'cfg-if'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '2.33.0'
+crates-io = true
+status = 'transitive'
+features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
+optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+
+[[target-package]]
+name = 'clear_on_drop'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-channel'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-deque'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'crossbeam-epoch'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crossbeam-queue'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'crossbeam-utils'
+version = '0.7.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crunchy'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'limit_128']
+
+[[target-package]]
+name = 'crypto-mac'
+version = '0.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'csv'
+version = '1.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'csv-core'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'data-encoding'
+version = '2.2.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'dirs'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'either'
+version = '1.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'encode_unicode'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'endian-type'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno'
+version = '0.2.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'failure'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['backtrace', 'default', 'derive', 'failure_derive', 'std']
+optional-deps = ['backtrace', 'failure_derive']
+
+[[target-package]]
+name = 'fake-simd'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fixedbitset'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-executor'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
+
+[[target-package]]
+name = 'generic-array'
+version = '0.12.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.1.14'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'glob'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'h2'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hex_fmt'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'http-body'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'httparse'
+version = '1.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'idna'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'indexmap'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'iovec'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'itoa'
+version = '0.4.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'keccak'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'librocksdb_sys'
+version = '0.1.0'
+source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'libtitan_sys'
+version = '0.0.1'
+source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'libz-sys'
+version = '1.0.25'
+crates-io = true
+status = 'transitive'
+features = ['static']
+
+[[target-package]]
+name = 'lz4-sys'
+version = '1.8.3'
+source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'matches'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'maybe-uninit'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[target-package]]
+name = 'memoffset'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memsec'
+version = '0.5.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'mio'
+version = '0.6.21'
+crates-io = true
+status = 'transitive'
+features = ['default', 'with-deprecated']
+
+[[target-package]]
+name = 'net2'
+version = '0.2.33'
+crates-io = true
+status = 'transitive'
+features = ['default', 'duration']
+
+[[target-package]]
+name = 'nibble_vec'
+version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-integer'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num_cpus'
+version = '1.12.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'opaque-debug'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'parity-multihash'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'percent-encoding'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0-alpha.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'ppv-lite86'
+version = '0.2.6'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'prettytable-rs'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['csv', 'default', 'win_crlf']
+optional-deps = ['csv']
+
+[[target-package]]
+name = 'proc-macro-nested'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'libc', 'std']
+
+[[target-package]]
+name = 'rand'
+version = '0.7.3'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
+optional-deps = ['getrandom_package', 'rand_pcg']
+
+[[target-package]]
+name = 'rand04'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand04_compat'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.5.1'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_hc'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_isaac'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_jitter'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_os'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_pcg'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.8'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.16'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'remove_dir_all'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rustc-demangle'
+version = '0.1.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sha-1'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sha3'
+version = '0.8.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'snappy-sys'
+version = '0.1.0'
+source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'spin'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'structopt'
+version = '0.2.18'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'subtle'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'subtle'
+version = '2.2.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'i128', 'std']
+
+[[target-package]]
+name = 'term'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'textwrap'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'time'
+version = '0.1.42'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tiny-keccak'
+version = '1.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'keccak']
+
+[[target-package]]
+name = 'tokio-util'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = ['codec', 'default']
+
+[[target-package]]
+name = 'tower'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'full', 'log']
+
+[[target-package]]
+name = 'tower-balance'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'log']
+
+[[target-package]]
+name = 'tower-buffer'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['log']
+
+[[target-package]]
+name = 'tower-discover'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-layer'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-limit'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-load'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-load-shed'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-make'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['connect', 'tokio']
+optional-deps = ['tokio']
+
+[[target-package]]
+name = 'tower-ready-cache'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-retry'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-service'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-timeout'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tower-util'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['call-all', 'default', 'futures-util']
+optional-deps = ['futures-util']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.13'
+crates-io = true
+status = 'transitive'
+features = ['attributes', 'default', 'log', 'std', 'tracing-attributes']
+optional-deps = ['log', 'tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['lazy_static', 'std']
+optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'tracing-futures'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'pin-project', 'std', 'std-future']
+optional-deps = ['pin-project']
+
+[[target-package]]
+name = 'try-lock'
+version = '0.2.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'typenum'
+version = '1.11.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-bidi'
+version = '0.3.4'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unicode-normalization'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-segmentation'
+version = '1.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'unicode-width'
+version = '0.1.7'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'unsigned-varint'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'url'
+version = '2.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'vec_map'
+version = '0.8.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'want'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'zstd-sys'
+version = '1.4.15+zstd.1.4.4'
+source = 'git+https://github.com/gyscos/zstd-rs.git#bc874a57298bdb500cdb5aeac5f23878b6480d0b'
+status = 'transitive'
+features = ['default', 'legacy']
 
 [[host-package]]
 name = 'libra-crypto-derive'
@@ -152,129 +1776,10 @@ status = 'workspace'
 features = []
 
 [[host-package]]
-name = 'libra-metrics'
-version = '0.1.0'
-workspace-path = 'common/metrics'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'libra-nibble'
-version = '0.1.0'
-workspace-path = 'common/nibble'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'libra-temppath'
-version = '0.1.0'
-workspace-path = 'common/temppath'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'libra-types'
-version = '0.1.0'
-workspace-path = 'types'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'libradb'
-version = '0.1.0'
-workspace-path = 'storage/libradb'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'move-core-types'
-version = '0.1.0'
-workspace-path = 'language/move-core/types'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'move-ir-types'
-version = '0.1.0'
-workspace-path = 'language/move-ir/types'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'move-lang'
-version = '0.0.1'
-workspace-path = 'language/move-lang'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'move-vm-types'
-version = '0.1.0'
-workspace-path = 'language/move-vm/types'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
 name = 'num-variants'
 version = '0.1.0'
 workspace-path = 'common/num-variants'
 status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'schemadb'
-version = '0.1.0'
-workspace-path = 'storage/schemadb'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'stdlib'
-version = '0.1.0'
-workspace-path = 'language/stdlib'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'storage-proto'
-version = '0.1.0'
-workspace-path = 'storage/storage-proto'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'transaction-builder'
-version = '0.1.0'
-workspace-path = 'language/transaction-builder'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'vm'
-version = '0.1.0'
-workspace-path = 'language/vm'
-status = 'workspace'
-features = ['default']
-
-[[host-package]]
-name = 'anyhow'
-version = '1.0.26'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'arc-swap'
-version = '0.4.4'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'bincode'
-version = '1.2.1'
-crates-io = true
-status = 'direct'
 features = []
 
 [[host-package]]
@@ -286,205 +1791,8 @@ features = ['clap', 'default', 'env_logger', 'log', 'logging', 'runtime', 'which
 optional-deps = ['clap', 'env_logger', 'log', 'which']
 
 [[host-package]]
-name = 'bit-vec'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.3.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'i128', 'std']
-
-[[host-package]]
-name = 'bytes'
-version = '0.5.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'serde', 'std']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'chrono'
-version = '0.4.11'
-crates-io = true
-status = 'direct'
-features = ['clock', 'default', 'std', 'time']
-optional-deps = ['time']
-
-[[host-package]]
-name = 'codespan'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = ['serde', 'serialization']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'codespan-reporting'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'crossbeam'
-version = '0.7.3'
-crates-io = true
-status = 'direct'
-features = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue', 'default', 'std']
-optional-deps = ['crossbeam-channel', 'crossbeam-deque', 'crossbeam-queue']
-
-[[host-package]]
-name = 'curve25519-dalek'
-version = '1.2.3'
-source = 'git+https://github.com/calibra/curve25519-dalek.git?branch=fiat#caa6b9028e90351d939cbee102ce91b1a1ca032b'
-status = 'direct'
-features = ['alloc', 'std', 'u64_backend']
-
-[[host-package]]
-name = 'difference'
-version = '2.0.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'digest'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['std']
-
-[[host-package]]
-name = 'ed25519-dalek'
-version = '1.0.0-pre.1'
-source = 'git+https://github.com/calibra/ed25519-dalek.git?branch=fiat#ecb1d36ade13e719c71ac818942170a2410ae910'
-status = 'direct'
-features = ['serde', 'std', 'u64_backend']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'futures'
-version = '0.3.4'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
-optional-deps = ['futures-executor']
-
-[[host-package]]
-name = 'get_if_addrs'
-version = '0.5.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hex'
-version = '0.4.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'hmac'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'hyper'
-version = '0.13.3'
-crates-io = true
-status = 'direct'
-features = ['default', 'net2', 'runtime', 'stream', 'tcp']
-optional-deps = ['net2']
-
-[[host-package]]
-name = 'include_dir'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'itertools'
-version = '0.9.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'use_std']
-
-[[host-package]]
-name = 'libc'
-version = '0.2.67'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'log'
-version = '0.4.8'
-crates-io = true
-status = 'direct'
-features = ['serde', 'std']
-optional-deps = ['serde']
-
-[[host-package]]
-name = 'mirai-annotations'
-version = '1.6.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
 name = 'num-derive'
 version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.11'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'once_cell'
-version = '1.3.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'pairing'
-version = '0.14.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'u128-support']
-
-[[host-package]]
-name = 'parity-multiaddr'
-version = '0.7.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'petgraph'
-version = '0.5.0'
-crates-io = true
-status = 'direct'
-features = ['default', 'graphmap', 'matrix_graph', 'stable_graph']
-
-[[host-package]]
-name = 'prettydiff'
-version = '0.3.1'
 crates-io = true
 status = 'direct'
 features = []
@@ -497,34 +1805,11 @@ status = 'direct'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'prometheus'
-version = '0.8.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'proptest'
-version = '0.9.5'
-crates-io = true
-status = 'direct'
-features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
-optional-deps = ['bit-set', 'lazy_static', 'quick-error', 'regex-syntax', 'rusty-fork', 'tempfile']
-
-[[host-package]]
 name = 'proptest-derive'
 version = '0.1.2'
 crates-io = true
 status = 'direct'
 features = []
-
-[[host-package]]
-name = 'prost'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'prost-derive']
-optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-build'
@@ -539,86 +1824,6 @@ version = '1.0.3'
 crates-io = true
 status = 'direct'
 features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'radix_trie'
-version = '0.1.6'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'rand'
-version = '0.6.5'
-crates-io = true
-status = 'direct'
-features = ['alloc', 'default', 'i128_support', 'rand_os', 'std']
-optional-deps = ['rand_os']
-
-[[host-package]]
-name = 'ref-cast'
-version = '1.0.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'regex'
-version = '1.3.4'
-crates-io = true
-status = 'direct'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[host-package]]
-name = 'rocksdb'
-version = '0.3.0'
-source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'serde'
-version = '1.0.104'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[host-package]]
-name = 'serde_json'
-version = '1.0.48'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'sha2'
-version = '0.8.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'static_assertions'
-version = '1.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'structopt'
-version = '0.3.11'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[host-package]]
-name = 'strum'
-version = '0.18.0'
-crates-io = true
-status = 'direct'
-features = []
 
 [[host-package]]
 name = 'strum_macros'
@@ -636,83 +1841,11 @@ features = ['clone-impls', 'default', 'derive', 'extra-traits', 'fold', 'full', 
 optional-deps = ['quote']
 
 [[host-package]]
-name = 'tempfile'
-version = '3.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'termcolor'
-version = '1.1.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'thiserror'
-version = '1.0.11'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'threshold_crypto'
-version = '0.3.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tiny-keccak'
-version = '2.0.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'sha3']
-
-[[host-package]]
-name = 'tokio'
-version = '0.2.13'
-crates-io = true
-status = 'direct'
-features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds']
-optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'memchr', 'mio', 'num_cpus', 'slab', 'tokio-macros']
-
-[[host-package]]
-name = 'toml'
-version = '0.5.6'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'tonic'
-version = '0.1.1'
-crates-io = true
-status = 'direct'
-features = ['async-trait', 'codegen', 'default', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures', 'transport']
-optional-deps = ['async-trait', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures']
-
-[[host-package]]
 name = 'tonic-build'
 version = '0.1.1'
 crates-io = true
 status = 'direct'
 features = ['default', 'rustfmt', 'transport']
-
-[[host-package]]
-name = 'walkdir'
-version = '2.3.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
-name = 'x25519-dalek'
-version = '0.5.2'
-source = 'git+https://github.com/calibra/x25519-dalek.git?branch=fiat#8d5b63010f8466d75a4fa2fb95f573092aed5611'
-status = 'direct'
-features = ['std', 'u64_backend']
 
 [[host-package]]
 name = 'aho-corasick'
@@ -722,25 +1855,11 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'ansi_term'
-version = '0.9.0'
+name = 'anyhow'
+version = '1.0.26'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'arrayref'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'async-stream'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['default', 'std']
 
 [[host-package]]
 name = 'async-stream-impl'
@@ -782,8 +1901,8 @@ name = 'backtrace'
 version = '0.3.45'
 crates-io = true
 status = 'transitive'
-features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'serde', 'serialize-serde', 'std']
-optional-deps = ['backtrace-sys', 'serde']
+features = ['backtrace-sys', 'dbghelp', 'default', 'dladdr', 'libbacktrace', 'libunwind', 'std']
+optional-deps = ['backtrace-sys']
 
 [[host-package]]
 name = 'backtrace-sys'
@@ -791,13 +1910,6 @@ version = '0.1.33'
 crates-io = true
 status = 'transitive'
 features = ['backtrace-sys']
-
-[[host-package]]
-name = 'base64'
-version = '0.10.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'bindgen'
@@ -808,20 +1920,6 @@ features = ['clap', 'default', 'env_logger', 'log', 'logging', 'which', 'which-r
 optional-deps = ['clap', 'env_logger', 'log', 'which']
 
 [[host-package]]
-name = 'bit-set'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'bit-vec'
-version = '0.5.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
 name = 'bitflags'
 version = '1.2.1'
 crates-io = true
@@ -829,61 +1927,18 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'blake2'
-version = '0.8.1'
+name = 'byteorder'
+version = '1.3.4'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['i128']
 
 [[host-package]]
-name = 'block-buffer'
-version = '0.7.3'
+name = 'bytes'
+version = '0.5.4'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'block-padding'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bs58'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'bstr'
-version = '0.2.11'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'regex-automata', 'serde', 'serde1', 'serde1-nostd', 'std', 'unicode']
-optional-deps = ['lazy_static', 'regex-automata', 'serde']
-
-[[host-package]]
-name = 'byte-tools'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bzip2-sys'
-version = '0.1.8+1.0.8'
-source = 'git+https://github.com/alexcrichton/bzip2-rs.git#461d66916a5e6848e455c6d4fb9a5f70f4617efd'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'c_linked_list'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['default', 'std']
 
 [[host-package]]
 name = 'cc'
@@ -938,80 +1993,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'crossbeam-channel'
-version = '0.4.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-deque'
-version = '0.7.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'crossbeam-epoch'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crossbeam-queue'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'crossbeam-utils'
-version = '0.7.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'crunchy'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'limit_128']
-
-[[host-package]]
-name = 'crypto-mac'
-version = '0.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'csv'
-version = '1.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'csv-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'data-encoding'
-version = '2.2.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'dirs'
-version = '1.0.5'
+name = 'digest'
+version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1019,20 +2002,6 @@ features = []
 [[host-package]]
 name = 'either'
 version = '1.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'encode_unicode'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'endian-type'
-version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1054,13 +2023,6 @@ features = ['atty', 'default', 'humantime', 'regex', 'termcolor']
 optional-deps = ['atty', 'humantime', 'regex', 'termcolor']
 
 [[host-package]]
-name = 'errno'
-version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'failure'
 version = '0.1.7'
 crates-io = true
@@ -1076,13 +2038,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'fake-simd'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'fixedbitset'
 version = '0.2.0'
 crates-io = true
@@ -1090,69 +2045,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'fnv'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-channel'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'futures-sink', 'sink', 'std']
-optional-deps = ['futures-sink']
-
-[[host-package]]
-name = 'futures-core'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-executor'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'futures-io'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
 name = 'futures-macro'
 version = '0.3.4'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'futures-sink'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'std']
-
-[[host-package]]
-name = 'futures-task'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[host-package]]
-name = 'futures-util'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std']
-optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
 
 [[host-package]]
 name = 'generic-array'
@@ -1176,13 +2073,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'h2'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'heck'
 version = '0.3.1'
 crates-io = true
@@ -1190,43 +2080,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'hex_fmt'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'http-body'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'httparse'
-version = '1.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'humantime'
 version = '1.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'idna'
-version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1246,13 +2101,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'iovec'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'itertools'
 version = '0.8.2'
 crates-io = true
@@ -1260,22 +2108,8 @@ status = 'transitive'
 features = ['default', 'use_std']
 
 [[host-package]]
-name = 'itoa'
-version = '0.4.5'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'jobserver'
 version = '0.1.21'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'keccak'
-version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1295,6 +2129,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'libc'
+version = '0.2.67'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'libloading'
 version = '0.5.2'
 crates-io = true
@@ -1302,46 +2143,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'librocksdb_sys'
-version = '0.1.0'
-source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'libtitan_sys'
-version = '0.0.1'
-source = 'git+https://github.com/tikv/rust-rocksdb.git?rev=72e45c3f3283302c825d53c3cd7154f4cd9e8f5b#72e45c3f3283302c825d53c3cd7154f4cd9e8f5b'
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'libz-sys'
-version = '1.0.25'
+name = 'log'
+version = '0.4.8'
 crates-io = true
 status = 'transitive'
-features = ['static']
-
-[[host-package]]
-name = 'lz4-sys'
-version = '1.8.3'
-source = 'git+https://github.com/busyjay/lz4-rs.git?branch=adjust-build#5a8afe4010c67899fc7af876a58d67fd6269bf81'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'matches'
-version = '0.1.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'maybe-uninit'
-version = '2.0.0'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['std']
 
 [[host-package]]
 name = 'memchr'
@@ -1351,44 +2157,8 @@ status = 'transitive'
 features = ['default', 'std', 'use_std']
 
 [[host-package]]
-name = 'memoffset'
-version = '0.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memsec'
-version = '0.5.7'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom']
-
-[[host-package]]
-name = 'mio'
-version = '0.6.21'
-crates-io = true
-status = 'transitive'
-features = ['default', 'with-deprecated']
-
-[[host-package]]
 name = 'multimap'
 version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'net2'
-version = '0.2.33'
-crates-io = true
-status = 'transitive'
-features = ['default', 'duration']
-
-[[host-package]]
-name = 'nibble_vec'
-version = '0.0.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1401,34 +2171,6 @@ status = 'transitive'
 features = ['alloc', 'default', 'std', 'verbose-errors']
 
 [[host-package]]
-name = 'num-integer'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num_cpus'
-version = '1.12.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'opaque-debug'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'parity-multihash'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'peeking_take_while'
 version = '0.1.2'
 crates-io = true
@@ -1436,22 +2178,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'percent-encoding'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'percent-encoding'
-version = '2.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-project'
-version = '0.4.8'
+name = 'petgraph'
+version = '0.5.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1464,33 +2192,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'pin-project-lite'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-utils'
-version = '0.1.0-alpha.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'pkg-config'
 version = '0.3.17'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'prettytable-rs'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = ['csv', 'default', 'win_crlf']
-optional-deps = ['csv']
 
 [[host-package]]
 name = 'proc-macro-error'
@@ -1514,18 +2220,19 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'proc-macro-nested'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'proc-macro2'
 version = '0.4.30'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'prost'
+version = '0.6.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'prost-derive']
+optional-deps = ['prost-derive']
 
 [[host-package]]
 name = 'prost-derive'
@@ -1557,39 +2264,11 @@ features = ['default', 'proc-macro']
 
 [[host-package]]
 name = 'rand'
-version = '0.4.6'
-crates-io = true
-status = 'transitive'
-features = ['default', 'libc', 'std']
-
-[[host-package]]
-name = 'rand'
 version = '0.7.3'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
-optional-deps = ['getrandom_package', 'rand_pcg']
-
-[[host-package]]
-name = 'rand04'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand04_compat'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'rand_chacha'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package']
 
 [[host-package]]
 name = 'rand_core'
@@ -1614,55 +2293,6 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'rand_hc'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_isaac'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_jitter'
-version = '0.1.4'
-crates-io = true
-status = 'transitive'
-features = ['std']
-
-[[host-package]]
-name = 'rand_os'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_pcg'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_pcg'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rand_xorshift'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ref-cast-impl'
 version = '1.0.0'
 crates-io = true
@@ -1670,18 +2300,19 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'regex-automata'
-version = '0.1.8'
+name = 'regex'
+version = '1.3.4'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
 
 [[host-package]]
 name = 'regex-syntax'
 version = '0.6.16'
 crates-io = true
 status = 'transitive'
-features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[host-package]]
 name = 'remove_dir_all'
@@ -1712,35 +2343,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'rusty-fork'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = ['timeout', 'wait-timeout']
-optional-deps = ['wait-timeout']
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'same-file'
-version = '1.0.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'scopeguard'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'semver'
 version = '0.9.0'
 crates-io = true
@@ -1762,43 +2364,8 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'sha-1'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'sha3'
-version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'shlex'
 version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'smallvec'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'snappy-sys'
-version = '0.1.0'
-source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'spin'
-version = '0.5.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1809,13 +2376,6 @@ version = '0.8.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'structopt'
-version = '0.2.18'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[host-package]]
 name = 'structopt-derive'
@@ -1833,17 +2393,10 @@ features = []
 
 [[host-package]]
 name = 'subtle'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'subtle'
 version = '2.2.2'
 crates-io = true
 status = 'transitive'
-features = ['default', 'i128', 'std']
+features = ['std']
 
 [[host-package]]
 name = 'syn'
@@ -1868,11 +2421,18 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'term'
-version = '0.5.2'
+name = 'tempfile'
+version = '3.1.0'
 crates-io = true
 status = 'transitive'
-features = ['default']
+features = []
+
+[[host-package]]
+name = 'termcolor'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'textwrap'
@@ -1896,140 +2456,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'time'
-version = '0.1.42'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tiny-keccak'
-version = '1.5.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'keccak']
-
-[[host-package]]
 name = 'tokio-macros'
 version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'tokio-util'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = ['codec', 'default']
-
-[[host-package]]
-name = 'tower'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'full', 'log']
-
-[[host-package]]
-name = 'tower-balance'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'log']
-
-[[host-package]]
-name = 'tower-buffer'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['log']
-
-[[host-package]]
-name = 'tower-discover'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-layer'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-limit'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-load'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-load-shed'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-make'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['connect', 'tokio']
-optional-deps = ['tokio']
-
-[[host-package]]
-name = 'tower-ready-cache'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-retry'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-service'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-timeout'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tower-util'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = ['call-all', 'default', 'futures-util']
-optional-deps = ['futures-util']
-
-[[host-package]]
-name = 'tracing'
-version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = ['attributes', 'default', 'log', 'std', 'tracing-attributes']
-optional-deps = ['log', 'tracing-attributes']
 
 [[host-package]]
 name = 'tracing-attributes'
@@ -2039,45 +2470,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'tracing-core'
-version = '0.1.10'
-crates-io = true
-status = 'transitive'
-features = ['lazy_static', 'std']
-optional-deps = ['lazy_static']
-
-[[host-package]]
-name = 'tracing-futures'
-version = '0.2.3'
-crates-io = true
-status = 'transitive'
-features = ['default', 'pin-project', 'std', 'std-future']
-optional-deps = ['pin-project']
-
-[[host-package]]
-name = 'try-lock'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'typenum'
 version = '1.11.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'unicode-bidi'
-version = '0.3.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'unicode-normalization'
-version = '0.1.12'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2111,20 +2505,6 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'unsigned-varint'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'url'
-version = '2.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'vec_map'
 version = '0.8.1'
 crates-io = true
@@ -2146,29 +2526,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'wait-timeout'
-version = '0.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'want'
-version = '0.3.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'which'
 version = '3.1.0'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'zstd-sys'
-version = '1.4.15+zstd.1.4.4'
-source = 'git+https://github.com/gyscos/zstd-rs.git#bc874a57298bdb500cdb5aeac5f23878b6480d0b'
-status = 'transitive'
-features = ['default', 'legacy']

--- a/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
@@ -2,19 +2,30 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_libra_f0091a4
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-unknown-linux-gnu'
-target-features = 'unknown'
+triple = 'sparcv9-sun-solaris'
+target-features = 'all'
+flags = ['test-flag']
 
 [metadata.target-platform]
 spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'num-complex'
-version = '0.2.4'
+name = 'filecheck'
+version = '0.4.0'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'rental'
+version = '0.5.5'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'typed-arena'
+version = '2.0.1'
 crates-io = true
 
 [[target-package]]
@@ -578,13 +589,6 @@ features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa
 optional-deps = ['aho-corasick', 'memchr', 'thread_local']
 
 [[target-package]]
-name = 'rental'
-version = '0.5.5'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'rocksdb'
 version = '0.3.0'
 source = 'git+https://github.com/pingcap/rust-rocksdb.git?rev=3cd18c44d160a3cdba586d6502d51b7cc67efc59#3cd18c44d160a3cdba586d6502d51b7cc67efc59'
@@ -703,15 +707,15 @@ name = 'tokio'
 version = '0.2.11'
 crates-io = true
 status = 'direct'
-features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds', 'winapi']
-optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'libc', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'num_cpus', 'signal-hook-registry', 'slab', 'tokio-macros', 'winapi']
+features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds']
+optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'memchr', 'mio', 'num_cpus', 'slab', 'tokio-macros']
 
 [[target-package]]
 name = 'toml'
 version = '0.5.6'
 crates-io = true
 status = 'direct'
-features = ['default']
+features = []
 
 [[target-package]]
 name = 'tonic'
@@ -720,13 +724,6 @@ crates-io = true
 status = 'direct'
 features = ['async-trait', 'codegen', 'default', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures', 'transport']
 optional-deps = ['async-trait', 'hyper', 'prost', 'prost-derive', 'tokio', 'tower', 'tower-balance', 'tower-load', 'tracing-futures']
-
-[[target-package]]
-name = 'typed-arena'
-version = '2.0.1'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'walkdir'
@@ -867,7 +864,7 @@ version = '2.33.0'
 crates-io = true
 status = 'transitive'
 features = ['ansi_term', 'atty', 'color', 'default', 'strsim', 'suggestions', 'vec_map']
-optional-deps = ['ansi_term', 'atty', 'strsim', 'vec_map']
+optional-deps = ['atty', 'strsim', 'vec_map']
 
 [[target-package]]
 name = 'clear_on_drop'
@@ -1231,7 +1228,7 @@ version = '0.5.7'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc', 'mach_o_sys', 'winapi']
+optional-deps = ['getrandom']
 
 [[target-package]]
 name = 'mio'
@@ -1359,7 +1356,6 @@ version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'libc', 'std']
-optional-deps = ['libc']
 
 [[target-package]]
 name = 'rand'
@@ -1367,7 +1363,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
-optional-deps = ['getrandom_package', 'libc', 'rand_pcg']
+optional-deps = ['getrandom_package', 'rand_pcg']
 
 [[target-package]]
 name = 'rand04'
@@ -1941,7 +1937,7 @@ name = 'syn'
 version = '1.0.14'
 crates-io = true
 status = 'direct'
-features = ['clone-impls', 'default', 'derive', 'extra-traits', 'fold', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit', 'visit-mut']
 optional-deps = ['quote']
 
 [[host-package]]
@@ -1991,7 +1987,7 @@ name = 'byteorder'
 version = '1.3.4'
 crates-io = true
 status = 'transitive'
-features = ['default', 'i128', 'std']
+features = ['i128']
 
 [[host-package]]
 name = 'bytes'
@@ -2048,7 +2044,7 @@ name = 'digest'
 version = '0.8.1'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = []
 
 [[host-package]]
 name = 'either'
@@ -2139,7 +2135,7 @@ name = 'log'
 version = '0.4.8'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = []
 
 [[host-package]]
 name = 'multimap'
@@ -2160,7 +2156,7 @@ name = 'petgraph'
 version = '0.5.0'
 crates-io = true
 status = 'transitive'
-features = ['default', 'graphmap', 'matrix_graph', 'stable_graph']
+features = []
 
 [[host-package]]
 name = 'pin-project-internal'
@@ -2252,8 +2248,8 @@ name = 'rand'
 version = '0.7.3'
 crates-io = true
 status = 'transitive'
-features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
-optional-deps = ['getrandom_package', 'libc', 'rand_pcg']
+features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
+optional-deps = ['getrandom_package', 'libc']
 
 [[host-package]]
 name = 'rand_chacha'
@@ -2285,13 +2281,6 @@ features = ['alloc', 'getrandom', 'std']
 optional-deps = ['getrandom']
 
 [[host-package]]
-name = 'rand_pcg'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'ref-cast-impl'
 version = '1.0.0'
 crates-io = true
@@ -2301,13 +2290,6 @@ features = []
 [[host-package]]
 name = 'remove_dir_all'
 version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'rental-impl'
-version = '0.5.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2345,8 +2327,7 @@ name = 'serde'
 version = '1.0.104'
 crates-io = true
 status = 'transitive'
-features = ['default', 'derive', 'rc', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
+features = ['default', 'std']
 
 [[host-package]]
 name = 'serde_derive'

--- a/fixtures/large/summaries/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-0.toml
@@ -2,19 +2,32 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
 
 [metadata]
-resolver = 'install'
-include-dev = false
-initials-platform = 'host'
+resolver = '2'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'powerpc64-unknown-linux-musl'
+target-features = 'unknown'
+flags = ['foo']
 
 [metadata.target-platform]
-triple = 'riscv32em-unknown-none-elf'
+triple = 'i686-uwp-windows-gnu'
 target-features = 'unknown'
+flags = ['bar']
 [[metadata.omitted-packages.ids]]
-name = 'rand'
-version = '0.8.5'
+name = 'p384'
+version = '0.13.0'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'terminal_size'
+version = '0.1.17'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'vte_generate_state_changes'
+version = '0.1.1'
 crates-io = true
 
 [[metadata.features-only]]
@@ -29,6 +42,647 @@ version = '0.1.0'
 workspace-path = 'platforms/x86_64/bootloader'
 features = []
 
+[[target-package]]
+name = 'forth3'
+version = '0.1.0'
+workspace-path = 'source/forth3'
+status = 'initial'
+features = ['async', 'default']
+
+[[target-package]]
+name = 'manganese'
+version = '0.1.0'
+workspace-path = 'tools/manganese'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-alloc'
+version = '0.1.0'
+workspace-path = 'source/alloc'
+status = 'initial'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-x86_64-bootloader'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/bootloader'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos-x86_64-core'
+version = '0.1.0'
+workspace-path = 'platforms/x86_64/core'
+status = 'initial'
+features = []
+
+[[target-package]]
+name = 'mnemos'
+version = '0.1.0'
+workspace-path = 'source/kernel'
+status = 'workspace'
+features = ['mnemos-trace-proto', 'serial-trace', 'tracing-core', 'tracing-serde-structured']
+optional-deps = ['mnemos-trace-proto', 'tracing-core', 'tracing-serde-structured']
+
+[[target-package]]
+name = 'mnemos-abi'
+version = '0.1.0'
+workspace-path = 'source/abi'
+status = 'workspace'
+features = ['default']
+
+[[target-package]]
+name = 'mnemos-trace-proto'
+version = '0.1.0'
+workspace-path = 'source/trace-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'sermux-proto'
+version = '0.1.0'
+workspace-path = 'source/sermux-proto'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'spitebuf'
+version = '0.1.0'
+workspace-path = 'source/spitebuf'
+status = 'workspace'
+features = []
+
+[[target-package]]
+name = 'acpi'
+version = '4.1.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'anyhow'
+version = '1.0.71'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'cfg-if'
+version = '1.0.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'clap'
+version = '4.4.0'
+crates-io = true
+status = 'direct'
+features = ['color', 'default', 'derive', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['clap_derive', 'once_cell']
+
+[[target-package]]
+name = 'cobs'
+version = '0.2.3'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'embedded-graphics'
+version = '0.7.1'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal-async'
+version = '0.2.0-alpha.2'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'futures'
+version = '0.3.28'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'async-await', 'default', 'executor', 'futures-executor', 'std']
+optional-deps = ['futures-executor']
+
+[[target-package]]
+name = 'hal-core'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['embedded-graphics-core']
+optional-deps = ['embedded-graphics-core']
+
+[[target-package]]
+name = 'hal-x86_64'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['alloc', 'default']
+
+[[target-package]]
+name = 'hash32'
+version = '0.3.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'heapless'
+version = '0.7.16'
+crates-io = true
+status = 'direct'
+features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
+optional-deps = ['defmt', 'serde']
+
+[[target-package]]
+name = 'input-mgr'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'linked_list_allocator'
+version = '0.10.5'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'maitake'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['alloc']
+
+[[target-package]]
+name = 'mycelium-alloc'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['buddy', 'bump', 'hal-core', 'mycelium-util', 'tracing']
+optional-deps = ['hal-core', 'mycelium-util', 'tracing']
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'mycelium-util'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'ovmf-prebuilt'
+version = '0.1.0-alpha.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'portable-atomic'
+version = '1.4.2'
+crates-io = true
+status = 'direct'
+features = ['default', 'fallback', 'require-cas']
+
+[[target-package]]
+name = 'postcard'
+version = '1.0.6'
+crates-io = true
+status = 'direct'
+features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
+optional-deps = ['const_format', 'heapless', 'postcard-derive']
+
+[[target-package]]
+name = 'profont'
+version = '0.6.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'ring-drawer'
+version = '0.1.0'
+source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
+status = 'direct'
+features = ['default']
+
+[[target-package]]
+name = 'serde'
+version = '1.0.188'
+crates-io = true
+status = 'direct'
+features = ['derive', 'serde_derive']
+optional-deps = ['serde_derive']
+
+[[target-package]]
+name = 'tracing'
+version = '0.1.37'
+crates-io = true
+status = 'direct'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'uuid'
+version = '1.4.1'
+crates-io = true
+status = 'direct'
+features = ['serde']
+optional-deps = ['serde']
+
+[[target-package]]
+name = 'anstream'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = ['auto', 'default', 'wincon']
+optional-deps = ['anstyle-query', 'anstyle-wincon', 'colorchoice']
+
+[[target-package]]
+name = 'anstyle'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'anstyle-parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'utf8']
+optional-deps = ['utf8parse']
+
+[[target-package]]
+name = 'anstyle-query'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'anstyle-wincon'
+version = '2.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'clap_builder'
+version = '4.4.0'
+crates-io = true
+status = 'transitive'
+features = ['color', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
+optional-deps = ['anstream', 'strsim']
+
+[[target-package]]
+name = 'clap_lex'
+version = '0.5.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'colorchoice'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'cordyceps'
+version = '0.3.2'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'futures-sink', 'sink', 'std']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-executor'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'io', 'memchr', 'sink', 'slab', 'std']
+optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'slab']
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mycelium-bitfield'
+version = '0.1.3'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'mycelium-trace'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = ['default', 'embedded-graphics']
+optional-deps = ['embedded-graphics']
+
+[[target-package]]
+name = 'mycotest'
+version = '0.1.0'
+source = 'git+https://github.com/hawkw/mycelium#1f125194902cd4970b72eab0aa1d85d1b6ec1489'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'once_cell'
+version = '1.18.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'raw-cpuid'
+version = '10.7.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rsdp'
+version = '2.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'strsim'
+version = '0.10.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'utf8parse'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'volatile'
+version = '0.4.6'
+crates-io = true
+status = 'transitive'
+features = ['unstable']
+
+[[target-package]]
+name = 'windows-sys'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Console', 'default']
+
+[[target-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
 [[host-package]]
 name = 'forth3'
 version = '0.1.0'
@@ -37,25 +691,11 @@ status = 'initial'
 features = ['async', 'default']
 
 [[host-package]]
-name = 'manganese'
-version = '0.1.0'
-workspace-path = 'tools/manganese'
-status = 'initial'
-features = []
-
-[[host-package]]
 name = 'mnemos-alloc'
 version = '0.1.0'
 workspace-path = 'source/alloc'
 status = 'initial'
 features = ['default']
-
-[[host-package]]
-name = 'mnemos-x86_64-bootloader'
-version = '0.1.0'
-workspace-path = 'platforms/x86_64/bootloader'
-status = 'initial'
-features = []
 
 [[host-package]]
 name = 'mnemos-x86_64-core'
@@ -138,14 +778,6 @@ status = 'direct'
 features = []
 
 [[host-package]]
-name = 'clap'
-version = '4.4.0'
-crates-io = true
-status = 'direct'
-features = ['color', 'default', 'derive', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
-optional-deps = ['clap_derive', 'once_cell']
-
-[[host-package]]
 name = 'cobs'
 version = '0.2.3'
 crates-io = true
@@ -209,7 +841,7 @@ version = '0.7.16'
 crates-io = true
 status = 'direct'
 features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+optional-deps = ['defmt', 'serde']
 
 [[host-package]]
 name = 'input-mgr'
@@ -262,13 +894,6 @@ status = 'direct'
 features = ['default']
 
 [[host-package]]
-name = 'ovmf-prebuilt'
-version = '0.1.0-alpha.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[host-package]]
 name = 'portable-atomic'
 version = '1.4.2'
 crates-io = true
@@ -310,7 +935,7 @@ name = 'tracing'
 version = '0.1.37'
 crates-io = true
 status = 'direct'
-features = ['attributes', 'default', 'std', 'tracing-attributes']
+features = ['attributes', 'tracing-attributes']
 optional-deps = ['tracing-attributes']
 
 [[host-package]]
@@ -318,8 +943,7 @@ name = 'tracing-core'
 version = '0.1.31'
 crates-io = true
 status = 'direct'
-features = ['default', 'once_cell', 'std', 'valuable']
-optional-deps = ['once_cell', 'valuable']
+features = []
 
 [[host-package]]
 name = 'tracing-serde-structured'
@@ -345,31 +969,8 @@ features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time'
 optional-deps = ['rustc_version', 'time']
 
 [[host-package]]
-name = 'anstream'
-version = '0.5.0'
-crates-io = true
-status = 'transitive'
-features = ['auto', 'default', 'wincon']
-optional-deps = ['anstyle-query', 'anstyle-wincon', 'colorchoice']
-
-[[host-package]]
-name = 'anstyle'
-version = '1.0.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'anstyle-parse'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'utf8']
-optional-deps = ['utf8parse']
-
-[[host-package]]
-name = 'anstyle-query'
-version = '1.0.0'
+name = 'async-io'
+version = '1.13.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -452,14 +1053,6 @@ status = 'transitive'
 features = ['std']
 
 [[host-package]]
-name = 'clap_builder'
-version = '4.4.0'
-crates-io = true
-status = 'transitive'
-features = ['color', 'env', 'error-context', 'help', 'std', 'suggestions', 'usage']
-optional-deps = ['anstream', 'strsim']
-
-[[host-package]]
 name = 'clap_derive'
 version = '4.4.0'
 crates-io = true
@@ -467,18 +1060,11 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'clap_lex'
-version = '0.5.0'
+name = 'concurrent-queue'
+version = '2.2.0'
 crates-io = true
 status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'colorchoice'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
+features = ['default', 'std']
 
 [[host-package]]
 name = 'const_format'
@@ -516,6 +1102,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'crossbeam-utils'
+version = '0.8.16'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'defmt'
 version = '0.3.5'
 crates-io = true
@@ -546,6 +1139,13 @@ features = ['default']
 [[host-package]]
 name = 'embedded-hal'
 version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -688,11 +1288,33 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'io-lifetimes'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = ['close', 'hermit-abi', 'libc', 'windows-sys']
+optional-deps = ['libc']
+
+[[host-package]]
 name = 'itoa'
 version = '1.0.6'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[host-package]]
+name = 'linux-raw-sys'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['general', 'ioctl', 'no_std']
 
 [[host-package]]
 name = 'llvm-tools'
@@ -706,7 +1328,7 @@ name = 'log'
 version = '0.4.20'
 crates-io = true
 status = 'transitive'
-features = ['std']
+features = []
 
 [[host-package]]
 name = 'mbrman'
@@ -759,13 +1381,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'once_cell'
-version = '1.18.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[host-package]]
 name = 'parking'
 version = '2.1.0'
 crates-io = true
@@ -799,6 +1414,13 @@ version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'polling'
+version = '2.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'postcard-derive'
@@ -865,6 +1487,14 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'rustix'
+version = '0.37.20'
+crates-io = true
+status = 'transitive'
+features = ['default', 'fs', 'io-lifetimes', 'libc', 'std', 'use-libc-auxv']
+optional-deps = ['io-lifetimes', 'libc']
+
+[[host-package]]
 name = 'rustversion'
 version = '1.0.12'
 crates-io = true
@@ -907,6 +1537,20 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
+name = 'signal-hook'
+version = '0.3.17'
+crates-io = true
+status = 'transitive'
+features = ['channel', 'iterator']
+
+[[host-package]]
+name = 'signal-hook-registry'
+version = '1.4.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'slab'
 version = '0.4.8'
 crates-io = true
@@ -914,15 +1558,15 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[host-package]]
-name = 'stable_deref_trait'
-version = '1.2.0'
+name = 'socket2'
+version = '0.4.9'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['all']
 
 [[host-package]]
-name = 'strsim'
-version = '0.10.0'
+name = 'stable_deref_trait'
+version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1025,13 +1669,6 @@ features = []
 [[host-package]]
 name = 'unicode-xid'
 version = '0.2.4'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'utf8parse'
-version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = ['default']

--- a/fixtures/large/summaries/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-1.toml
@@ -2,87 +2,86 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
 
 [metadata]
-resolver = 'install'
-include-dev = false
-initials-platform = 'host'
+resolver = '2'
+include-dev = true
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'aarch64-pc-windows-gnullvm'
-target-features = ['bmi1', 'bmi2', 'sse2', 'sse4.2', 'xsaveopt', 'xsaves']
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-linux-gnu'
-target-features = ['bmi2', 'ssse3']
-flags = ['flag-test']
+triple = 'riscv32imac-esp-espidf'
+target-features = 'unknown'
+flags = ['foo']
 [[metadata.omitted-packages.ids]]
-name = 'gcd'
-version = '2.3.0'
+name = 'hkdf'
+version = '0.12.3'
 crates-io = true
 
-[[host-package]]
+[[target-package]]
 name = 'f3repl'
 version = '0.1.0'
 workspace-path = 'tools/f3repl'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'mnemos-beepy'
 version = '0.1.0'
 workspace-path = 'platforms/beepy'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'mnemos-config'
 version = '0.1.0'
 workspace-path = 'source/config'
 status = 'initial'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'forth3'
 version = '0.1.0'
 workspace-path = 'source/forth3'
 status = 'workspace'
 features = ['async', 'default', 'use-std']
 
-[[host-package]]
+[[target-package]]
 name = 'mnemos'
 version = '0.1.0'
 workspace-path = 'source/kernel'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'mnemos-abi'
 version = '0.1.0'
 workspace-path = 'source/abi'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'mnemos-alloc'
 version = '0.1.0'
 workspace-path = 'source/alloc'
 status = 'workspace'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'sermux-proto'
 version = '0.1.0'
 workspace-path = 'source/sermux-proto'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'spitebuf'
 version = '0.1.0'
 workspace-path = 'source/spitebuf'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'bbq10kbd'
 version = '0.1.0'
 source = 'git+https://github.com/hawkw/bbq10kbd?branch=eliza/async#d2365be8726e9320b0e4ab626043c1a8a41246f8'
@@ -90,106 +89,106 @@ status = 'direct'
 features = ['embedded-hal-async']
 optional-deps = ['embedded-hal-async']
 
-[[host-package]]
+[[target-package]]
 name = 'cfg-if'
 version = '1.0.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cobs'
 version = '0.2.3'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'cordyceps'
 version = '0.3.2'
 source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
 status = 'direct'
 features = ['alloc', 'default']
 
-[[host-package]]
+[[target-package]]
 name = 'embedded-graphics'
 version = '0.7.1'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'embedded-hal-async'
 version = '0.2.0-alpha.2'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'futures'
 version = '0.3.28'
 crates-io = true
 status = 'direct'
 features = ['async-await']
 
-[[host-package]]
+[[target-package]]
 name = 'hash32'
 version = '0.3.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'heapless'
 version = '0.7.16'
 crates-io = true
 status = 'direct'
 features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+optional-deps = ['defmt', 'serde']
 
-[[host-package]]
+[[target-package]]
 name = 'input-mgr'
 version = '0.1.0'
 source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'linked_list_allocator'
 version = '0.10.5'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'maitake'
 version = '0.1.0'
 source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
 status = 'direct'
 features = ['alloc']
 
-[[host-package]]
+[[target-package]]
 name = 'mycelium-bitfield'
 version = '0.1.3'
 source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'mycelium-util'
 version = '0.1.0'
 source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'portable-atomic'
 version = '1.4.2'
 crates-io = true
 status = 'direct'
 features = ['default', 'fallback', 'require-cas']
 
-[[host-package]]
+[[target-package]]
 name = 'postcard'
 version = '1.0.6'
 crates-io = true
@@ -197,21 +196,21 @@ status = 'direct'
 features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
 optional-deps = ['const_format', 'heapless', 'postcard-derive']
 
-[[host-package]]
+[[target-package]]
 name = 'profont'
 version = '0.6.1'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'ring-drawer'
 version = '0.1.0'
 source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'serde'
 version = '1.0.188'
 crates-io = true
@@ -219,21 +218,221 @@ status = 'direct'
 features = ['derive', 'serde_derive']
 optional-deps = ['serde_derive']
 
-[[host-package]]
+[[target-package]]
 name = 'tracing'
 version = '0.1.37'
 crates-io = true
 status = 'direct'
-features = ['attributes', 'default', 'std', 'tracing-attributes']
+features = ['attributes', 'tracing-attributes']
 optional-deps = ['tracing-attributes']
 
-[[host-package]]
+[[target-package]]
 name = 'uuid'
 version = '1.4.1'
 crates-io = true
 status = 'direct'
 features = ['serde']
 optional-deps = ['serde']
+
+[[target-package]]
+name = 'az'
+version = '1.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'bitflags'
+version = '1.3.2'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'byteorder'
+version = '1.4.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'const_format'
+version = '0.2.31'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'defmt'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-graphics-core'
+version = '0.3.3'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'embedded-hal'
+version = '1.0.0-alpha.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'float-cmp'
+version = '0.8.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'num-traits', 'ratio']
+optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'futures-channel'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['futures-sink', 'sink']
+optional-deps = ['futures-sink']
+
+[[target-package]]
+name = 'futures-core'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-io'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-sink'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-task'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'futures-util'
+version = '0.3.28'
+crates-io = true
+status = 'transitive'
+features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
+optional-deps = ['futures-macro', 'futures-sink']
+
+[[target-package]]
+name = 'hash32'
+version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'micromath'
+version = '1.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nb'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'num-traits'
+version = '0.2.15'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-project-lite'
+version = '0.2.13'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'pin-utils'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'stable_deref_trait'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = ['attributes', 'tracing-attributes']
+optional-deps = ['tracing-attributes']
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tracing-core'
+version = '0.2.0'
+source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'vergen'
@@ -258,46 +457,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'az'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'bitflags'
-version = '1.3.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'byteorder'
-version = '1.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'const_format'
-version = '0.2.31'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
 name = 'const_format_proc_macros'
 version = '0.2.31'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'defmt'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'defmt-macros'
@@ -314,88 +478,8 @@ status = 'transitive'
 features = ['unstable']
 
 [[host-package]]
-name = 'embedded-graphics-core'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[host-package]]
-name = 'embedded-hal'
-version = '0.2.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'embedded-hal'
-version = '1.0.0-alpha.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'float-cmp'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'num-traits', 'ratio']
-optional-deps = ['num-traits']
-
-[[host-package]]
-name = 'futures-channel'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = ['futures-sink', 'sink']
-optional-deps = ['futures-sink']
-
-[[host-package]]
-name = 'futures-core'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-io'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'futures-macro'
 version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-sink'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-task'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'futures-util'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
-optional-deps = ['futures-macro', 'futures-sink']
-
-[[host-package]]
-name = 'hash32'
-version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -408,64 +492,8 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'micromath'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'nb'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'nb'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'num-traits'
-version = '0.2.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'once_cell'
-version = '1.18.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'race', 'std']
-
-[[host-package]]
-name = 'pin-project'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'pin-project-internal'
 version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-project-lite'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pin-utils'
-version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -535,13 +563,6 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
-name = 'stable_deref_trait'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'syn'
 version = '1.0.109'
 crates-io = true
@@ -587,14 +608,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'tracing'
-version = '0.2.0'
-source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
-status = 'transitive'
-features = ['attributes', 'tracing-attributes']
-optional-deps = ['tracing-attributes']
-
-[[host-package]]
 name = 'tracing-attributes'
 version = '0.1.26'
 crates-io = true
@@ -603,21 +616,6 @@ features = []
 
 [[host-package]]
 name = 'tracing-attributes'
-version = '0.2.0'
-source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tracing-core'
-version = '0.1.31'
-crates-io = true
-status = 'transitive'
-features = ['default', 'once_cell', 'std', 'valuable']
-optional-deps = ['once_cell', 'valuable']
-
-[[host-package]]
-name = 'tracing-core'
 version = '0.2.0'
 source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
 status = 'transitive'
@@ -640,13 +638,6 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'void'
-version = '1.0.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-4.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-4.toml
@@ -2,26 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'armv7a-kmc-solid_asp3-eabi'
+target-features = ['avx', 'bmi2', 'rdrand']
+flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-triple = 'i686-linux-android'
-target-features = ['xsave']
-flags = ['foo']
-[[metadata.omitted-packages.ids]]
-name = 'mnemos-x86_64-bootloader'
-version = '0.1.0'
-workspace-path = 'platforms/x86_64/bootloader'
-
-[[metadata.omitted-packages.ids]]
-name = 'windows_i686_gnu'
-version = '0.42.2'
-crates-io = true
+spec = 'any'
 
 [[metadata.features-only]]
 name = 'mnemos-config'
@@ -226,11 +217,33 @@ status = 'direct'
 features = []
 
 [[target-package]]
+name = 'proptest'
+version = '1.2.0'
+crates-io = true
+status = 'direct'
+features = ['bit-set', 'break-dead-code', 'default', 'fork', 'lazy_static', 'regex-syntax', 'rusty-fork', 'std', 'tempfile', 'timeout']
+optional-deps = ['bit-set', 'lazy_static', 'regex-syntax', 'rusty-fork', 'tempfile']
+
+[[target-package]]
 name = 'ring-drawer'
 version = '0.1.0'
 source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
 status = 'direct'
 features = ['default']
+
+[[target-package]]
+name = 'riscv'
+version = '0.10.1'
+crates-io = true
+status = 'direct'
+features = []
+
+[[target-package]]
+name = 'riscv-rt'
+version = '0.11.0'
+crates-io = true
+status = 'direct'
+features = []
 
 [[target-package]]
 name = 'serde'
@@ -257,6 +270,13 @@ features = ['serde']
 optional-deps = ['serde']
 
 [[target-package]]
+name = 'atomic-polyfill'
+version = '0.1.11'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'az'
 version = '1.2.1'
 crates-io = true
@@ -269,6 +289,20 @@ version = '1.0.0'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'bit-set'
+version = '0.5.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bit-vec'
+version = '0.6.3'
+crates-io = true
+status = 'transitive'
+features = ['std']
 
 [[target-package]]
 name = 'bit_field'
@@ -289,7 +323,7 @@ name = 'byteorder'
 version = '1.4.3'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['std']
 
 [[target-package]]
 name = 'const_format'
@@ -327,12 +361,40 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'errno'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'errno-dragonfly'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'fastrand'
+version = '1.9.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'float-cmp'
 version = '0.8.0'
 crates-io = true
 status = 'transitive'
 features = ['default', 'num-traits', 'ratio']
 optional-deps = ['num-traits']
+
+[[target-package]]
+name = 'fnv'
+version = '1.0.7'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'futures-channel'
@@ -379,8 +441,100 @@ features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink',
 optional-deps = ['futures-macro', 'futures-sink']
 
 [[target-package]]
+name = 'generator'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'getrandom'
+version = '0.2.10'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
 name = 'hash32'
 version = '0.2.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'hermit-abi'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'instant'
+version = '0.1.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'io-lifetimes'
+version = '1.0.11'
+crates-io = true
+status = 'transitive'
+features = ['close', 'hermit-abi', 'libc', 'windows-sys']
+optional-deps = ['hermit-abi', 'libc', 'windows-sys']
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[target-package]]
+name = 'libm'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'linux-raw-sys'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['errno', 'general', 'ioctl', 'no_std']
+
+[[target-package]]
+name = 'lock_api'
+version = '0.4.10'
+crates-io = true
+status = 'transitive'
+features = ['atomic_usize', 'default']
+
+[[target-package]]
+name = 'log'
+version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'loom'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[target-package]]
+name = 'matchers'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -407,11 +561,19 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'nu-ansi-term'
+version = '0.46.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'num-traits'
 version = '0.2.15'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['libm', 'std']
+optional-deps = ['libm']
 
 [[target-package]]
 name = 'once_cell'
@@ -419,6 +581,13 @@ version = '1.18.0'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'race', 'std']
+
+[[target-package]]
+name = 'overload'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'pin-project'
@@ -442,15 +611,169 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'riscv'
-version = '0.10.1'
+name = 'ppv-lite86'
+version = '0.2.17'
+crates-io = true
+status = 'transitive'
+features = ['simd', 'std']
+
+[[target-package]]
+name = 'quick-error'
+version = '1.2.3'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'r0'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'rand'
+version = '0.8.5'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'libc', 'rand_chacha', 'std']
+optional-deps = ['libc', 'rand_chacha']
+
+[[target-package]]
+name = 'rand_chacha'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[target-package]]
+name = 'rand_core'
+version = '0.6.4'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'getrandom', 'std']
+optional-deps = ['getrandom']
+
+[[target-package]]
+name = 'rand_xorshift'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'redox_syscall'
+version = '0.3.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'regex-syntax', 'std']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'meta', 'nfa-pikevm', 'nfa-thompson', 'std', 'syntax', 'unicode-case', 'unicode-perl', 'unicode-word-boundary']
+optional-deps = ['regex-syntax']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.29'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[target-package]]
+name = 'rustix'
+version = '0.37.20'
+crates-io = true
+status = 'transitive'
+features = ['default', 'fs', 'io-lifetimes', 'libc', 'std', 'use-libc-auxv']
+optional-deps = ['io-lifetimes', 'libc']
+
+[[target-package]]
+name = 'rusty-fork'
+version = '0.3.0'
+crates-io = true
+status = 'transitive'
+features = ['timeout', 'wait-timeout']
+optional-deps = ['wait-timeout']
+
+[[target-package]]
+name = 'scoped-tls'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'scopeguard'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'sharded-slab'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'smallvec'
+version = '1.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'spin'
+version = '0.9.8'
+crates-io = true
+status = 'transitive'
+features = ['barrier', 'default', 'lazy', 'lock_api', 'lock_api_crate', 'mutex', 'once', 'rwlock', 'spin_mutex']
+optional-deps = ['lock_api_crate']
+
+[[target-package]]
 name = 'stable_deref_trait'
 version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tempfile'
+version = '3.6.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '1.1.7'
 crates-io = true
 status = 'transitive'
 features = []
@@ -479,6 +802,35 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'tracing-log'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = ['log-tracer', 'std']
+
+[[target-package]]
+name = 'tracing-subscriber'
+version = '0.3.17'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'ansi', 'default', 'env-filter', 'fmt', 'matchers', 'nu-ansi-term', 'once_cell', 'regex', 'registry', 'sharded-slab', 'smallvec', 'std', 'thread_local', 'tracing', 'tracing-log']
+optional-deps = ['matchers', 'nu-ansi-term', 'once_cell', 'regex', 'sharded-slab', 'smallvec', 'thread_local', 'tracing', 'tracing-log']
+
+[[target-package]]
+name = 'unarray'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'valuable'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
+
+[[target-package]]
 name = 'vcell'
 version = '0.1.3'
 crates-io = true
@@ -492,6 +844,118 @@ crates-io = true
 status = 'transitive'
 features = []
 
+[[target-package]]
+name = 'wait-timeout'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'wasi'
+version = '0.11.0+wasi-snapshot-preview1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.9'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'processenv']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_Memory', 'Win32_System_SystemInformation', 'default']
+
+[[target-package]]
+name = 'windows-sys'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_NetworkManagement', 'Win32_NetworkManagement_IpHelper', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_IO', 'Win32_System_Threading', 'default']
+
+[[target-package]]
+name = 'windows-targets'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_aarch64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'windows_x86_64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'proptest-derive'
+version = '0.4.0'
+crates-io = true
+status = 'direct'
+features = []
+
 [[host-package]]
 name = 'vergen'
 version = '8.2.1'
@@ -499,6 +963,14 @@ crates-io = true
 status = 'direct'
 features = ['cargo', 'default', 'git', 'gitcl', 'rustc', 'rustc_version', 'time']
 optional-deps = ['rustc_version', 'time']
+
+[[host-package]]
+name = 'aho-corasick'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'perf-literal', 'std']
+optional-deps = ['memchr']
 
 [[host-package]]
 name = 'anyhow'
@@ -510,6 +982,13 @@ features = ['default', 'std']
 [[host-package]]
 name = 'autocfg'
 version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'cc'
+version = '1.0.79'
 crates-io = true
 status = 'transitive'
 features = []
@@ -548,6 +1027,20 @@ version = '1.0.6'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.5.0'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[host-package]]
 name = 'pin-project-internal'
@@ -593,6 +1086,43 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['default', 'perf', 'perf-backtrack', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'perf-onepass', 'std', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr']
+
+[[host-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'dfa-onepass', 'hybrid', 'meta', 'nfa-backtrack', 'nfa-pikevm', 'nfa-thompson', 'perf-inline', 'perf-literal', 'perf-literal-multisubstring', 'perf-literal-substring', 'std', 'syntax', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment', 'unicode-word-boundary']
+optional-deps = ['aho-corasick', 'memchr', 'regex-syntax']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'riscv-rt-macros'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'riscv-target'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'rustc_version'
 version = '0.4.0'
 crates-io = true
@@ -625,7 +1155,7 @@ name = 'syn'
 version = '1.0.109'
 crates-io = true
 status = 'transitive'
-features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
+features = ['clone-impls', 'default', 'derive', 'extra-traits', 'full', 'parsing', 'printing', 'proc-macro', 'quote', 'visit']
 optional-deps = ['quote']
 
 [[host-package]]

--- a/fixtures/large/summaries/mnemos_b3b4da9-5.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-5.toml
@@ -2,19 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'thumbv7neon-unknown-linux-gnueabihf'
-target-features = []
-flags = ['flag-test', 'foo']
+triple = 'riscv32imac-unknown-none-elf'
+target-features = 'all'
+flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'riscv32e-unknown-none-elf'
-target-features = 'unknown'
-flags = ['cargo_web', 'test-flag']
+spec = 'always'
+[[metadata.omitted-packages.ids]]
+name = 'slab'
+version = '0.4.8'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'dumbloader'
@@ -34,532 +36,61 @@ version = '0.1.0'
 workspace-path = 'platforms/allwinner-d1'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'forth3'
 version = '0.1.0'
 workspace-path = 'source/forth3'
 status = 'initial'
 features = ['async', 'default']
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos-abi'
 version = '0.1.0'
 workspace-path = 'source/abi'
 status = 'initial'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos-d1'
 version = '0.1.0'
 workspace-path = 'platforms/allwinner-d1'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos-trace-proto'
 version = '0.1.0'
 workspace-path = 'source/trace-proto'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'd1-config'
 version = '0.1.0'
 workspace-path = 'platforms/allwinner-d1/d1-config'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos'
 version = '0.1.0'
 workspace-path = 'source/kernel'
 status = 'workspace'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos-alloc'
 version = '0.1.0'
 workspace-path = 'source/alloc'
 status = 'workspace'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'mnemos-bitslab'
 version = '0.1.0'
 workspace-path = 'source/bitslab'
 status = 'workspace'
 features = []
-
-[[target-package]]
-name = 'mnemos-config'
-version = '0.1.0'
-workspace-path = 'source/config'
-status = 'workspace'
-features = ['default']
-
-[[target-package]]
-name = 'mnemos-d1-core'
-version = '0.1.0'
-workspace-path = 'platforms/allwinner-d1/d1-core'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'sermux-proto'
-version = '0.1.0'
-workspace-path = 'source/sermux-proto'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'spitebuf'
-version = '0.1.0'
-workspace-path = 'source/spitebuf'
-status = 'workspace'
-features = []
-
-[[target-package]]
-name = 'cfg-if'
-version = '1.0.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'cobs'
-version = '0.2.3'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'cordyceps'
-version = '0.3.2'
-source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
-status = 'direct'
-features = ['alloc', 'default']
-
-[[target-package]]
-name = 'critical-section'
-version = '1.1.2'
-crates-io = true
-status = 'direct'
-features = ['restore-state-bool']
-
-[[target-package]]
-name = 'd1-pac'
-version = '0.0.31'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'embedded-graphics'
-version = '0.7.1'
-crates-io = true
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'embedded-hal-async'
-version = '0.2.0-alpha.2'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'futures'
-version = '0.3.28'
-crates-io = true
-status = 'direct'
-features = ['async-await']
-
-[[target-package]]
-name = 'hash32'
-version = '0.3.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'heapless'
-version = '0.7.16'
-crates-io = true
-status = 'direct'
-features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['defmt', 'serde']
-
-[[target-package]]
-name = 'input-mgr'
-version = '0.1.0'
-source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'linked_list_allocator'
-version = '0.10.5'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'maitake'
-version = '0.1.0'
-source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
-status = 'direct'
-features = ['alloc']
-
-[[target-package]]
-name = 'mycelium-bitfield'
-version = '0.1.3'
-source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'mycelium-util'
-version = '0.1.0'
-source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'portable-atomic'
-version = '1.4.2'
-crates-io = true
-status = 'direct'
-features = ['default', 'fallback', 'require-cas']
-
-[[target-package]]
-name = 'postcard'
-version = '1.0.6'
-crates-io = true
-status = 'direct'
-features = ['const_format', 'default', 'experimental-derive', 'heapless', 'heapless-cas', 'postcard-derive']
-optional-deps = ['const_format', 'heapless', 'postcard-derive']
-
-[[target-package]]
-name = 'profont'
-version = '0.6.1'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'ring-drawer'
-version = '0.1.0'
-source = 'git+https://github.com/tosc-rs/teletype/?rev=de95e610cc79db6d59ad6b40eb2d82adebb4e033#de95e610cc79db6d59ad6b40eb2d82adebb4e033'
-status = 'direct'
-features = ['default']
-
-[[target-package]]
-name = 'riscv'
-version = '0.10.1'
-crates-io = true
-status = 'direct'
-features = ['critical-section-single-hart']
-
-[[target-package]]
-name = 'riscv-rt'
-version = '0.11.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'serde'
-version = '1.0.188'
-crates-io = true
-status = 'direct'
-features = ['default', 'derive', 'serde_derive', 'std']
-optional-deps = ['serde_derive']
-
-[[target-package]]
-name = 'tracing'
-version = '0.1.37'
-crates-io = true
-status = 'direct'
-features = ['attributes', 'tracing-attributes']
-optional-deps = ['tracing-attributes']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.1.31'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'tracing-serde-structured'
-version = '0.2.0'
-source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'uuid'
-version = '1.4.1'
-crates-io = true
-status = 'direct'
-features = ['serde']
-optional-deps = ['serde']
-
-[[target-package]]
-name = 'az'
-version = '1.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bare-metal'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bit_field'
-version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'bitflags'
-version = '1.3.2'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'byteorder'
-version = '1.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'const_format'
-version = '0.2.31'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'defmt'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'embedded-graphics-core'
-version = '0.3.3'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'embedded-hal'
-version = '0.2.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'embedded-hal'
-version = '1.0.0-alpha.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'float-cmp'
-version = '0.8.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'num-traits', 'ratio']
-optional-deps = ['num-traits']
-
-[[target-package]]
-name = 'futures-channel'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = ['futures-sink', 'sink']
-optional-deps = ['futures-sink']
-
-[[target-package]]
-name = 'futures-core'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-io'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-sink'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-task'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'futures-util'
-version = '0.3.28'
-crates-io = true
-status = 'transitive'
-features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink', 'sink']
-optional-deps = ['futures-macro', 'futures-sink']
-
-[[target-package]]
-name = 'hash32'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'micromath'
-version = '1.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nb'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nb'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'num-traits'
-version = '0.2.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-project'
-version = '1.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-project-lite'
-version = '0.2.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'pin-utils'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'r0'
-version = '1.0.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'stable_deref_trait'
-version = '1.2.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tracing'
-version = '0.2.0'
-source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
-status = 'transitive'
-features = ['attributes', 'tracing-attributes']
-optional-deps = ['tracing-attributes']
-
-[[target-package]]
-name = 'tracing-core'
-version = '0.2.0'
-source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'vcell'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'void'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'forth3'
-version = '0.1.0'
-workspace-path = 'source/forth3'
-status = 'initial'
-features = ['async', 'default']
-
-[[host-package]]
-name = 'mnemos-abi'
-version = '0.1.0'
-workspace-path = 'source/abi'
-status = 'initial'
-features = ['default']
-
-[[host-package]]
-name = 'd1-config'
-version = '0.1.0'
-workspace-path = 'platforms/allwinner-d1/d1-config'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'mnemos'
-version = '0.1.0'
-workspace-path = 'source/kernel'
-status = 'workspace'
-features = []
-
-[[host-package]]
-name = 'mnemos-alloc'
-version = '0.1.0'
-workspace-path = 'source/alloc'
-status = 'workspace'
-features = ['default']
 
 [[host-package]]
 name = 'mnemos-config'
@@ -570,6 +101,13 @@ features = ['default', 'use-std']
 optional-deps = ['miette', 'toml']
 
 [[host-package]]
+name = 'mnemos-d1-core'
+version = '0.1.0'
+workspace-path = 'platforms/allwinner-d1/d1-core'
+status = 'workspace'
+features = []
+
+[[host-package]]
 name = 'sermux-proto'
 version = '0.1.0'
 workspace-path = 'source/sermux-proto'
@@ -603,6 +141,20 @@ version = '0.3.2'
 source = 'git+https://github.com/hawkw/mycelium.git?rev=101a4abaa19afdd131b334a16d92c9fb4909c064#101a4abaa19afdd131b334a16d92c9fb4909c064'
 status = 'direct'
 features = ['alloc', 'default']
+
+[[host-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'direct'
+features = ['restore-state-bool']
+
+[[host-package]]
+name = 'd1-pac'
+version = '0.0.31'
+crates-io = true
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'embedded-graphics'
@@ -713,6 +265,20 @@ status = 'direct'
 features = ['default']
 
 [[host-package]]
+name = 'riscv'
+version = '0.10.1'
+crates-io = true
+status = 'direct'
+features = ['critical-section-single-hart']
+
+[[host-package]]
+name = 'riscv-rt'
+version = '0.11.0'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
 name = 'serde'
 version = '1.0.188'
 crates-io = true
@@ -735,6 +301,20 @@ crates-io = true
 status = 'direct'
 features = ['attributes', 'tracing-attributes']
 optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-core'
+version = '0.1.31'
+crates-io = true
+status = 'direct'
+features = []
+
+[[host-package]]
+name = 'tracing-serde-structured'
+version = '0.2.0'
+source = 'git+https://github.com/hawkw/tracing-serde-structured?branch=eliza/span-fields#d8c384a09f27eb06aaf31dd3f9bb9c69b33f7e66'
+status = 'direct'
+features = []
 
 [[host-package]]
 name = 'uuid'
@@ -810,6 +390,20 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'bare-metal'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'bit_field'
+version = '0.10.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'bitflags'
 version = '1.3.2'
 crates-io = true
@@ -874,6 +468,13 @@ features = ['default']
 
 [[host-package]]
 name = 'embedded-hal'
+version = '0.2.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'embedded-hal'
 version = '1.0.0-alpha.11'
 crates-io = true
 status = 'transitive'
@@ -882,6 +483,13 @@ features = []
 [[host-package]]
 name = 'equivalent'
 version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1017,13 +625,6 @@ status = 'transitive'
 features = ['default', 'extra_traits', 'std']
 
 [[host-package]]
-name = 'linux-raw-sys'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['errno', 'general', 'ioctl', 'no_std']
-
-[[host-package]]
 name = 'memchr'
 version = '2.5.0'
 crates-io = true
@@ -1047,6 +648,20 @@ features = []
 [[host-package]]
 name = 'miniz_oxide'
 version = '0.7.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nb'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'nb'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1142,6 +757,13 @@ version = '1.0.32'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'r0'
+version = '1.0.0'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'regex'
@@ -1366,13 +988,6 @@ features = []
 
 [[host-package]]
 name = 'tracing-core'
-version = '0.1.31'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'tracing-core'
 version = '0.2.0'
 source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
 status = 'transitive'
@@ -1407,8 +1022,22 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'vcell'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'version_check'
 version = '0.9.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'void'
+version = '1.0.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-6.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-6.toml
@@ -2,25 +2,18 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture mnemos_b3b4da9
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i686-pc-windows-gnullvm'
-target-features = 'all'
-flags = ['cargo_web', 'foo']
+spec = 'any'
 
 [metadata.target-platform]
-spec = 'any'
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'anstyle-parse'
-version = '0.2.1'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'mach'
-version = '0.2.3'
+name = 'serde_path_to_error'
+version = '0.1.14'
 crates-io = true
 
 [[target-package]]
@@ -115,7 +108,7 @@ version = '1.12.0'
 crates-io = true
 status = 'direct'
 features = ['alloc', 'async-channel', 'async-global-executor', 'async-io', 'async-lock', 'async-process', 'crossbeam-utils', 'default', 'futures-channel', 'futures-core', 'futures-io', 'futures-lite', 'gloo-timers', 'kv-log-macro', 'log', 'memchr', 'once_cell', 'pin-project-lite', 'pin-utils', 'slab', 'std', 'unstable', 'wasm-bindgen-futures']
-optional-deps = ['async-channel', 'async-global-executor', 'async-io', 'async-lock', 'async-process', 'crossbeam-utils', 'futures-channel', 'futures-core', 'futures-io', 'futures-lite', 'gloo-timers', 'kv-log-macro', 'log', 'memchr', 'once_cell', 'pin-project-lite', 'pin-utils', 'slab', 'wasm-bindgen-futures']
+optional-deps = ['async-channel', 'async-lock', 'crossbeam-utils', 'futures-core', 'futures-io', 'kv-log-macro', 'log', 'memchr', 'once_cell', 'pin-project-lite', 'pin-utils', 'slab']
 
 [[target-package]]
 name = 'atty'
@@ -137,7 +130,7 @@ version = '0.4.26'
 crates-io = true
 status = 'direct'
 features = ['clock', 'default', 'iana-time-zone', 'js-sys', 'oldtime', 'std', 'time', 'wasm-bindgen', 'wasmbind', 'winapi']
-optional-deps = ['iana-time-zone', 'js-sys', 'time', 'wasm-bindgen', 'winapi']
+optional-deps = ['time']
 
 [[target-package]]
 name = 'clap'
@@ -262,7 +255,7 @@ version = '0.7.16'
 crates-io = true
 status = 'direct'
 features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['atomic-polyfill', 'defmt', 'serde']
+optional-deps = ['defmt', 'serde']
 
 [[target-package]]
 name = 'humantime'
@@ -349,8 +342,8 @@ name = 'tokio'
 version = '1.29.1'
 crates-io = true
 status = 'direct'
-features = ['bytes', 'default', 'io-std', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'socket2', 'sync', 'time', 'tokio-macros', 'tracing', 'windows-sys']
-optional-deps = ['bytes', 'libc', 'mio', 'socket2', 'tokio-macros', 'tracing', 'windows-sys']
+features = ['bytes', 'default', 'io-std', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'socket2', 'sync', 'time', 'tokio-macros', 'tracing']
+optional-deps = ['bytes', 'mio', 'tokio-macros']
 
 [[target-package]]
 name = 'tracing'
@@ -365,8 +358,8 @@ name = 'tracing-core'
 version = '0.1.31'
 crates-io = true
 status = 'direct'
-features = ['default', 'once_cell', 'std', 'valuable']
-optional-deps = ['once_cell', 'valuable']
+features = ['default', 'once_cell', 'std']
+optional-deps = ['once_cell']
 
 [[target-package]]
 name = 'tracing-modality'
@@ -427,13 +420,6 @@ status = 'direct'
 features = ['AbortSignal', 'AddEventListenerOptions', 'BinaryType', 'Blob', 'BlobPropertyBag', 'CanvasRenderingContext2d', 'CloseEvent', 'CloseEventInit', 'DedicatedWorkerGlobalScope', 'Document', 'DomException', 'Element', 'ErrorEvent', 'Event', 'EventSource', 'EventTarget', 'File', 'FileList', 'FilePropertyBag', 'FileReader', 'FormData', 'Headers', 'History', 'HtmlCanvasElement', 'HtmlElement', 'HtmlHeadElement', 'HtmlInputElement', 'ImageData', 'KeyboardEvent', 'Location', 'MessageEvent', 'Node', 'ObserverCallback', 'ProgressEvent', 'ReadableStream', 'ReferrerPolicy', 'Request', 'RequestCache', 'RequestCredentials', 'RequestInit', 'RequestMode', 'RequestRedirect', 'Response', 'ResponseInit', 'ResponseType', 'Storage', 'UiEvent', 'Url', 'UrlSearchParams', 'WebSocket', 'Window', 'Worker', 'WorkerGlobalScope', 'WorkerOptions', 'console']
 
 [[target-package]]
-name = 'addr2line'
-version = '0.20.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'adler'
 version = '1.0.2'
 crates-io = true
@@ -446,20 +432,6 @@ version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
-
-[[target-package]]
-name = 'android-tzdata'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'android_system_properties'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'anyhow'
@@ -476,58 +448,8 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'async-executor'
-version = '1.5.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'async-global-executor'
-version = '2.3.1'
-crates-io = true
-status = 'transitive'
-features = ['async-io', 'default']
-optional-deps = ['async-io']
-
-[[target-package]]
-name = 'async-io'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'async-lock'
 version = '2.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'async-process'
-version = '1.7.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'async-task'
-version = '4.4.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'atomic-polyfill'
-version = '0.1.11'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'atomic-waker'
-version = '1.1.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -552,13 +474,6 @@ version = '1.2.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'backtrace'
-version = '0.3.68'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'base64'
@@ -589,13 +504,6 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
-name = 'blocking'
-version = '1.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'bytemuck'
 version = '1.13.1'
 crates-io = true
@@ -622,14 +530,6 @@ version = '0.2.4'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'cloudabi'
-version = '0.0.3'
-crates-io = true
-status = 'transitive'
-features = ['bitflags', 'default']
-optional-deps = ['bitflags']
 
 [[target-package]]
 name = 'color_quant'
@@ -660,32 +560,11 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
-name = 'core-foundation'
-version = '0.9.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'core-foundation-sys'
-version = '0.8.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'crc32fast'
 version = '1.3.2'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
-
-[[target-package]]
-name = 'critical-section'
-version = '1.1.2'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'crossbeam-channel'
@@ -767,29 +646,8 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'errno'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'errno-dragonfly'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'event-listener'
 version = '2.5.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'fastrand'
-version = '1.9.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -826,32 +684,11 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'foreign-types'
-version = '0.3.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'foreign-types-shared'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'form_urlencoded'
 version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'fuchsia-cprng'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'futures-channel'
@@ -876,14 +713,6 @@ status = 'transitive'
 features = ['default', 'std']
 
 [[target-package]]
-name = 'futures-lite'
-version = '1.13.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'default', 'fastrand', 'futures-io', 'memchr', 'parking', 'std', 'waker-fn']
-optional-deps = ['fastrand', 'futures-io', 'memchr', 'parking', 'waker-fn']
-
-[[target-package]]
 name = 'futures-sink'
 version = '0.3.28'
 crates-io = true
@@ -898,13 +727,6 @@ status = 'transitive'
 features = ['alloc', 'std']
 
 [[target-package]]
-name = 'generator'
-version = '0.7.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'getrandom'
 version = '0.2.10'
 crates-io = true
@@ -917,13 +739,6 @@ version = '0.11.4'
 crates-io = true
 status = 'transitive'
 features = ['default', 'raii_no_panic', 'std']
-
-[[target-package]]
-name = 'gimli'
-version = '0.27.3'
-crates-io = true
-status = 'transitive'
-features = ['read', 'read-core']
 
 [[target-package]]
 name = 'gloo-console'
@@ -1037,20 +852,6 @@ features = ['base64', 'flate2', 'nom', 'serialization']
 optional-deps = ['base64', 'flate2', 'nom']
 
 [[target-package]]
-name = 'hermit-abi'
-version = '0.1.19'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'hermit-abi'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
 name = 'hex'
 version = '0.4.3'
 crates-io = true
@@ -1101,20 +902,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'iana-time-zone'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = ['fallback']
-
-[[target-package]]
-name = 'iana-time-zone-haiku'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'idna'
 version = '0.4.0'
 crates-io = true
@@ -1135,21 +922,6 @@ version = '1.9.3'
 crates-io = true
 status = 'transitive'
 features = ['std']
-
-[[target-package]]
-name = 'instant'
-version = '0.1.12'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'io-lifetimes'
-version = '1.0.11'
-crates-io = true
-status = 'transitive'
-features = ['close', 'hermit-abi', 'libc', 'windows-sys']
-optional-deps = ['hermit-abi', 'libc', 'windows-sys']
 
 [[target-package]]
 name = 'itoa'
@@ -1192,21 +964,7 @@ name = 'libc'
 version = '0.2.147'
 crates-io = true
 status = 'transitive'
-features = ['default', 'extra_traits', 'std']
-
-[[target-package]]
-name = 'linux-raw-sys'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['errno', 'general', 'ioctl', 'no_std']
-
-[[target-package]]
-name = 'lock_api'
-version = '0.4.10'
-crates-io = true
-status = 'transitive'
-features = ['atomic_usize', 'default']
+features = ['default', 'std']
 
 [[target-package]]
 name = 'log'
@@ -1215,13 +973,6 @@ crates-io = true
 status = 'transitive'
 features = ['kv_unstable', 'std', 'value-bag']
 optional-deps = ['value-bag']
-
-[[target-package]]
-name = 'loom'
-version = '0.5.6'
-crates-io = true
-status = 'transitive'
-features = ['default']
 
 [[target-package]]
 name = 'matchers'
@@ -1386,39 +1137,11 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'object'
-version = '0.31.1'
-crates-io = true
-status = 'transitive'
-features = ['archive', 'coff', 'elf', 'macho', 'pe', 'read_core', 'unaligned']
-
-[[target-package]]
 name = 'once_cell'
 version = '1.18.0'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'race', 'std']
-
-[[target-package]]
-name = 'openssl'
-version = '0.10.55'
-crates-io = true
-status = 'transitive'
-features = ['default']
-
-[[target-package]]
-name = 'openssl-probe'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'openssl-sys'
-version = '0.9.90'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'os_str_bytes'
@@ -1430,13 +1153,6 @@ features = ['raw_os_str']
 [[target-package]]
 name = 'overload'
 version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'parking'
-version = '2.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1485,13 +1201,6 @@ features = ['default', 'deflate', 'png-encoding']
 optional-deps = ['deflate']
 
 [[target-package]]
-name = 'polling'
-version = '2.8.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'ppv-lite86'
 version = '0.2.17'
 crates-io = true
@@ -1527,7 +1236,7 @@ version = '0.8.5'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'rand_chacha', 'small_rng', 'std', 'std_rng']
-optional-deps = ['libc', 'rand_chacha']
+optional-deps = ['rand_chacha']
 
 [[target-package]]
 name = 'rand_chacha'
@@ -1622,34 +1331,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'rdrand'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.2.16'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_syscall'
-version = '0.3.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'redox_users'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'regex'
 version = '1.9.4'
 crates-io = true
@@ -1687,37 +1368,8 @@ status = 'transitive'
 features = ['std', 'unicode-case', 'unicode-perl']
 
 [[target-package]]
-name = 'rustc-demangle'
-version = '0.1.23'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'rustix'
-version = '0.37.20'
-crates-io = true
-status = 'transitive'
-features = ['default', 'fs', 'io-lifetimes', 'libc', 'std', 'use-libc-auxv']
-optional-deps = ['io-lifetimes', 'libc']
-
-[[target-package]]
 name = 'ryu'
 version = '1.0.15'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'schannel'
-version = '0.1.22'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'scoped-tls'
-version = '1.0.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -1751,20 +1403,6 @@ status = 'transitive'
 features = ['default']
 
 [[target-package]]
-name = 'security-framework'
-version = '2.9.2'
-crates-io = true
-status = 'transitive'
-features = ['OSX_10_9', 'default']
-
-[[target-package]]
-name = 'security-framework-sys'
-version = '2.9.1'
-crates-io = true
-status = 'transitive'
-features = ['OSX_10_9', 'default']
-
-[[target-package]]
 name = 'serde-wasm-bindgen'
 version = '0.5.0'
 crates-io = true
@@ -1793,20 +1431,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'signal-hook'
-version = '0.3.17'
-crates-io = true
-status = 'transitive'
-features = ['channel', 'iterator']
-
-[[target-package]]
-name = 'signal-hook-registry'
-version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'slab'
 version = '0.4.8'
 crates-io = true
@@ -1828,14 +1452,6 @@ status = 'transitive'
 features = ['all']
 
 [[target-package]]
-name = 'spin'
-version = '0.9.8'
-crates-io = true
-status = 'transitive'
-features = ['barrier', 'default', 'lazy', 'lock_api', 'lock_api_crate', 'mutex', 'once', 'rwlock', 'spin_mutex']
-optional-deps = ['lock_api_crate']
-
-[[target-package]]
 name = 'stable_deref_trait'
 version = '1.2.0'
 crates-io = true
@@ -1852,13 +1468,6 @@ features = []
 [[target-package]]
 name = 'sync_wrapper'
 version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tempfile'
-version = '3.6.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2038,22 +1647,8 @@ features = ['default', 'getrandom', 'std', 'v4']
 optional-deps = ['getrandom']
 
 [[target-package]]
-name = 'valuable'
-version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = ['alloc', 'std']
-
-[[target-package]]
 name = 'value-bag'
 version = '1.4.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'waker-fn'
-version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2066,123 +1661,11 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'wasi'
-version = '0.10.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'wasi'
-version = '0.11.0+wasi-snapshot-preview1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
 name = 'weezl'
 version = '0.1.7'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'std']
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.9'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'knownfolders', 'minwinbase', 'minwindef', 'ntdef', 'ntsecapi', 'objbase', 'processenv', 'profileapi', 'shlobj', 'std', 'sysinfoapi', 'timezoneapi', 'winbase', 'wincon', 'winerror', 'winnt', 'ws2ipdef', 'ws2tcpip']
-
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = ['Globalization', 'Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_Memory', 'Win32_System_SystemInformation', 'default']
-
-[[target-package]]
-name = 'windows-sys'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = ['Win32', 'Win32_Foundation', 'Win32_NetworkManagement', 'Win32_NetworkManagement_IpHelper', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Security_Authentication', 'Win32_Security_Authentication_Identity', 'Win32_Security_Credentials', 'Win32_Security_Cryptography', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_IO', 'Win32_System_LibraryLoader', 'Win32_System_Memory', 'Win32_System_Pipes', 'Win32_System_SystemServices', 'Win32_System_Threading', 'Win32_System_WindowsProgramming', 'default']
-
-[[target-package]]
-name = 'windows-targets'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_aarch64_gnullvm'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_aarch64_msvc'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_i686_gnu'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_i686_msvc'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_gnu'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_gnullvm'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'windows_x86_64_msvc'
-version = '0.48.0'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'mnemos-abi'
@@ -2296,7 +1779,7 @@ version = '0.7.16'
 crates-io = true
 status = 'direct'
 features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['defmt', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
 
 [[host-package]]
 name = 'input-mgr'
@@ -2391,8 +1874,16 @@ name = 'tracing'
 version = '0.1.37'
 crates-io = true
 status = 'direct'
-features = ['attributes', 'tracing-attributes']
+features = ['attributes', 'default', 'std', 'tracing-attributes']
 optional-deps = ['tracing-attributes']
+
+[[host-package]]
+name = 'tracing-subscriber'
+version = '0.3.17'
+crates-io = true
+status = 'direct'
+features = ['alloc', 'ansi', 'default', 'env-filter', 'fmt', 'matchers', 'nu-ansi-term', 'once_cell', 'regex', 'registry', 'sharded-slab', 'smallvec', 'std', 'thread_local', 'tracing', 'tracing-log']
+optional-deps = ['matchers', 'nu-ansi-term', 'once_cell', 'regex', 'sharded-slab', 'smallvec', 'thread_local', 'tracing', 'tracing-log']
 
 [[host-package]]
 name = 'uuid'
@@ -2434,6 +1925,13 @@ features = ['default', 'std']
 [[host-package]]
 name = 'async-trait'
 version = '0.1.72'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'atomic-polyfill'
+version = '0.1.11'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2530,6 +2028,13 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'critical-section'
+version = '1.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'defmt'
 version = '0.3.5'
 crates-io = true
@@ -2574,6 +2079,20 @@ features = []
 [[host-package]]
 name = 'equivalent'
 version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'errno-dragonfly'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2638,6 +2157,13 @@ features = ['async-await', 'async-await-macro', 'futures-macro', 'futures-sink',
 optional-deps = ['futures-macro', 'futures-sink']
 
 [[host-package]]
+name = 'generator'
+version = '0.7.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'gimli'
 version = '0.27.3'
 crates-io = true
@@ -2673,6 +2199,13 @@ status = 'transitive'
 features = ['default']
 
 [[host-package]]
+name = 'hermit-abi'
+version = '0.3.1'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
 name = 'indexmap'
 version = '2.0.0'
 crates-io = true
@@ -2685,7 +2218,7 @@ version = '1.0.11'
 crates-io = true
 status = 'transitive'
 features = ['close', 'default', 'hermit-abi', 'libc', 'windows-sys']
-optional-deps = ['windows-sys']
+optional-deps = ['hermit-abi', 'libc', 'windows-sys']
 
 [[host-package]]
 name = 'is-terminal'
@@ -2716,15 +2249,50 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'libc'
-version = '0.2.147'
+name = 'lazy_static'
+version = '1.4.0'
 crates-io = true
 status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'libc'
+version = '0.2.147'
+crates-io = true
+status = 'transitive'
+features = ['default', 'extra_traits', 'std']
+
+[[host-package]]
+name = 'linux-raw-sys'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['errno', 'general', 'ioctl', 'no_std']
+
+[[host-package]]
+name = 'lock_api'
+version = '0.4.10'
+crates-io = true
+status = 'transitive'
+features = ['atomic_usize', 'default']
+
+[[host-package]]
 name = 'log'
 version = '0.4.20'
+crates-io = true
+status = 'transitive'
+features = ['std']
+
+[[host-package]]
+name = 'loom'
+version = '0.5.6'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'matchers'
+version = '0.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2765,6 +2333,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'nu-ansi-term'
+version = '0.46.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'num-traits'
 version = '0.2.15'
 crates-io = true
@@ -2786,7 +2361,7 @@ status = 'transitive'
 features = ['alloc', 'default', 'race', 'std']
 
 [[host-package]]
-name = 'openssl-macros'
+name = 'overload'
 version = '0.1.1'
 crates-io = true
 status = 'transitive'
@@ -2823,13 +2398,6 @@ features = []
 [[host-package]]
 name = 'pin-utils'
 version = '0.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'pkg-config'
-version = '0.3.27'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2885,6 +2453,43 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'regex'
+version = '1.9.4'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[host-package]]
+name = 'regex-automata'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = ['default', 'regex-syntax', 'std']
+optional-deps = ['regex-syntax']
+
+[[host-package]]
+name = 'regex-automata'
+version = '0.3.7'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'meta', 'nfa-pikevm', 'nfa-thompson', 'std', 'syntax', 'unicode-case', 'unicode-perl', 'unicode-word-boundary']
+optional-deps = ['regex-syntax']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.6.29'
+crates-io = true
+status = 'transitive'
+features = ['default', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.7.5'
+crates-io = true
+status = 'transitive'
+features = ['std', 'unicode-case', 'unicode-perl']
+
+[[host-package]]
 name = 'rustc-demangle'
 version = '0.1.23'
 crates-io = true
@@ -2899,8 +2504,30 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'rustix'
+version = '0.37.20'
+crates-io = true
+status = 'transitive'
+features = ['default', 'io-lifetimes', 'libc', 'std', 'termios', 'use-libc-auxv']
+optional-deps = ['io-lifetimes', 'libc']
+
+[[host-package]]
 name = 'rustversion'
 version = '1.0.12'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scoped-tls'
+version = '1.0.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'scopeguard'
+version = '1.1.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2928,11 +2555,33 @@ features = ['serde']
 optional-deps = ['serde']
 
 [[host-package]]
+name = 'sharded-slab'
+version = '0.1.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'smallvec'
+version = '1.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'smawk'
 version = '0.3.1'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'spin'
+version = '0.9.8'
+crates-io = true
+status = 'transitive'
+features = ['barrier', 'default', 'lazy', 'lock_api', 'lock_api_crate', 'mutex', 'once', 'rwlock', 'spin_mutex']
+optional-deps = ['lock_api_crate']
 
 [[host-package]]
 name = 'stable_deref_trait'
@@ -3008,6 +2657,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'thread_local'
+version = '1.1.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'time'
 version = '0.3.22'
 crates-io = true
@@ -3072,7 +2728,8 @@ name = 'tracing-core'
 version = '0.1.31'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'once_cell', 'std', 'valuable']
+optional-deps = ['once_cell', 'valuable']
 
 [[host-package]]
 name = 'tracing-core'
@@ -3080,6 +2737,13 @@ version = '0.2.0'
 source = 'git+https://github.com/tokio-rs/tracing#941b1591faeea55d62c1c8cf524ffa3e95b66887'
 status = 'transitive'
 features = []
+
+[[host-package]]
+name = 'tracing-log'
+version = '0.1.3'
+crates-io = true
+status = 'transitive'
+features = ['log-tracer', 'std']
 
 [[host-package]]
 name = 'unicode-ident'
@@ -3108,6 +2772,13 @@ version = '0.2.4'
 crates-io = true
 status = 'transitive'
 features = ['default']
+
+[[host-package]]
+name = 'valuable'
+version = '0.1.0'
+crates-io = true
+status = 'transitive'
+features = ['alloc', 'std']
 
 [[host-package]]
 name = 'version_check'
@@ -3149,14 +2820,35 @@ name = 'winapi'
 version = '0.3.9'
 crates-io = true
 status = 'transitive'
-features = ['handleapi', 'processenv', 'winbase', 'wincon', 'winnt']
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'processenv', 'winbase', 'wincon', 'winnt']
+
+[[host-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = ['Win32', 'Win32_Foundation', 'Win32_System', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_Memory', 'Win32_System_SystemInformation', 'default']
 
 [[host-package]]
 name = 'windows-sys'
 version = '0.48.0'
 crates-io = true
 status = 'transitive'
-features = ['Win32', 'Win32_Foundation', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_IO', 'Win32_System_Threading', 'default']
+features = ['Win32', 'Win32_Foundation', 'Win32_NetworkManagement', 'Win32_NetworkManagement_IpHelper', 'Win32_Networking', 'Win32_Networking_WinSock', 'Win32_Security', 'Win32_Storage', 'Win32_Storage_FileSystem', 'Win32_System', 'Win32_System_Console', 'Win32_System_Diagnostics', 'Win32_System_Diagnostics_Debug', 'Win32_System_IO', 'Win32_System_Threading', 'default']
 
 [[host-package]]
 name = 'windows-targets'
@@ -3166,7 +2858,49 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'windows_aarch64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_aarch64_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'windows_i686_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_i686_msvc'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_x86_64_gnu'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_x86_64_gnullvm'
+version = '0.48.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'windows_x86_64_msvc'
 version = '0.48.0'
 crates-io = true
 status = 'transitive'

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -2,20 +2,51 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata1
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'auto'
+# resolver = 'install'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
-# workspace-hack-line-style = 'workspace-dotted'
+# dep-format-version = '4'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['riscv64gc-unknown-openbsd', 'bpfeb-unknown-none']
+# [[traversal-excludes.ids]]
+# name = 'dtoa'
+# version = '0.4.4'
+# crates-io = true
+#
 # [[traversal-excludes.ids]]
 # name = 'linked-hash-map'
 # version = '0.5.2'
 # crates-io = true
-# [[final-excludes.ids]]
-# name = 'regex-syntax'
-# version = '0.6.12'
+#
+# [[traversal-excludes.ids]]
+# name = 'memchr'
+# version = '2.2.1'
 # crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'quote'
+# version = '1.0.2'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'serde'
+# version = '1.0.100'
+# crates-io = true
+# [[final-excludes.ids]]
+# name = 'mach'
+# version = '0.2.3'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'thread_local'
+# version = '0.3.6'
+# crates-io = true
+
+[dependencies]
+datatest = { version = "0.4", features = ["unsafe_test_runner"] }
+
+[build-dependencies]
+datatest = { version = "0.4", features = ["unsafe_test_runner"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -2,16 +2,26 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata1
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
+# resolver = '3'
 # unify-target-host = 'none'
-# output-single-feature = false
-# dep-format-version = '4'
+# output-single-feature = true
+# dep-format-version = '1'
 # workspace-hack-line-style = 'full'
 # platforms = ['xtensa-esp32s3-espidf', 'aarch64-linux-android']
 # [[traversal-excludes.ids]]
+# name = 'ctor'
+# version = '0.1.10'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'memchr'
+# version = '2.2.1'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.2'
-# crates-io = true
+# path = '../quote'
 #
 # [[traversal-excludes.ids]]
 # name = 'serde_yaml'
@@ -19,46 +29,28 @@
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'version_check'
-# version = '0.9.1'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'walkdir'
-# version = '2.2.9'
-# source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
+# name = 'testcrate'
+# version = '0.1.0'
+# workspace-path = ''
 #
 # [[traversal-excludes.ids]]
 # name = 'winapi'
 # version = '0.3.8'
 # crates-io = true
-# [[final-excludes.ids]]
-# name = 'ctor'
-# version = '0.1.10'
-# crates-io = true
 #
-# [[final-excludes.ids]]
-# name = 'mach'
-# version = '0.2.3'
+# [[traversal-excludes.ids]]
+# name = 'winapi-i686-pc-windows-gnu'
+# version = '0.4.0'
 # crates-io = true
-#
 # [[final-excludes.ids]]
-# name = 'memchr'
-# version = '2.2.1'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'serde_yaml'
-# version = '0.8.9'
+# name = 'datatest-derive'
+# version = '0.4.0'
 # crates-io = true
 #
 # [[final-excludes.ids]]
 # name = 'walkdir'
 # version = '2.2.9'
 # source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
-
-[dependencies]
-datatest = { version = "0.4", features = ["unsafe_test_runner"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata2-1.toml
+++ b/fixtures/small/hakari/metadata2-1.toml
@@ -2,55 +2,55 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata2
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'unify-if-both'
+# resolver = '3'
+# unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '1'
-# workspace-hack-line-style = 'workspace-dotted'
+# dep-format-version = '4'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['aarch64-apple-tvos-sim', 'armv7-wrs-vxworks-eabihf']
 # [[traversal-excludes.ids]]
-# name = 'quote'
-# version = '1.0.2'
-# path = '../quote'
-#
-# [[traversal-excludes.ids]]
-# name = 'same-file'
-# version = '1.0.5'
+# name = 'datatest'
+# version = '0.4.2'
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'version_check'
-# version = '0.9.1'
-# crates-io = true
-# [[final-excludes.ids]]
-# name = 'datatest-derive'
-# version = '0.4.0'
+# name = 'linked-hash-map'
+# version = '0.5.2'
 # crates-io = true
 #
+# [[traversal-excludes.ids]]
+# name = 'proc-macro2'
+# version = '1.0.3'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'regex'
+# version = '1.3.1'
+# crates-io = true
 # [[final-excludes.ids]]
 # name = 'dtoa'
 # version = '0.4.4'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'linked-hash-map'
-# version = '0.5.2'
+# name = 'regex'
+# version = '1.3.1'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'memchr'
-# version = '2.2.1'
+# name = 'unicode-xid'
+# version = '0.2.0'
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'quote'
-# version = '1.0.2'
-# path = '../quote'
+# name = 'version_check'
+# version = '0.9.1'
+# crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'winapi-i686-pc-windows-gnu'
-# version = '0.4.0'
-# crates-io = true
+# name = 'walkdir'
+# version = '2.2.9'
+# workspace-path = 'walkdir'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata2-3.toml
+++ b/fixtures/small/hakari/metadata2-3.toml
@@ -2,70 +2,50 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata2
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'auto'
-# output-single-feature = true
-# dep-format-version = '3'
+# resolver = '3'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = false
+# dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
 # platforms = ['aarch64-uwp-windows-msvc', 'mipsisa32r6-unknown-linux-gnu', 'riscv32imafc-esp-espidf']
-# [[traversal-excludes.ids]]
-# name = 'quote'
-# version = '1.0.2'
-# path = '../quote'
-#
-# [[traversal-excludes.ids]]
-# name = 'regex'
-# version = '1.3.1'
-# crates-io = true
-#
 # [[traversal-excludes.ids]]
 # name = 'regex-syntax'
 # version = '0.6.12'
 # crates-io = true
+# [[final-excludes.ids]]
+# name = 'datatest'
+# version = '0.4.2'
+# crates-io = true
 #
-# [[traversal-excludes.ids]]
+# [[final-excludes.ids]]
+# name = 'datatest-derive'
+# version = '0.4.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'dtoa'
+# version = '0.4.4'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'linked-hash-map'
+# version = '0.5.2'
+# crates-io = true
+#
+# [[final-excludes.ids]]
 # name = 'same-file'
 # version = '1.0.5'
 # crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'serde_yaml'
-# version = '0.8.9'
-# crates-io = true
+# [[final-excludes.ids]]
+# name = 'walkdir'
+# version = '0.1.0'
+# path = '../walkdir'
 #
-# [[traversal-excludes.ids]]
-# name = 'thread_local'
-# version = '0.3.6'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
+# [[final-excludes.ids]]
 # name = 'winapi-i686-pc-windows-gnu'
 # version = '0.4.0'
 # crates-io = true
-# [[final-excludes.ids]]
-# name = 'regex'
-# version = '1.3.1'
-# crates-io = true
-
-[dependencies]
-datatest = { version = "0.4" }
-linked-hash-map = { version = "0.5", default-features = false }
-serde = { version = "1" }
-walkdir-cd6c3afff8ff167c = { package = "walkdir", path = "/Users/fakeuser/local/testworkspace/../walkdir", default-features = false }
-walkdir-f595c2ba2a3f28df = { package = "walkdir", version = "2", default-features = false }
-yaml-rust = { version = "0.4", default-features = false }
-
-[build-dependencies]
-ctor = { version = "0.1", default-features = false }
-datatest-derive = { version = "0.4", default-features = false }
-proc-macro2 = { version = "1" }
-syn = { version = "1", features = ["fold", "full"] }
-unicode-xid = { version = "0.2" }
-version_check = { version = "0.9", default-features = false }
-
-[target.aarch64-uwp-windows-msvc.dependencies]
-winapi = { version = "0.3", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "minwindef", "processenv", "std", "winbase", "wincon", "winerror", "winnt"] }
-winapi-util = { version = "0.1", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_alternate_registries-1.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-1.toml
@@ -2,32 +2,34 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_alternate_registries
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'unify-if-both'
-# output-single-feature = true
-# dep-format-version = '2'
-# workspace-hack-line-style = 'full'
+# resolver = '3'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
+# dep-format-version = '3'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['loongarch64-unknown-linux-musl', 'arm64e-apple-ios']
-#
-# [traversal-excludes]
-# [[final-excludes.ids]]
-# name = 'proc-macro2'
-# version = '1.0.29'
+# [[traversal-excludes.ids]]
+# name = 'serde'
+# version = '1.0.130'
 # source = 'registry+https://github.com/fakeorg/crates.io-index'
 #
-# [[final-excludes.ids]]
-# name = 'quote'
-# version = '1.0.10'
-# source = 'registry+https://github.com/fakeorg/crates.io-index'
-#
-# [[final-excludes.ids]]
-# name = 'ryu'
-# version = '1.0.5'
+# [[traversal-excludes.ids]]
+# name = 'unicode-xid'
+# version = '0.2.2'
 # crates-io = true
 #
+# [[traversal-excludes.ids]]
+# name = 'unicode-xid'
+# version = '0.2.2'
+# source = 'registry+https://github.com/fakeorg/crates.io-index'
 # [[final-excludes.ids]]
 # name = 'serde_derive'
 # version = '1.0.130'
+# source = 'registry+https://github.com/fakeorg/crates.io-index'
+#
+# [[final-excludes.ids]]
+# name = 'syn'
+# version = '1.0.80'
 # source = 'registry+https://github.com/fakeorg/crates.io-index'
 #
 # [[final-excludes.ids]]
@@ -36,16 +38,6 @@
 # source = 'registry+https://github.com/fakeorg/crates.io-index'
 # [registries.my-registry]
 # index = 'https://github.com/fakeorg/crates.io-index'
-
-[dependencies]
-itoa = { version = "0.4", default-features = false }
-serde-e7e45184a9cd0878 = { package = "serde", version = "1", registry = "my-registry", default-features = false, features = ["derive", "serde_derive"] }
-serde-dff4ba8e3ae991db = { package = "serde", version = "1", default-features = false, features = ["std"] }
-serde_json = { version = "1", features = ["std"] }
-unicode-xid = { version = "0.2" }
-
-[build-dependencies]
-syn = { version = "1", registry = "my-registry", features = ["clone-impls", "derive", "parsing", "printing", "proc-macro", "quote"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_alternate_registries-3.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-3.toml
@@ -2,21 +2,21 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_alternate_registries
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'replicate-target-on-host'
-# output-single-feature = false
-# dep-format-version = '4'
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = true
+# dep-format-version = '3'
 # workspace-hack-line-style = 'full'
 # platforms = ['riscv32emc-unknown-none-elf']
-# [[traversal-excludes.ids]]
-# name = 'proc-macro2'
-# version = '1.0.29'
-# source = 'registry+https://github.com/fakeorg/crates.io-index'
-#
 # [[traversal-excludes.ids]]
 # name = 'quote'
 # version = '1.0.10'
 # source = 'registry+https://github.com/fakeorg/crates.io-index'
+#
+# [[traversal-excludes.ids]]
+# name = 'ryu'
+# version = '1.0.5'
+# crates-io = true
 #
 # [[traversal-excludes.ids]]
 # name = 'serde'
@@ -24,20 +24,35 @@
 # crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'serde_json'
-# version = '1.0.68'
-# crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'syn'
-# version = '1.0.80'
+# name = 'serde_derive'
+# version = '1.0.130'
 # source = 'registry+https://github.com/fakeorg/crates.io-index'
+# [[final-excludes.ids]]
+# name = 'proc-macro2'
+# version = '1.0.29'
+# source = 'registry+https://github.com/fakeorg/crates.io-index'
+#
+# [[final-excludes.ids]]
+# name = 'quote'
+# version = '1.0.10'
+# source = 'registry+https://github.com/fakeorg/crates.io-index'
+#
 # [[final-excludes.ids]]
 # name = 'ryu'
 # version = '1.0.5'
 # crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'unicode-xid'
+# version = '0.2.2'
+# crates-io = true
 # [registries.my-registry]
 # index = 'https://github.com/fakeorg/crates.io-index'
+
+[dependencies]
+itoa = { version = "0.4", default-features = false }
+serde = { version = "1", registry = "my-registry", default-features = false, features = ["derive"] }
+serde_json = { version = "1" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_build_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-2.toml
@@ -2,18 +2,20 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_build_targets1
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'none'
-# output-single-feature = true
-# dep-format-version = '2'
-# workspace-hack-line-style = 'workspace-dotted'
+# resolver = '3'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
+# dep-format-version = '3'
+# workspace-hack-line-style = 'version-only'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'
 # workspace-path = ''
-#
-# [final-excludes]
+# [[final-excludes.ids]]
+# name = 'testcrate'
+# version = '0.1.0'
+# workspace-path = ''
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_builddep-0.toml
+++ b/fixtures/small/hakari/metadata_builddep-0.toml
@@ -2,30 +2,18 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_builddep
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'auto'
-# output-single-feature = true
+# resolver = '2'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
 # dep-format-version = '3'
-# workspace-hack-line-style = 'full'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['powerpc64le-unknown-linux-gnu', 'powerpc-unknown-netbsd', 'loongarch64-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'
 # workspace-path = 'builddep'
 #
-# [[traversal-excludes.ids]]
-# name = 'main'
-# version = '0.1.0'
-# workspace-path = 'main'
-# [[final-excludes.ids]]
-# name = 'builddep'
-# version = '0.1.0'
-# workspace-path = 'builddep'
-#
-# [[final-excludes.ids]]
-# name = 'main'
-# version = '0.1.0'
-# workspace-path = 'main'
+# [final-excludes]
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -2,11 +2,11 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_builddep
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'replicate-target-on-host'
-# output-single-feature = false
-# dep-format-version = '4'
-# workspace-hack-line-style = 'workspace-dotted'
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
+# output-single-feature = true
+# dep-format-version = '2'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['wasm32-wasip1', 'armv5te-none-eabi', 'riscv64imac-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
@@ -17,8 +17,15 @@
 # name = 'main'
 # version = '0.1.0'
 # workspace-path = 'main'
+# [[final-excludes.ids]]
+# name = 'builddep'
+# version = '0.1.0'
+# workspace-path = 'builddep'
 #
-# [final-excludes]
+# [[final-excludes.ids]]
+# name = 'main'
+# version = '0.1.0'
+# workspace-path = 'main'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_builddep-2.toml
+++ b/fixtures/small/hakari/metadata_builddep-2.toml
@@ -2,25 +2,18 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_builddep
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'unify-if-both'
-# output-single-feature = false
-# dep-format-version = '4'
-# workspace-hack-line-style = 'full'
+# resolver = '2'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = true
+# dep-format-version = '2'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = []
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'
 # workspace-path = 'builddep'
 #
-# [[traversal-excludes.ids]]
-# name = 'main'
-# version = '0.1.0'
-# workspace-path = 'main'
-# [[final-excludes.ids]]
-# name = 'main'
-# version = '0.1.0'
-# workspace-path = 'main'
+# [final-excludes]
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_cycle1-0.toml
+++ b/fixtures/small/hakari/metadata_cycle1-0.toml
@@ -2,30 +2,21 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle1
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'none'
-# output-single-feature = false
-# dep-format-version = '3'
+# resolver = '3'
+# unify-target-host = 'auto'
+# output-single-feature = true
+# dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['wasm32-unknown-emscripten', 'x86_64-apple-ios-macabi']
-# [[traversal-excludes.ids]]
-# name = 'testcycles-base'
-# version = '0.1.0'
-# workspace-path = ''
 #
-# [[traversal-excludes.ids]]
-# name = 'testcycles-helper'
-# version = '0.1.0'
-# path = '../testcycles-helper'
+# [traversal-excludes]
 # [[final-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'
 # workspace-path = ''
-#
-# [[final-excludes.ids]]
-# name = 'testcycles-helper'
-# version = '0.1.0'
-# path = '../testcycles-helper'
+
+[dependencies]
+testcycles-helper = { path = "/Users/fakeuser/local/testcrates/testcycles/testcycles-base/../testcycles-helper", default-features = false }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_cycle1-1.toml
+++ b/fixtures/small/hakari/metadata_cycle1-1.toml
@@ -2,21 +2,16 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle1
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'auto'
+# resolver = '2'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
 # dep-format-version = '1'
-# workspace-hack-line-style = 'full'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['s390x-unknown-linux-gnu', 'x86_64-apple-ios', 'mipsel-unknown-linux-uclibc']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'
 # workspace-path = ''
-# [[final-excludes.ids]]
-# name = 'testcycles-base'
-# version = '0.1.0'
-# workspace-path = ''
-#
 # [[final-excludes.ids]]
 # name = 'testcycles-helper'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -2,11 +2,11 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle2
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'unify-if-both'
+# resolver = 'install'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
-# workspace-hack-line-style = 'full'
+# dep-format-version = '3'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['aarch64-apple-ios-sim', 'x86_64-unknown-fuchsia']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
@@ -22,16 +22,6 @@
 # name = 'upper-a'
 # version = '0.1.0'
 # workspace-path = 'upper-a'
-#
-# [[traversal-excludes.ids]]
-# name = 'upper-b'
-# version = '0.1.0'
-# workspace-path = 'upper-b'
-# [[final-excludes.ids]]
-# name = 'lower-a'
-# version = '0.1.0'
-# workspace-path = 'lower-a'
-#
 # [[final-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'
@@ -41,11 +31,6 @@
 # name = 'upper-a'
 # version = '0.1.0'
 # workspace-path = 'upper-a'
-#
-# [[final-excludes.ids]]
-# name = 'upper-b'
-# version = '0.1.0'
-# workspace-path = 'upper-b'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_cycle2-1.toml
+++ b/fixtures/small/hakari/metadata_cycle2-1.toml
@@ -2,10 +2,10 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle2
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'none'
-# output-single-feature = true
-# dep-format-version = '1'
+# resolver = 'install'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
+# dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
 # platforms = ['armv7-unknown-linux-gnueabihf']
 # [[traversal-excludes.ids]]
@@ -13,7 +13,29 @@
 # version = '0.1.0'
 # workspace-path = 'lower-a'
 #
-# [final-excludes]
+# [[traversal-excludes.ids]]
+# name = 'lower-b'
+# version = '0.1.0'
+# workspace-path = 'lower-b'
+#
+# [[traversal-excludes.ids]]
+# name = 'upper-b'
+# version = '0.1.0'
+# workspace-path = 'upper-b'
+# [[final-excludes.ids]]
+# name = 'lower-a'
+# version = '0.1.0'
+# workspace-path = 'lower-a'
+#
+# [[final-excludes.ids]]
+# name = 'lower-b'
+# version = '0.1.0'
+# workspace-path = 'lower-b'
+#
+# [[final-excludes.ids]]
+# name = 'upper-a'
+# version = '0.1.0'
+# workspace-path = 'upper-a'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_cycle2-2.toml
+++ b/fixtures/small/hakari/metadata_cycle2-2.toml
@@ -2,18 +2,33 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle2
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '3'
+# unify-target-host = 'none'
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['powerpc-unknown-linux-muslspe', 'aarch64-apple-visionos', 'wasm32-unknown-emscripten']
-# [[traversal-excludes.ids]]
+#
+# [traversal-excludes]
+# [[final-excludes.ids]]
+# name = 'lower-a'
+# version = '0.1.0'
+# workspace-path = 'lower-a'
+#
+# [[final-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'
 # workspace-path = 'lower-b'
 #
-# [final-excludes]
+# [[final-excludes.ids]]
+# name = 'upper-a'
+# version = '0.1.0'
+# workspace-path = 'upper-a'
+#
+# [[final-excludes.ids]]
+# name = 'upper-b'
+# version = '0.1.0'
+# workspace-path = 'upper-b'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_cycle2-3.toml
+++ b/fixtures/small/hakari/metadata_cycle2-3.toml
@@ -2,26 +2,21 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle2
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'unify-if-both'
+# resolver = '2'
+# unify-target-host = 'auto'
 # output-single-feature = false
-# dep-format-version = '4'
-# workspace-hack-line-style = 'version-only'
+# dep-format-version = '2'
+# workspace-hack-line-style = 'full'
 # platforms = ['powerpc64le-unknown-freebsd']
-# [[traversal-excludes.ids]]
-# name = 'lower-a'
-# version = '0.1.0'
-# workspace-path = 'lower-a'
-#
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'
 # workspace-path = 'lower-b'
-#
-# [[traversal-excludes.ids]]
-# name = 'upper-a'
+# [[final-excludes.ids]]
+# name = 'lower-a'
 # version = '0.1.0'
-# workspace-path = 'upper-a'
+# workspace-path = 'lower-a'
+#
 # [[final-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-0.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-0.toml
@@ -2,12 +2,17 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_cycle_features
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '2'
+# unify-target-host = 'none'
 # output-single-feature = true
-# dep-format-version = '1'
-# workspace-hack-line-style = 'workspace-dotted'
+# dep-format-version = '4'
+# workspace-hack-line-style = 'full'
 # platforms = ['armv7-unknown-freebsd', 'riscv32imafc-unknown-none-elf', 'x86_64-apple-ios']
+# [[traversal-excludes.ids]]
+# name = 'testcycles-base'
+# version = '0.1.0'
+# workspace-path = 'testcycles-base'
+#
 # [[traversal-excludes.ids]]
 # name = 'testcycles-helper'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_dups-2.toml
+++ b/fixtures/small/hakari/metadata_dups-2.toml
@@ -2,8 +2,8 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_dups
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '2'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
@@ -14,12 +14,6 @@
 # [final-excludes]
 
 [dependencies]
-bytes-468e82937335b1c9 = { package = "bytes", version = "0.3", default-features = false }
-bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["std"] }
-lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
-lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
-
-[build-dependencies]
 bytes-468e82937335b1c9 = { package = "bytes", version = "0.3", default-features = false }
 bytes-d8f496e17d97b5cb = { package = "bytes", version = "0.5", features = ["std"] }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -2,21 +2,14 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_dups
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
-# unify-target-host = 'none'
-# output-single-feature = true
-# dep-format-version = '2'
-# workspace-hack-line-style = 'full'
+# resolver = '2'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
+# dep-format-version = '4'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['armv4t-unknown-linux-gnueabi']
-# [[traversal-excludes.ids]]
-# name = 'bytes'
-# version = '0.3.0'
-# crates-io = true
 #
-# [[traversal-excludes.ids]]
-# name = 'testcrate-dups'
-# version = '0.1.0'
-# workspace-path = ''
+# [traversal-excludes]
 # [[final-excludes.ids]]
 # name = 'bytes'
 # version = '0.3.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-1.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-1.toml
@@ -2,30 +2,35 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_proc_macro1
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '3'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = false
 # dep-format-version = '1'
-# workspace-hack-line-style = 'full'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['x86_64-apple-watchos-sim', 'armv8r-none-eabihf', 'armv7a-kmc-solid_asp3-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'
 # version = '0.1.0'
 # workspace-path = 'dev-user'
-#
-# [[traversal-excludes.ids]]
-# name = 'macro'
+# [[final-excludes.ids]]
+# name = 'build-user'
 # version = '0.1.0'
-# workspace-path = 'macro'
+# workspace-path = 'build-user'
 #
-# [[traversal-excludes.ids]]
-# name = 'normal-user'
+# [[final-excludes.ids]]
+# name = 'dev-user'
 # version = '0.1.0'
-# workspace-path = 'normal-user'
+# workspace-path = 'dev-user'
+#
 # [[final-excludes.ids]]
 # name = 'macro'
 # version = '0.1.0'
 # workspace-path = 'macro'
+#
+# [[final-excludes.ids]]
+# name = 'normal-user'
+# version = '0.1.0'
+# workspace-path = 'normal-user'
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_targets1-0.toml
@@ -2,34 +2,39 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_targets1
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'none'
+# resolver = '3'
+# unify-target-host = 'unify-if-both'
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['aarch64-apple-ios-sim', 'armv7-unknown-linux-musleabi']
 # [[traversal-excludes.ids]]
-# name = 'dep-a'
-# version = '0.1.0'
-# path = '../dep-a'
+# name = 'bytes'
+# version = '0.5.3'
+# crates-io = true
 #
 # [[traversal-excludes.ids]]
 # name = 'lazy_static'
 # version = '0.1.16'
 # crates-io = true
-# [[final-excludes.ids]]
-# name = 'dep-a'
-# version = '0.1.0'
-# path = '../dep-a'
 #
+# [[traversal-excludes.ids]]
+# name = 'lazy_static'
+# version = '0.2.11'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'lazy_static'
+# version = '1.4.0'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'serde'
+# version = '1.0.105'
+# crates-io = true
 # [[final-excludes.ids]]
 # name = 'lazy_static'
 # version = '0.1.16'
-# crates-io = true
-#
-# [[final-excludes.ids]]
-# name = 'lazy_static'
-# version = '0.2.11'
 # crates-io = true
 #
 # [[final-excludes.ids]]
@@ -38,17 +43,18 @@
 # crates-io = true
 #
 # [[final-excludes.ids]]
-# name = 'serde'
-# version = '1.0.105'
-# crates-io = true
-#
-# [[final-excludes.ids]]
 # name = 'testcrate-targets'
 # version = '0.1.0'
 # workspace-path = ''
 
 [dependencies]
-bytes = { version = "0.5", default-features = false, features = ["serde"] }
+dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false }
+
+[target.aarch64-apple-ios-sim.dependencies]
+dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false, features = ["baz", "foo", "quux"] }
+
+[target.armv7-unknown-linux-musleabi.dependencies]
+dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false, features = ["baz", "foo", "quux"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_targets1-2.toml
@@ -2,29 +2,40 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_targets1
 
 ### BEGIN HAKARI SECTION
-# resolver = '1'
-# unify-target-host = 'unify-if-both'
-# output-single-feature = true
-# dep-format-version = '3'
+# resolver = 'install'
+# unify-target-host = 'replicate-target-on-host'
+# output-single-feature = false
+# dep-format-version = '4'
 # workspace-hack-line-style = 'full'
 # platforms = ['i686-unknown-openbsd', 'armebv7r-none-eabihf', 'riscv32em-unknown-none-elf']
 # [[traversal-excludes.ids]]
-# name = 'dep-a'
-# version = '0.1.0'
-# path = '../dep-a'
+# name = 'serde'
+# version = '1.0.105'
+# crates-io = true
 #
 # [[traversal-excludes.ids]]
-# name = 'lazy_static'
-# version = '1.4.0'
+# name = 'testcrate-targets'
+# version = '0.1.0'
+# workspace-path = ''
+# [[final-excludes.ids]]
+# name = 'bytes'
+# version = '0.5.3'
 # crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'lazy_static'
+# version = '0.1.16'
+# crates-io = true
+#
 # [[final-excludes.ids]]
 # name = 'lazy_static'
 # version = '0.2.11'
 # crates-io = true
-
-[dependencies]
-bytes = { version = "0.5", features = ["serde"] }
-serde = { version = "1" }
+#
+# [[final-excludes.ids]]
+# name = 'testcrate-targets'
+# version = '0.1.0'
+# workspace-path = ''
 
 ### END HAKARI SECTION
 

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
@@ -2,9 +2,9 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_weak_namespaced_features
 
 ### BEGIN HAKARI SECTION
-# resolver = 'install'
+# resolver = '2'
 # unify-target-host = 'replicate-target-on-host'
-# output-single-feature = true
+# output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
 # platforms = []
@@ -12,11 +12,6 @@
 # name = 'arrayvec'
 # version = '0.7.2'
 # crates-io = true
-#
-# [[traversal-excludes.ids]]
-# name = 'namespaced-weak'
-# version = '0.1.0'
-# workspace-path = ''
 # [[final-excludes.ids]]
 # name = 'namespaced-weak'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
@@ -2,11 +2,11 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_weak_namespaced_features
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'unify-if-both'
+# resolver = '3'
+# unify-target-host = 'replicate-target-on-host'
 # output-single-feature = false
-# dep-format-version = '2'
-# workspace-hack-line-style = 'full'
+# dep-format-version = '1'
+# workspace-hack-line-style = 'workspace-dotted'
 # platforms = ['wasm64-unknown-unknown', 'mipsel-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'
@@ -22,9 +22,34 @@
 # name = 'pathdiff'
 # version = '0.2.1'
 # crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'smallvec'
+# version = '1.8.0'
+# crates-io = true
+#
+# [[traversal-excludes.ids]]
+# name = 'tinyvec'
+# version = '1.5.1'
+# crates-io = true
 # [[final-excludes.ids]]
-# name = 'arrayvec'
-# version = '0.7.2'
+# name = 'namespaced-weak'
+# version = '0.1.0'
+# workspace-path = ''
+#
+# [[final-excludes.ids]]
+# name = 'pathdiff'
+# version = '0.2.1'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'smallvec'
+# version = '1.8.0'
+# crates-io = true
+#
+# [[final-excludes.ids]]
+# name = 'tinyvec'
+# version = '1.5.1'
 # crates-io = true
 
 ### END HAKARI SECTION

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-3.toml
@@ -2,30 +2,28 @@
 #    cargo run -p fixture-manager -- generate-hakari --fixture metadata_weak_namespaced_features
 
 ### BEGIN HAKARI SECTION
-# resolver = '2'
-# unify-target-host = 'replicate-target-on-host'
+# resolver = '3'
+# unify-target-host = 'auto'
 # output-single-feature = true
-# dep-format-version = '3'
-# workspace-hack-line-style = 'full'
+# dep-format-version = '2'
+# workspace-hack-line-style = 'version-only'
 # platforms = ['sparc64-unknown-openbsd', 'riscv64gc-unknown-freebsd', 'riscv32imac-unknown-none-elf']
-# [[traversal-excludes.ids]]
-# name = 'arrayvec'
-# version = '0.7.2'
-# crates-io = true
-#
 # [[traversal-excludes.ids]]
 # name = 'smallvec'
 # version = '1.8.0'
 # crates-io = true
 # [[final-excludes.ids]]
-# name = 'smallvec'
-# version = '1.8.0'
+# name = 'namespaced-weak'
+# version = '0.1.0'
+# workspace-path = ''
+#
+# [[final-excludes.ids]]
+# name = 'tinyvec'
+# version = '1.5.1'
 # crates-io = true
 
 [dependencies]
-pathdiff = { version = "0.2", default-features = false }
-
-[build-dependencies]
+arrayvec = { version = "0.7", default-features = false, features = ["std"] }
 pathdiff = { version = "0.2", default-features = false }
 
 ### END HAKARI SECTION

--- a/fixtures/small/summaries/metadata1-1.toml
+++ b/fixtures/small/summaries/metadata1-1.toml
@@ -2,24 +2,32 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata1
 
 [metadata]
-resolver = 'install'
-include-dev = false
-initials-platform = 'standard'
+resolver = '2'
+include-dev = true
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'armv7-unknown-linux-uclibceabihf'
+target-features = 'unknown'
+flags = ['cargo_web', 'flag-test']
 
 [metadata.target-platform]
-spec = 'always'
+triple = 'i686-apple-darwin'
+target-features = ['sse3', 'sse4.1', 'sse4.2', 'ssse3', 'xsave']
 [[metadata.omitted-packages.ids]]
-name = 'memchr'
-version = '2.2.1'
+name = 'linked-hash-map'
+version = '0.5.2'
 crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'testcrate'
+version = '0.1.0'
+workspace-path = ''
 
 [[metadata.omitted-packages.ids]]
 name = 'walkdir'
 version = '2.2.9'
-source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'testcrate'
@@ -41,7 +49,8 @@ name = 'datatest'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
-features = ['default']
+features = ['default', 'region', 'unsafe_test_runner']
+optional-deps = ['region']
 
 [[target-package]]
 name = 'aho-corasick'
@@ -49,6 +58,13 @@ version = '0.7.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[target-package]]
 name = 'dtoa'
@@ -65,11 +81,25 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
+name = 'libc'
+version = '0.2.62'
 crates-io = true
 status = 'transitive'
-features = []
+features = ['default', 'std', 'use_std']
+
+[[target-package]]
+name = 'mach'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'deprecated', 'use_std']
+
+[[target-package]]
+name = 'memchr'
+version = '2.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
 
 [[target-package]]
 name = 'regex'
@@ -85,6 +115,20 @@ version = '0.6.12'
 crates-io = true
 status = 'transitive'
 features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'region'
+version = '2.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'serde'
@@ -104,6 +148,13 @@ features = []
 name = 'thread_local'
 version = '0.3.6'
 crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'walkdir'
+version = '2.2.9'
+source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
 status = 'transitive'
 features = []
 

--- a/fixtures/small/summaries/metadata1-3.toml
+++ b/fixtures/small/summaries/metadata1-3.toml
@@ -2,20 +2,24 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata1
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'thumbv5te-none-eabi'
-target-features = 'all'
+spec = 'any'
 [[metadata.omitted-packages.ids]]
-name = 'serde'
-version = '1.0.100'
+name = 'walkdir'
+version = '2.2.9'
 crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'walkdir'
+version = '2.2.9'
+source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
 
 [[metadata.features-only]]
 name = 'testcrate'
@@ -35,7 +39,8 @@ name = 'datatest'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
-features = ['default']
+features = ['default', 'region', 'unsafe_test_runner']
+optional-deps = ['region']
 
 [[target-package]]
 name = 'aho-corasick'
@@ -43,6 +48,13 @@ version = '0.7.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
 
 [[target-package]]
 name = 'dtoa'
@@ -59,11 +71,25 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'libc'
+version = '0.2.62'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std', 'use_std']
+
+[[target-package]]
 name = 'linked-hash-map'
 version = '0.5.2'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'mach'
+version = '0.2.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'deprecated', 'use_std']
 
 [[target-package]]
 name = 'memchr'
@@ -88,11 +114,18 @@ status = 'transitive'
 features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
 
 [[target-package]]
-name = 'same-file'
-version = '1.0.5'
+name = 'region'
+version = '2.1.2'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.100'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'serde_yaml'
@@ -109,9 +142,23 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'walkdir'
-version = '2.2.9'
-source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['basetsd', 'memoryapi', 'minwindef', 'sysinfoapi', 'winnt']
+
+[[target-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
 status = 'transitive'
 features = []
 

--- a/fixtures/small/summaries/metadata1-5.toml
+++ b/fixtures/small/summaries/metadata1-5.toml
@@ -2,26 +2,28 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata1
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'loongarch64-unknown-linux-gnu'
+target-features = 'unknown'
+flags = ['foo']
 
 [metadata.target-platform]
-triple = 'i686-wrs-vxworks'
+triple = 'x86_64-unknown-l4re-uclibc'
 target-features = 'all'
-flags = ['bar']
+flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]
-name = 'quote'
-version = '1.0.2'
+name = 'bitflags'
+version = '1.1.0'
 crates-io = true
 
 [[metadata.omitted-packages.ids]]
-name = 'testcrate'
-version = '0.1.0'
-workspace-path = ''
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'testcrate'
@@ -177,34 +179,6 @@ features = []
 name = 'walkdir'
 version = '2.2.9'
 source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
-
-[[host-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-util'
-version = '0.1.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-x86_64-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
 status = 'transitive'
 features = []
 

--- a/fixtures/small/summaries/metadata1-7.toml
+++ b/fixtures/small/summaries/metadata1-7.toml
@@ -2,47 +2,146 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata1
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'host'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'arm64_32-apple-watchos'
-target-features = 'unknown'
-flags = ['flag-test', 'foo']
+triple = 'aarch64-apple-watchos-sim'
+target-features = []
 
 [metadata.target-platform]
-triple = 'sparc64-unknown-netbsd'
+triple = 'wasm32-unknown-unknown'
 target-features = 'all'
-flags = ['foo']
-[[metadata.omitted-packages.ids]]
-name = 'bitflags'
-version = '1.1.0'
-crates-io = true
+flags = ['bar']
 
-[[metadata.omitted-packages.ids]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-
-[[host-package]]
+[[target-package]]
 name = 'testcrate'
 version = '0.1.0'
 workspace-path = ''
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'datatest'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
+features = ['default', 'region', 'unsafe_test_runner']
+optional-deps = ['region']
+
+[[target-package]]
+name = 'aho-corasick'
+version = '0.7.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'bitflags'
+version = '1.1.0'
+crates-io = true
+status = 'transitive'
 features = ['default']
+
+[[target-package]]
+name = 'dtoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'libc'
+version = '0.2.62'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'memchr'
+version = '2.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[target-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[target-package]]
+name = 'regex-syntax'
+version = '0.6.12'
+crates-io = true
+status = 'transitive'
+features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[target-package]]
+name = 'region'
+version = '2.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.100'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
+name = 'serde_yaml'
+version = '0.8.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'thread_local'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'walkdir'
+version = '2.2.9'
+source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'yaml-rust'
+version = '0.4.3'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'ctor'
@@ -54,20 +153,6 @@ features = []
 [[host-package]]
 name = 'datatest-derive'
 version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'dtoa'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
 crates-io = true
 status = 'transitive'
 features = []
@@ -87,27 +172,6 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
-name = 'same-file'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'serde'
-version = '1.0.100'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'serde_yaml'
-version = '0.8.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'syn'
 version = '1.0.5'
 crates-io = true
@@ -125,20 +189,6 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'walkdir'
-version = '2.2.9'
-source = 'git+https://github.com/BurntSushi/walkdir?tag=2.2.9#7c7013259eb9db400b3e5c7bc60330ca08068826'
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'yaml-rust'
-version = '0.4.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/summaries/metadata2-0.toml
+++ b/fixtures/small/summaries/metadata2-0.toml
@@ -2,68 +2,119 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'host'
+resolver = '3'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'i586-unknown-linux-musl'
+target-features = 'all'
+flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-nuttx-elf'
-target-features = 'unknown'
-flags = ['abc', 'cargo_web']
+triple = 'x86_64-win7-windows-msvc'
+target-features = ['aes', 'avx', 'bmi1', 'fma']
+flags = ['bar']
 [[metadata.omitted-packages.ids]]
-name = 'dtoa'
-version = '0.4.4'
-crates-io = true
+name = 'quote'
+version = '1.0.2'
+path = '../quote'
 
 [[metadata.omitted-packages.ids]]
-name = 'winapi'
-version = '0.3.8'
+name = 'regex'
+version = '1.3.1'
 crates-io = true
 
-[[host-package]]
+[[target-package]]
 name = 'testworkspace-crate'
 version = '0.1.0'
 workspace-path = 'testcrate'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'walkdir'
 version = '2.2.9'
 workspace-path = 'walkdir'
 status = 'workspace'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'datatest'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[host-package]]
+[[target-package]]
 name = 'walkdir'
 version = '0.1.0'
 path = '../walkdir'
 status = 'direct'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'walkdir'
 version = '2.2.9'
 crates-io = true
 status = 'direct'
 features = []
 
-[[host-package]]
-name = 'aho-corasick'
-version = '0.7.6'
+[[target-package]]
+name = 'dtoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'same-file'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.100'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
+
+[[target-package]]
+name = 'serde_yaml'
+version = '0.8.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
+
+[[target-package]]
+name = 'winapi-util'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'yaml-rust'
+version = '0.4.3'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'ctor'
@@ -80,75 +131,11 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'memchr'
-version = '2.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[host-package]]
 name = 'proc-macro2'
 version = '1.0.3'
 crates-io = true
 status = 'transitive'
 features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'quote'
-version = '1.0.2'
-path = '../quote'
-status = 'transitive'
-features = ['default', 'proc-macro']
-
-[[host-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[host-package]]
-name = 'regex-syntax'
-version = '0.6.12'
-crates-io = true
-status = 'transitive'
-features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[host-package]]
-name = 'same-file'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'serde'
-version = '1.0.100'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[host-package]]
-name = 'serde_yaml'
-version = '0.8.9'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'syn'
@@ -157,13 +144,6 @@ crates-io = true
 status = 'transitive'
 features = ['clone-impls', 'default', 'derive', 'fold', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
 optional-deps = ['quote']
-
-[[host-package]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'unicode-xid'
@@ -175,13 +155,6 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'yaml-rust'
-version = '0.4.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/summaries/metadata2-1.toml
+++ b/fixtures/small/summaries/metadata2-1.toml
@@ -2,17 +2,31 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'x86_64-pc-windows-gnullvm'
+target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabi'
-target-features = 'all'
-flags = ['abc', 'cargo_web']
+triple = 'riscv32imc-unknown-nuttx-elf'
+target-features = ['avx']
+[[metadata.omitted-packages.ids]]
+name = 'thread_local'
+version = '0.3.6'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'version_check'
+version = '0.9.1'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'winapi-util'
+version = '0.1.2'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'testworkspace-crate'
@@ -76,13 +90,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'linked-hash-map'
 version = '0.5.2'
 crates-io = true
@@ -128,13 +135,6 @@ features = ['default', 'std']
 [[target-package]]
 name = 'serde_yaml'
 version = '0.8.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '0.3.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -188,10 +188,3 @@ version = '0.2.0'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'version_check'
-version = '0.9.1'
-crates-io = true
-status = 'transitive'
-features = []

--- a/fixtures/small/summaries/metadata2-2.toml
+++ b/fixtures/small/summaries/metadata2-2.toml
@@ -2,13 +2,13 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = '1'
-include-dev = true
+resolver = 'install'
+include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-none-elf'
-target-features = 'all'
+triple = 'aarch64-uwp-windows-msvc'
+target-features = 'unknown'
 
 [metadata.target-platform]
 spec = 'any'
@@ -184,6 +184,20 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
+
+[[host-package]]
+name = 'winapi-util'
+version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/summaries/metadata2-4.toml
+++ b/fixtures/small/summaries/metadata2-4.toml
@@ -2,15 +2,24 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = 'install'
-include-dev = true
+resolver = '2'
+include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-spec = 'any'
+spec = 'always'
 
 [metadata.target-platform]
 spec = 'always'
+[[metadata.omitted-packages.ids]]
+name = 'proc-macro2'
+version = '1.0.3'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'testworkspace-crate'

--- a/fixtures/small/summaries/metadata2-5.toml
+++ b/fixtures/small/summaries/metadata2-5.toml
@@ -2,79 +2,209 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'any'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'riscv32gc-unknown-linux-gnu'
+target-features = 'all'
+flags = ['bar', 'cargo_web']
 [[metadata.omitted-packages.ids]]
-name = 'datatest'
-version = '0.4.2'
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
 crates-io = true
 
-[[target-package]]
+[[host-package]]
 name = 'testworkspace-crate'
 version = '0.1.0'
 workspace-path = 'testcrate'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'walkdir'
 version = '2.2.9'
 workspace-path = 'walkdir'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
+name = 'datatest'
+version = '0.4.2'
+crates-io = true
+status = 'direct'
+features = ['default']
+
+[[host-package]]
 name = 'walkdir'
 version = '0.1.0'
 path = '../walkdir'
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'walkdir'
 version = '2.2.9'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
+name = 'aho-corasick'
+version = '0.7.6'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'ctor'
+version = '0.1.10'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'datatest-derive'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'dtoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
+name = 'proc-macro2'
+version = '1.0.3'
+crates-io = true
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'quote'
+version = '1.0.2'
+path = '../quote'
+status = 'transitive'
+features = ['default', 'proc-macro']
+
+[[host-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.6.12'
+crates-io = true
+status = 'transitive'
+features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
 name = 'same-file'
 version = '1.0.5'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[target-package]]
+[[host-package]]
+name = 'serde'
+version = '1.0.100'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_yaml'
+version = '0.8.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'syn'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = ['clone-impls', 'default', 'derive', 'fold', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
+optional-deps = ['quote']
+
+[[host-package]]
+name = 'thread_local'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'unicode-xid'
+version = '0.2.0'
+crates-io = true
+status = 'transitive'
+features = ['default']
+
+[[host-package]]
+name = 'version_check'
+version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'winapi'
 version = '0.3.8'
 crates-io = true
 status = 'transitive'
 features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
 
-[[target-package]]
-name = 'winapi-i686-pc-windows-gnu'
-version = '0.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
+[[host-package]]
 name = 'winapi-util'
 version = '0.1.2'
 crates-io = true
 status = 'transitive'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'winapi-x86_64-pc-windows-gnu'
 version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'yaml-rust'
+version = '0.4.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/summaries/metadata2-6.toml
+++ b/fixtures/small/summaries/metadata2-6.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata2
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'any'
@@ -12,125 +12,47 @@ spec = 'any'
 [metadata.target-platform]
 spec = 'always'
 
-[[target-package]]
+[[host-package]]
 name = 'testworkspace-crate'
 version = '0.1.0'
 workspace-path = 'testcrate'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'walkdir'
 version = '2.2.9'
 workspace-path = 'walkdir'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'datatest'
 version = '0.4.2'
 crates-io = true
 status = 'direct'
 features = ['default']
 
-[[target-package]]
+[[host-package]]
 name = 'walkdir'
 version = '0.1.0'
 path = '../walkdir'
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'walkdir'
 version = '2.2.9'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'aho-corasick'
 version = '0.7.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'std']
-
-[[target-package]]
-name = 'dtoa'
-version = '0.4.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'linked-hash-map'
-version = '0.5.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'memchr'
-version = '2.2.1'
-crates-io = true
-status = 'transitive'
-features = ['default', 'use_std']
-
-[[target-package]]
-name = 'regex'
-version = '1.3.1'
-crates-io = true
-status = 'transitive'
-features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-optional-deps = ['aho-corasick', 'memchr', 'thread_local']
-
-[[target-package]]
-name = 'regex-syntax'
-version = '0.6.12'
-crates-io = true
-status = 'transitive'
-features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
-
-[[target-package]]
-name = 'same-file'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'serde'
-version = '1.0.100'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'serde_yaml'
-version = '0.8.9'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'thread_local'
-version = '0.3.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'yaml-rust'
-version = '0.4.3'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'ctor'
@@ -147,6 +69,34 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'dtoa'
+version = '0.4.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'linked-hash-map'
+version = '0.5.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'memchr'
+version = '2.2.1'
+crates-io = true
+status = 'transitive'
+features = ['default', 'use_std']
+
+[[host-package]]
 name = 'proc-macro2'
 version = '1.0.3'
 crates-io = true
@@ -161,12 +111,55 @@ status = 'transitive'
 features = ['default', 'proc-macro']
 
 [[host-package]]
+name = 'regex'
+version = '1.3.1'
+crates-io = true
+status = 'transitive'
+features = ['aho-corasick', 'default', 'memchr', 'perf', 'perf-cache', 'perf-dfa', 'perf-inline', 'perf-literal', 'std', 'thread_local', 'unicode', 'unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+optional-deps = ['aho-corasick', 'memchr', 'thread_local']
+
+[[host-package]]
+name = 'regex-syntax'
+version = '0.6.12'
+crates-io = true
+status = 'transitive'
+features = ['unicode-age', 'unicode-bool', 'unicode-case', 'unicode-gencat', 'unicode-perl', 'unicode-script', 'unicode-segment']
+
+[[host-package]]
+name = 'same-file'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'serde'
+version = '1.0.100'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
+name = 'serde_yaml'
+version = '0.8.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'syn'
 version = '1.0.5'
 crates-io = true
 status = 'transitive'
 features = ['clone-impls', 'default', 'derive', 'fold', 'full', 'parsing', 'printing', 'proc-macro', 'quote']
 optional-deps = ['quote']
+
+[[host-package]]
+name = 'thread_local'
+version = '0.3.6'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'unicode-xid'
@@ -178,6 +171,41 @@ features = ['default']
 [[host-package]]
 name = 'version_check'
 version = '0.9.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['consoleapi', 'errhandlingapi', 'fileapi', 'minwindef', 'processenv', 'std', 'winbase', 'wincon', 'winerror', 'winnt']
+
+[[host-package]]
+name = 'winapi-i686-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi-util'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'winapi-x86_64-pc-windows-gnu'
+version = '0.4.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
+name = 'yaml-rust'
+version = '0.4.3'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/small/summaries/metadata_alternate_registries-0.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-0.toml
@@ -2,13 +2,13 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_alternate_registries
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-fuchsia'
-target-features = 'all'
+triple = 'x86_64-unknown-hermit'
+target-features = 'unknown'
 
 [metadata.target-platform]
 spec = 'always'
@@ -31,36 +31,8 @@ status = 'initial'
 features = []
 
 [[host-package]]
-name = 'serde_json'
-version = '1.0.68'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[host-package]]
 name = 'unicode-xid'
 version = '0.2.2'
 crates-io = true
 status = 'direct'
 features = ['default']
-
-[[host-package]]
-name = 'itoa'
-version = '0.4.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'ryu'
-version = '1.0.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'serde'
-version = '1.0.130'
-crates-io = true
-status = 'transitive'
-features = ['std']

--- a/fixtures/small/summaries/metadata_alternate_registries-1.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-1.toml
@@ -2,24 +2,23 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_alternate_registries
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'host'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv7k-apple-watchos'
-target-features = ['aes', 'fma', 'sha', 'sse2', 'xsavec']
+triple = 'x86_64-apple-watchos-sim'
+target-features = ['sse2', 'sse4.2', 'ssse3']
 
 [metadata.target-platform]
-triple = 'mipsel-sony-psx'
-target-features = 'all'
+spec = 'always'
 [[metadata.omitted-packages.ids]]
 name = 'quote'
 version = '1.0.10'
 source = 'registry+https://github.com/fakeorg/crates.io-index'
 
 [[metadata.omitted-packages.ids]]
-name = 'serde_derive'
+name = 'serde'
 version = '1.0.130'
 source = 'registry+https://github.com/fakeorg/crates.io-index'
 
@@ -35,7 +34,7 @@ workspace-path = ''
 features = ['serde']
 optional-deps = ['serde']
 
-[[host-package]]
+[[target-package]]
 name = 'debug-ignore'
 version = '1.0.1'
 workspace-path = ''
@@ -43,15 +42,7 @@ status = 'initial'
 features = ['serde']
 optional-deps = ['serde']
 
-[[host-package]]
-name = 'serde'
-version = '1.0.130'
-source = 'registry+https://github.com/fakeorg/crates.io-index'
-status = 'direct'
-features = ['derive', 'serde_derive']
-optional-deps = ['serde_derive']
-
-[[host-package]]
+[[target-package]]
 name = 'unicode-xid'
 version = '0.2.2'
 crates-io = true

--- a/fixtures/small/summaries/metadata_alternate_registries-2.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-2.toml
@@ -2,20 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_alternate_registries
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-uclibc'
-target-features = 'all'
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'syn'
-version = '1.0.80'
-source = 'registry+https://github.com/fakeorg/crates.io-index'
+triple = 'x86_64-unknown-haiku'
+target-features = ['bmi2', 'fma', 'rdrand', 'sse4.1', 'sse4.2', 'xsavec']
+flags = ['cargo_web', 'flag-test']
 
 [[target-package]]
 name = 'debug-ignore'

--- a/fixtures/small/summaries/metadata_alternate_registries-3.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-3.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_alternate_registries
 
 [metadata]
-resolver = '1'
-include-dev = false
-initials-platform = 'proc-macros-on-target'
+resolver = 'install'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'always'
@@ -40,8 +40,29 @@ features = ['derive', 'serde_derive']
 optional-deps = ['serde_derive']
 
 [[target-package]]
+name = 'serde_json'
+version = '1.0.68'
+crates-io = true
+status = 'direct'
+features = ['default', 'std']
+
+[[target-package]]
 name = 'unicode-xid'
 version = '0.2.2'
 crates-io = true
 status = 'direct'
 features = ['default']
+
+[[target-package]]
+name = 'ryu'
+version = '1.0.5'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'serde'
+version = '1.0.130'
+crates-io = true
+status = 'transitive'
+features = ['std']

--- a/fixtures/small/summaries/metadata_build_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-1.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_build_targets1
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'always'

--- a/fixtures/small/summaries/metadata_build_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-2.toml
@@ -2,16 +2,16 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_build_targets1
 
 [metadata]
-resolver = '1'
-include-dev = true
+resolver = 'install'
+include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'aarch64-wrs-vxworks'
+target-features = 'all'
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-linux-musl'
-target-features = 'all'
+spec = 'any'
 [[metadata.omitted-packages.ids]]
 name = 'testcrate'
 version = '0.1.0'

--- a/fixtures/small/summaries/metadata_build_targets1-3.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-3.toml
@@ -2,7 +2,7 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_build_targets1
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
 initials-platform = 'standard'
 
@@ -10,8 +10,13 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc64le-unknown-linux-musl'
-target-features = ['ssse3']
+triple = 'thumbv7a-uwp-windows-msvc'
+target-features = ['aes', 'sha', 'sse', 'sse4.2', 'xsave', 'xsaves']
+flags = ['test-flag']
+[[metadata.omitted-packages.ids]]
+name = 'testcrate'
+version = '0.1.0'
+workspace-path = ''
 
 [[target-package]]
 name = 'testcrate'

--- a/fixtures/small/summaries/metadata_build_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-6.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_build_targets1
 
 [metadata]
-resolver = '2'
-include-dev = true
-initials-platform = 'standard'
+resolver = '3'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'always'
@@ -23,7 +23,7 @@ version = '0.1.0'
 workspace-path = ''
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'testcrate'
 version = '0.1.0'
 workspace-path = ''

--- a/fixtures/small/summaries/metadata_builddep-0.toml
+++ b/fixtures/small/summaries/metadata_builddep-0.toml
@@ -2,19 +2,15 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_builddep
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'standard'
+resolver = '2'
+include-dev = false
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-gnu'
-target-features = 'all'
-flags = ['test-flag']
+spec = 'any'
 
 [metadata.target-platform]
-triple = 'thumbv8m.base-none-eabi'
-target-features = 'unknown'
-flags = ['test-flag']
+spec = 'always'
 [[metadata.omitted-packages.ids]]
 name = 'builddep'
 version = '0.1.0'

--- a/fixtures/small/summaries/metadata_builddep-1.toml
+++ b/fixtures/small/summaries/metadata_builddep-1.toml
@@ -2,12 +2,14 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_builddep
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'armv7r-none-eabi'
+target-features = 'all'
+flags = ['test-flag']
 
 [metadata.target-platform]
 spec = 'any'

--- a/fixtures/small/summaries/metadata_builddep-5.toml
+++ b/fixtures/small/summaries/metadata_builddep-5.toml
@@ -2,16 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_builddep
 
 [metadata]
-resolver = '2'
-include-dev = false
+resolver = '3'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'wasm32-wasi'
-target-features = 'all'
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'always'
+triple = 'x86_64-pc-windows-msvc'
+target-features = 'all'
+flags = ['flag-test', 'test-flag']
 [[metadata.omitted-packages.ids]]
 name = 'main'
 version = '0.1.0'

--- a/fixtures/small/summaries/metadata_builddep-6.toml
+++ b/fixtures/small/summaries/metadata_builddep-6.toml
@@ -2,17 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_builddep
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'arm-unknown-linux-gnueabihf'
-target-features = 'all'
-flags = ['cargo_web', 'foo']
+spec = 'any'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'x86_64h-apple-darwin'
+target-features = ['fma', 'rdrand', 'sha']
+flags = ['abc']
 
 [[host-package]]
 name = 'builddep'

--- a/fixtures/small/summaries/metadata_builddep-7.toml
+++ b/fixtures/small/summaries/metadata_builddep-7.toml
@@ -2,15 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_builddep
 
 [metadata]
-resolver = '2'
-include-dev = false
+resolver = '3'
+include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'armv7r-none-eabi'
+target-features = []
+flags = ['flag-test']
 
 [metadata.target-platform]
-spec = 'always'
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'builddep'
+version = '0.1.0'
+workspace-path = 'builddep'
 
 [[metadata.features-only]]
 name = 'main'

--- a/fixtures/small/summaries/metadata_cycle1-0.toml
+++ b/fixtures/small/summaries/metadata_cycle1-0.toml
@@ -2,28 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = '1'
-include-dev = false
+resolver = 'install'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'wasm64-unknown-unknown'
-target-features = 'unknown'
-flags = ['cargo_web']
+spec = 'any'
 
 [metadata.target-platform]
-triple = 'riscv32imc-esp-espidf'
-target-features = []
-flags = ['foo']
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-base'
-version = '0.1.0'
-workspace-path = ''
-
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-helper'
-version = '0.1.0'
-path = '../testcycles-helper'
+triple = 'armv7-sony-vita-newlibeabihf'
+target-features = 'unknown'
+flags = ['bar']
 
 [[metadata.features-only]]
 name = 'testcycles-base'
@@ -36,4 +25,11 @@ name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = ''
 status = 'initial'
+features = []
+
+[[target-package]]
+name = 'testcycles-helper'
+version = '0.1.0'
+path = '../testcycles-helper'
+status = 'direct'
 features = []

--- a/fixtures/small/summaries/metadata_cycle1-1.toml
+++ b/fixtures/small/summaries/metadata_cycle1-1.toml
@@ -2,26 +2,15 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-hermit'
-target-features = 'unknown'
-flags = ['abc', 'bar']
+spec = 'any'
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-base'
-version = '0.1.0'
-workspace-path = ''
-
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-helper'
-version = '0.1.0'
-path = '../testcycles-helper'
+spec = 'always'
 
 [[host-package]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle1-2.toml
+++ b/fixtures/small/summaries/metadata_cycle1-2.toml
@@ -2,19 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = '1'
-include-dev = false
-initials-platform = 'host'
+resolver = 'install'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-nto-qnx700'
-target-features = []
-flags = ['flag-test']
+spec = 'any'
 
 [metadata.target-platform]
-spec = 'always'
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'testcycles-helper'
+version = '0.1.0'
+path = '../testcycles-helper'
 
-[[host-package]]
+[[target-package]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = ''

--- a/fixtures/small/summaries/metadata_cycle1-3.toml
+++ b/fixtures/small/summaries/metadata_cycle1-3.toml
@@ -2,21 +2,19 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'aarch64-unknown-linux-ohos'
+target-features = 'unknown'
+flags = ['test-flag']
 
 [metadata.target-platform]
-triple = 'bpfel-unknown-none'
+triple = 'wasm32-wasip1-threads'
 target-features = 'all'
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-base'
-version = '0.1.0'
-workspace-path = ''
-
+flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-helper'
 version = '0.1.0'

--- a/fixtures/small/summaries/metadata_cycle1-5.toml
+++ b/fixtures/small/summaries/metadata_cycle1-5.toml
@@ -2,16 +2,22 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'host'
+resolver = '3'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-none'
-target-features = 'unknown'
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'any'
+triple = 'i686-unknown-linux-musl'
+target-features = 'all'
+flags = ['cargo_web']
+[[metadata.omitted-packages.ids]]
+name = 'testcycles-base'
+version = '0.1.0'
+workspace-path = ''
+
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-helper'
 version = '0.1.0'
@@ -23,7 +29,7 @@ version = '0.1.0'
 workspace-path = ''
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = ''

--- a/fixtures/small/summaries/metadata_cycle1-6.toml
+++ b/fixtures/small/summaries/metadata_cycle1-6.toml
@@ -2,19 +2,22 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle1
 
 [metadata]
-resolver = '2'
-include-dev = false
-initials-platform = 'host'
+resolver = '3'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'armv4t-unknown-linux-gnueabi'
-target-features = 'all'
-flags = ['foo']
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'aarch64-pc-windows-msvc'
-target-features = 'all'
+triple = 'sparc64-unknown-openbsd'
+target-features = 'unknown'
 flags = ['foo']
+[[metadata.omitted-packages.ids]]
+name = 'testcycles-base'
+version = '0.1.0'
+workspace-path = ''
+
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-helper'
 version = '0.1.0'
@@ -26,7 +29,7 @@ version = '0.1.0'
 workspace-path = ''
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = ''

--- a/fixtures/small/summaries/metadata_cycle2-0.toml
+++ b/fixtures/small/summaries/metadata_cycle2-0.toml
@@ -2,19 +2,22 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle2
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'host'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'arm-unknown-linux-gnueabihf'
+target-features = ['aes', 'sha', 'sse4.1', 'ssse3']
 
 [metadata.target-platform]
-spec = 'always'
+triple = 'armv7s-apple-ios'
+target-features = []
+flags = ['flag-test', 'test-flag']
 [[metadata.omitted-packages.ids]]
-name = 'upper-a'
+name = 'lower-a'
 version = '0.1.0'
-workspace-path = 'upper-a'
+workspace-path = 'lower-a'
 
 [[metadata.features-only]]
 name = 'lower-a'
@@ -34,28 +37,28 @@ version = '0.1.0'
 workspace-path = 'upper-b'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'lower-a'
 version = '0.1.0'
 workspace-path = 'lower-a'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'lower-b'
 version = '0.1.0'
 workspace-path = 'lower-b'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'upper-a'
 version = '0.1.0'
 workspace-path = 'upper-a'
 status = 'initial'
 features = []
 
-[[host-package]]
+[[target-package]]
 name = 'upper-b'
 version = '0.1.0'
 workspace-path = 'upper-b'

--- a/fixtures/small/summaries/metadata_cycle2-3.toml
+++ b/fixtures/small/summaries/metadata_cycle2-3.toml
@@ -2,31 +2,26 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle2
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'host'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'powerpc64-unknown-linux-musl'
+target-features = ['sse3']
+flags = ['abc', 'flag-test']
 
 [metadata.target-platform]
-triple = 'wasm32-wasi'
-target-features = 'unknown'
-flags = ['bar']
-[[metadata.omitted-packages.ids]]
-name = 'lower-a'
-version = '0.1.0'
-workspace-path = 'lower-a'
-
+spec = 'any'
 [[metadata.omitted-packages.ids]]
 name = 'lower-b'
 version = '0.1.0'
 workspace-path = 'lower-b'
 
 [[metadata.omitted-packages.ids]]
-name = 'upper-a'
+name = 'upper-b'
 version = '0.1.0'
-workspace-path = 'upper-a'
+workspace-path = 'upper-b'
 
 [[metadata.features-only]]
 name = 'lower-a'
@@ -40,23 +35,30 @@ version = '0.1.0'
 workspace-path = 'lower-b'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'lower-b'
 version = '0.1.0'
 workspace-path = 'lower-b'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'upper-a'
 version = '0.1.0'
 workspace-path = 'upper-a'
 status = 'initial'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'upper-b'
 version = '0.1.0'
 workspace-path = 'upper-b'
 status = 'initial'
+features = []
+
+[[host-package]]
+name = 'lower-a'
+version = '0.1.0'
+workspace-path = 'lower-a'
+status = 'workspace'
 features = []

--- a/fixtures/small/summaries/metadata_cycle2-5.toml
+++ b/fixtures/small/summaries/metadata_cycle2-5.toml
@@ -2,26 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle2
 
 [metadata]
-resolver = 'install'
-include-dev = true
+resolver = '2'
+include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'avr-unknown-gnu-atmega328'
-target-features = 'unknown'
-flags = ['bar']
+triple = 'riscv32e-unknown-none-elf'
+target-features = 'all'
+flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'lower-a'
-version = '0.1.0'
-workspace-path = 'lower-a'
-
-[[metadata.omitted-packages.ids]]
-name = 'lower-b'
-version = '0.1.0'
-workspace-path = 'lower-b'
+spec = 'always'
 
 [[metadata.features-only]]
 name = 'upper-a'

--- a/fixtures/small/summaries/metadata_cycle2-7.toml
+++ b/fixtures/small/summaries/metadata_cycle2-7.toml
@@ -2,24 +2,24 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle2
 
 [metadata]
-resolver = '1'
-include-dev = false
+resolver = 'install'
+include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+spec = 'always'
 
 [metadata.target-platform]
 spec = 'any'
 [[metadata.omitted-packages.ids]]
-name = 'lower-a'
-version = '0.1.0'
-workspace-path = 'lower-a'
-
-[[metadata.omitted-packages.ids]]
 name = 'lower-b'
 version = '0.1.0'
 workspace-path = 'lower-b'
+
+[[metadata.omitted-packages.ids]]
+name = 'upper-b'
+version = '0.1.0'
+workspace-path = 'upper-b'
 
 [[metadata.features-only]]
 name = 'lower-a'
@@ -52,4 +52,11 @@ name = 'upper-b'
 version = '0.1.0'
 workspace-path = 'upper-b'
 status = 'initial'
+features = []
+
+[[target-package]]
+name = 'upper-a'
+version = '0.1.0'
+workspace-path = 'upper-a'
+status = 'workspace'
 features = []

--- a/fixtures/small/summaries/metadata_cycle_features-0.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-0.toml
@@ -2,15 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'i686-pc-windows-msvc'
+target-features = 'all'
+flags = ['foo']
 
 [metadata.target-platform]
-spec = 'always'
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'testcycles-base'
+version = '0.1.0'
+workspace-path = 'testcycles-base'
 
 [[target-package]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle_features-1.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-1.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'always'

--- a/fixtures/small/summaries/metadata_cycle_features-2.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-2.toml
@@ -2,21 +2,28 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'xtensa-esp32s3-none-elf'
+target-features = 'unknown'
+flags = ['bar', 'test-flag']
 
 [metadata.target-platform]
-triple = 'armv4t-unknown-linux-gnueabi'
-target-features = ['fma', 'rdrand', 'sha']
-flags = ['flag-test']
+triple = 'wasm32-unknown-emscripten'
+target-features = 'all'
+flags = ['cargo_web', 'test-flag']
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = 'testcycles-base'
+
+[[metadata.omitted-packages.ids]]
+name = 'testcycles-helper'
+version = '0.1.0'
+workspace-path = 'testcycles-helper'
 
 [[metadata.features-only]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle_features-3.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-3.toml
@@ -2,19 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = 'install'
-include-dev = true
-initials-platform = 'proc-macros-on-target'
+resolver = '2'
+include-dev = false
+initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-nuttx-elf'
+triple = 'thumbv8m.base-none-eabi'
 target-features = 'all'
-flags = ['foo']
+flags = ['bar']
 
 [metadata.target-platform]
-triple = 'i686-linux-android'
-target-features = ['bmi2', 'sse', 'sse4.1']
-flags = ['bar', 'flag-test']
+spec = 'any'
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-helper'
 version = '0.1.0'
@@ -26,14 +24,14 @@ version = '0.1.0'
 workspace-path = 'testcycles-base'
 features = ['default', 'default-enable', 'default-transitive', 'helper-enable', 'helper-transitive']
 
-[[target-package]]
+[[host-package]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = 'testcycles-base'
 status = 'initial'
 features = ['default', 'default-enable', 'default-transitive', 'helper-enable', 'helper-transitive']
 
-[[target-package]]
+[[host-package]]
 name = 'testcycles-helper'
 version = '0.1.0'
 workspace-path = 'testcycles-helper'

--- a/fixtures/small/summaries/metadata_cycle_features-4.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-4.toml
@@ -2,21 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = '1'
+resolver = 'install'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'riscv64gc-unknown-hermit'
+target-features = 'all'
+flags = ['abc']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-l4re-uclibc'
-target-features = 'all'
-flags = ['foo', 'test-flag']
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-helper'
-version = '0.1.0'
-workspace-path = 'testcycles-helper'
+spec = 'any'
 
 [[metadata.features-only]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle_features-5.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-5.toml
@@ -2,28 +2,22 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = 'install'
-include-dev = false
+resolver = '2'
+include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'loongarch64-unknown-none'
-target-features = 'all'
-flags = ['cargo_web', 'foo']
+triple = 'csky-unknown-linux-gnuabiv2'
+target-features = ['bmi1', 'rdrand', 'sha', 'sse2']
 
 [metadata.target-platform]
-triple = 'i686-unknown-hurd-gnu'
-target-features = 'unknown'
-flags = ['cargo_web', 'foo']
+triple = 'aarch64-unknown-netbsd'
+target-features = 'all'
+flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = 'testcycles-base'
-
-[[metadata.omitted-packages.ids]]
-name = 'testcycles-helper'
-version = '0.1.0'
-workspace-path = 'testcycles-helper'
 
 [[metadata.features-only]]
 name = 'testcycles-helper'
@@ -36,4 +30,11 @@ name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = 'testcycles-base'
 status = 'initial'
+features = []
+
+[[target-package]]
+name = 'testcycles-helper'
+version = '0.1.0'
+workspace-path = 'testcycles-helper'
+status = 'workspace'
 features = []

--- a/fixtures/small/summaries/metadata_cycle_features-7.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-7.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_cycle_features
 
 [metadata]
-resolver = 'install'
-include-dev = false
-initials-platform = 'standard'
+resolver = '2'
+include-dev = true
+initials-platform = 'host'
 
 [metadata.host-platform]
 triple = 'xtensa-esp32s2-espidf'
@@ -14,14 +14,14 @@ target-features = 'all'
 triple = 'armv6-unknown-freebsd'
 target-features = 'all'
 
-[[target-package]]
+[[host-package]]
 name = 'testcycles-base'
 version = '0.1.0'
 workspace-path = 'testcycles-base'
 status = 'initial'
 features = ['default', 'default-enable', 'default-transitive', 'helper-enable', 'helper-transitive']
 
-[[target-package]]
+[[host-package]]
 name = 'testcycles-helper'
 version = '0.1.0'
 workspace-path = 'testcycles-helper'

--- a/fixtures/small/summaries/metadata_dups-3.toml
+++ b/fixtures/small/summaries/metadata_dups-3.toml
@@ -2,19 +2,29 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_dups
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-freebsd'
-target-features = 'all'
-flags = ['test-flag']
+spec = 'always'
 
 [metadata.target-platform]
-triple = 'thumbv8m.main-none-eabihf'
-target-features = ['avx', 'sha', 'sse', 'xsaveopt']
-flags = ['flag-test', 'foo']
+spec = 'any'
+[[metadata.omitted-packages.ids]]
+name = 'bytes'
+version = '0.5.4'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'lazy_static'
+version = '0.2.11'
+crates-io = true
+
+[[metadata.omitted-packages.ids]]
+name = 'lazy_static'
+version = '1.4.0'
+crates-io = true
 
 [[metadata.features-only]]
 name = 'testcrate-dups'
@@ -32,27 +42,6 @@ features = []
 [[target-package]]
 name = 'bytes'
 version = '0.3.0'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'bytes'
-version = '0.5.4'
-crates-io = true
-status = 'direct'
-features = ['default', 'std']
-
-[[target-package]]
-name = 'lazy_static'
-version = '0.2.11'
-crates-io = true
-status = 'direct'
-features = []
-
-[[target-package]]
-name = 'lazy_static'
-version = '1.4.0'
 crates-io = true
 status = 'direct'
 features = []

--- a/fixtures/small/summaries/metadata_dups-5.toml
+++ b/fixtures/small/summaries/metadata_dups-5.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_dups
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
-initials-platform = 'proc-macros-on-target'
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'always'

--- a/fixtures/small/summaries/metadata_dups-7.toml
+++ b/fixtures/small/summaries/metadata_dups-7.toml
@@ -2,24 +2,20 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_dups
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
 spec = 'always'
 
 [metadata.target-platform]
-spec = 'always'
+triple = 'riscv64-linux-android'
+target-features = 'all'
 [[metadata.omitted-packages.ids]]
-name = 'bytes'
-version = '0.5.4'
+name = 'lazy_static'
+version = '1.4.0'
 crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'testcrate-dups'
-version = '0.1.0'
-workspace-path = ''
 
 [[metadata.features-only]]
 name = 'testcrate-dups'
@@ -42,15 +38,15 @@ status = 'direct'
 features = []
 
 [[target-package]]
-name = 'lazy_static'
-version = '0.2.11'
+name = 'bytes'
+version = '0.5.4'
 crates-io = true
 status = 'direct'
-features = []
+features = ['default', 'std']
 
 [[target-package]]
 name = 'lazy_static'
-version = '1.4.0'
+version = '0.2.11'
 crates-io = true
 status = 'direct'
 features = []

--- a/fixtures/small/summaries/metadata_proc_macro1-1.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-1.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_proc_macro1
 
 [metadata]
-resolver = '1'
-include-dev = true
-initials-platform = 'proc-macros-on-target'
+resolver = 'install'
+include-dev = false
+initials-platform = 'standard'
 
 [metadata.host-platform]
 spec = 'any'
@@ -43,13 +43,6 @@ features = []
 name = 'build-user'
 version = '0.1.0'
 workspace-path = 'build-user'
-status = 'initial'
-features = []
-
-[[target-package]]
-name = 'macro'
-version = '0.1.0'
-workspace-path = 'macro'
 status = 'initial'
 features = []
 

--- a/fixtures/small/summaries/metadata_targets1-3.toml
+++ b/fixtures/small/summaries/metadata_targets1-3.toml
@@ -2,9 +2,9 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_targets1
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = false
-initials-platform = 'standard'
+initials-platform = 'host'
 
 [metadata.host-platform]
 spec = 'any'
@@ -28,7 +28,7 @@ workspace-path = ''
 features = ['bytes', 'dep-a']
 optional-deps = ['bytes', 'dep-a']
 
-[[target-package]]
+[[host-package]]
 name = 'testcrate-targets'
 version = '0.1.0'
 workspace-path = ''
@@ -36,7 +36,7 @@ status = 'initial'
 features = ['bytes', 'dep-a']
 optional-deps = ['bytes', 'dep-a']
 
-[[target-package]]
+[[host-package]]
 name = 'bytes'
 version = '0.5.3'
 crates-io = true
@@ -44,21 +44,21 @@ status = 'direct'
 features = ['default', 'serde', 'std']
 optional-deps = ['serde']
 
-[[target-package]]
+[[host-package]]
 name = 'lazy_static'
 version = '0.2.11'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'lazy_static'
 version = '1.4.0'
 crates-io = true
 status = 'direct'
 features = []
 
-[[target-package]]
+[[host-package]]
 name = 'serde'
 version = '1.0.105'
 crates-io = true

--- a/fixtures/small/summaries/metadata_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_targets1-7.toml
@@ -2,18 +2,17 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_targets1
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'powerpc-unknown-linux-gnuspe'
-target-features = ['avx2', 'sse3']
+triple = 's390x-unknown-linux-gnu'
+target-features = 'unknown'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-muslabi64'
-target-features = 'unknown'
+spec = 'any'
 
 [[metadata.features-only]]
 name = 'testcrate-targets'
@@ -33,7 +32,7 @@ name = 'bytes'
 version = '0.5.3'
 crates-io = true
 status = 'direct'
-features = ['serde']
+features = ['default', 'serde', 'std']
 optional-deps = ['serde']
 
 [[target-package]]
@@ -41,7 +40,14 @@ name = 'dep-a'
 version = '0.1.0'
 path = '../dep-a'
 status = 'direct'
-features = ['baz', 'foo', 'quux']
+features = ['bar', 'baz', 'foo', 'quux']
+
+[[target-package]]
+name = 'lazy_static'
+version = '0.1.16'
+crates-io = true
+status = 'direct'
+features = []
 
 [[target-package]]
 name = 'lazy_static'

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
@@ -2,31 +2,21 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_weak_namespaced_features
 
 [metadata]
-resolver = '2'
+resolver = '3'
 include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mips64-unknown-linux-muslabi64'
+triple = 'i686-pc-windows-gnullvm'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-musleabihf'
-target-features = ['xsave', 'xsavec', 'xsaves']
-flags = ['bar', 'cargo_web']
+triple = 'aarch64-unknown-freebsd'
+target-features = 'unknown'
+flags = ['bar', 'foo']
 [[metadata.omitted-packages.ids]]
-name = 'arrayvec'
-version = '0.7.2'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'namespaced-weak'
-version = '0.1.0'
-workspace-path = ''
-
-[[metadata.omitted-packages.ids]]
-name = 'pathdiff'
-version = '0.2.1'
+name = 'smallvec'
+version = '1.8.0'
 crates-io = true
 
 [[metadata.features-only]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-3.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-3.toml
@@ -2,18 +2,20 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_weak_namespaced_features
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'always'
+triple = 'mipsisa64r6-unknown-linux-gnuabi64'
+target-features = []
+flags = ['test-flag']
 
 [metadata.target-platform]
-spec = 'any'
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'tinyvec'
-version = '1.5.1'
+name = 'arrayvec'
+version = '0.7.2'
 crates-io = true
 
 [[target-package]]
@@ -23,13 +25,6 @@ workspace-path = ''
 status = 'initial'
 features = ['arrayvec', 'bar', 'baz', 'foo', 'pathdiff2', 'smallvec', 'smallvec-union', 'tinyvec', 'upgrade1', 'upgrade2', 'upgrade3', 'upgrade4', 'upgrade5', 'upgrade6', 'upgrade7', 'upgrade8', 'windows-dep', 'windows-named', 'windows-non-weak', 'windows-weak']
 optional-deps = ['arrayvec', 'pathdiff', 'smallvec', 'tinyvec']
-
-[[target-package]]
-name = 'arrayvec'
-version = '0.7.2'
-crates-io = true
-status = 'direct'
-features = ['std']
 
 [[target-package]]
 name = 'pathdiff'

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-4.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-4.toml
@@ -2,24 +2,19 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_weak_namespaced_features
 
 [metadata]
-resolver = 'install'
+resolver = '2'
 include-dev = true
-initials-platform = 'standard'
+initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-spec = 'any'
+triple = 'i686-uwp-windows-gnu'
+target-features = ['avx']
+flags = ['foo']
 
 [metadata.target-platform]
-spec = 'any'
-[[metadata.omitted-packages.ids]]
-name = 'arrayvec'
-version = '0.7.2'
-crates-io = true
-
-[[metadata.omitted-packages.ids]]
-name = 'tinyvec'
-version = '1.5.1'
-crates-io = true
+triple = 'i586-unknown-netbsd'
+target-features = 'unknown'
+flags = ['bar', 'cargo_web']
 
 [[metadata.features-only]]
 name = 'namespaced-weak'

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-7.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-7.toml
@@ -2,20 +2,18 @@
 #   cargo run -p fixture-manager -- generate-summaries --fixture metadata_weak_namespaced_features
 
 [metadata]
-resolver = 'install'
-include-dev = false
-initials-platform = 'host'
+resolver = '2'
+include-dev = true
+initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-unknown-freebsd'
-target-features = 'all'
-flags = ['abc']
+spec = 'always'
 
 [metadata.target-platform]
-spec = 'any'
+spec = 'always'
 [[metadata.omitted-packages.ids]]
-name = 'tinyvec'
-version = '1.5.1'
+name = 'smallvec'
+version = '1.8.0'
 crates-io = true
 
 [[metadata.features-only]]
@@ -25,7 +23,7 @@ workspace-path = ''
 features = ['arrayvec', 'bar', 'baz', 'foo', 'pathdiff2', 'smallvec', 'smallvec-union', 'tinyvec', 'upgrade1', 'upgrade2', 'upgrade3', 'upgrade4', 'upgrade5', 'upgrade6', 'upgrade7', 'upgrade8', 'windows-dep', 'windows-named', 'windows-non-weak', 'windows-weak']
 optional-deps = ['arrayvec', 'pathdiff', 'smallvec', 'tinyvec']
 
-[[host-package]]
+[[target-package]]
 name = 'namespaced-weak'
 version = '0.1.0'
 workspace-path = ''
@@ -33,23 +31,16 @@ status = 'initial'
 features = ['arrayvec', 'bar', 'baz', 'foo', 'pathdiff2', 'smallvec', 'smallvec-union', 'tinyvec', 'upgrade1', 'upgrade2', 'upgrade3', 'upgrade4', 'upgrade5', 'upgrade6', 'upgrade7', 'upgrade8', 'windows-dep', 'windows-named', 'windows-non-weak', 'windows-weak']
 optional-deps = ['arrayvec', 'pathdiff', 'smallvec', 'tinyvec']
 
-[[host-package]]
+[[target-package]]
 name = 'arrayvec'
 version = '0.7.2'
 crates-io = true
 status = 'direct'
 features = ['std']
 
-[[host-package]]
+[[target-package]]
 name = 'pathdiff'
 version = '0.2.1'
 crates-io = true
 status = 'direct'
 features = []
-
-[[host-package]]
-name = 'smallvec'
-version = '1.8.0'
-crates-io = true
-status = 'direct'
-features = ['union']

--- a/guppy-cmdlib/src/lib.rs
+++ b/guppy-cmdlib/src/lib.rs
@@ -90,6 +90,7 @@ pub enum CargoResolverVersionCmd {
     V1,
     V1Install,
     V2,
+    V3,
 }
 
 #[derive(ArgEnum, Clone, Copy, Debug)]
@@ -124,6 +125,7 @@ impl CargoResolverVersionCmd {
             CargoResolverVersionCmd::V1 => CargoResolverVersion::V1,
             CargoResolverVersionCmd::V1Install => CargoResolverVersion::V1Install,
             CargoResolverVersionCmd::V2 => CargoResolverVersion::V2,
+            CargoResolverVersionCmd::V3 => CargoResolverVersion::V3,
         }
     }
 }

--- a/guppy/src/graph/cargo/build.rs
+++ b/guppy/src/graph/cargo/build.rs
@@ -46,7 +46,10 @@ impl<'a> CargoSetBuildState<'a> {
                 let avoid_dev_deps = !self.opts.include_dev;
                 self.new_v1(initials, features_only, avoid_dev_deps)
             }
-            CargoResolverVersion::V2 => self.new_v2(initials, features_only),
+            // V2 and V3 do the same feature resolution.
+            CargoResolverVersion::V2 | CargoResolverVersion::V3 => {
+                self.new_v2(initials, features_only)
+            }
         }
     }
 
@@ -57,7 +60,7 @@ impl<'a> CargoSetBuildState<'a> {
                 let avoid_dev_deps = !self.opts.include_dev;
                 self.new_v1_intermediate(query, avoid_dev_deps)
             }
-            CargoResolverVersion::V2 => self.new_v2_intermediate(query),
+            CargoResolverVersion::V2 | CargoResolverVersion::V3 => self.new_v2_intermediate(query),
         }
     }
 

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -153,10 +153,29 @@ pub enum CargoResolverVersion {
     /// * with dev-dependencies for initials, if tests aren't currently being built
     /// * with [platform-specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) that are currently inactive
     ///
-    /// Version 2 of the feature resolver can be enabled by specifying `resolver = "2"` in the
-    /// workspace's `Cargo.toml`.
+    /// Version 2 of the feature resolver can be enabled by specifying `resolver
+    /// = "2"` in the workspace's `Cargo.toml`. It is also [the default resolver
+    /// version](https://doc.rust-lang.org/beta/edition-guide/rust-2021/default-cargo-resolver.html)
+    /// for [the Rust 2021
+    /// edition](https://doc.rust-lang.org/edition-guide/rust-2021/index.html).
     #[serde(rename = "2", alias = "v2")]
     V2,
+
+    /// [Version 3 of the dependency
+    /// resolver](https://doc.rust-lang.org/beta/cargo/reference/resolver.html#resolver-versions),
+    /// available since Rust 1.84.
+    ///
+    /// Version 3 of the resolver enables [MSRV-aware dependency
+    /// resolution](https://doc.rust-lang.org/beta/cargo/reference/config.html#resolverincompatible-rust-versions).
+    /// There are no changes to feature resolution compared to version 2.
+    ///
+    /// Version 3 of the feature resolver can be enabled by specifying `resolver
+    /// = "3"` in the workspace's `Cargo.toml`. It is also [the default resolver
+    /// version](https://doc.rust-lang.org/beta/edition-guide/rust-2024/cargo-resolver.html)
+    /// for [the Rust 2024
+    /// edition](https://doc.rust-lang.org/beta/edition-guide/rust-2024/index.html).
+    #[serde(rename = "3", alias = "v3")]
+    V3,
 }
 
 /// For a given Cargo build simulation, what platform to assume the initials are being built on.

--- a/internal-tools/cargo-compare/src/tests/fixtures.rs
+++ b/internal-tools/cargo-compare/src/tests/fixtures.rs
@@ -90,6 +90,10 @@ impl Fixture {
             let resolver_version = match resolver {
                 CargoResolverVersion::V1 | CargoResolverVersion::V1Install => "1",
                 CargoResolverVersion::V2 => "2",
+                // Note: resolver v3 has the same feature resolution as v2 so
+                // not having coverage for it isn't a huge deal. Enable this
+                // once the MSRV moves to 1.84.
+                CargoResolverVersion::V3 => panic!("resolver v3 not yet supported in Cargo"),
                 _ => panic!("unknown resolver {:?}", resolver),
             };
             writeln!(f, "resolver = \"{}\"", resolver_version).expect("file written successfully");

--- a/tools/hakari/templates/hakari.toml-in
+++ b/tools/hakari/templates/hakari.toml-in
@@ -5,8 +5,10 @@ hakari-package = "%PACKAGE_NAME%"
 # Format version for hakari's output. Version 4 requires cargo-hakari 0.9.22 or above.
 dep-format-version = "4"
 
-# Setting workspace.resolver = "2" in the root Cargo.toml is HIGHLY recommended.
-# Hakari works much better with the new feature resolver.
+# Setting workspace.resolver = "2" or higher in the root Cargo.toml is HIGHLY recommended.
+# Hakari works much better with the v2 resolver. (The v2 and v3 resolvers are identical from
+# hakari's perspective, so you're welcome to set either.)
+#
 # For more about the new feature resolver, see:
 # https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver
 resolver = "2"


### PR DESCRIPTION
Resolver version 3 works the same as version 2.

A lot of our fixes need to be updated as a result of v3 now being probabilistically generated.