### PR TITLE
Allow use of sparse registries

### DIFF
--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -1493,7 +1493,7 @@ impl<'g> ExternalSource<'g> {
 
     /// The string `"sparse+"`.
     ///
-    /// Also used for matching with the `Registry` variant.
+    /// Also used for matching with the `Sparse` variant.
     pub const SPARSE_PLUS: &'static str = "sparse+";
 
     /// The string `"git+"`.

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -1362,6 +1362,18 @@ pub enum ExternalSource<'g> {
     ///     ExternalSource::Registry("https://github.com/rust-lang/crates.io-index"),
     /// );
     /// ```
+    ///
+    /// ```
+    /// use guppy::graph::ExternalSource;
+    ///
+    /// let source = "sparse+https://index.crates.io";
+    /// let parsed = ExternalSource::new(source).expect("this source is understood by guppy");
+    ///
+    /// assert_eq!(
+    ///     parsed,
+    ///     ExternalSource::Registry("https://index.crates.io"),
+    /// );
+    /// ```
     Registry(&'g str),
 
     /// This is a Git source.
@@ -1470,6 +1482,11 @@ impl<'g> ExternalSource<'g> {
     /// Used for matching with the `Registry` variant.
     pub const REGISTRY_PLUS: &'static str = "registry+";
 
+    /// The string `"sparse+"`.
+    ///
+    /// Also used for matching with the `Registry` variant.
+    pub const SPARSE_PLUS: &'static str = "sparse+";
+
     /// The string `"git+"`.
     ///
     /// Used for matching with the `Git` variant.
@@ -1501,7 +1518,10 @@ impl<'g> ExternalSource<'g> {
     pub fn new(source: &'g str) -> Option<Self> {
         // We *could* pull in a URL parsing library, but Cargo's sources are so limited that it
         // seems like a waste to.
-        if let Some(registry) = source.strip_prefix(Self::REGISTRY_PLUS) {
+        if let Some(registry) = source
+            .strip_prefix(Self::REGISTRY_PLUS)
+            .or_else(|| source.strip_prefix(Self::SPARSE_PLUS))
+        {
             // A registry source.
             Some(ExternalSource::Registry(registry))
         } else if let Some(rest) = source.strip_prefix(Self::GIT_PLUS) {

--- a/tools/hakari/src/toml_out.rs
+++ b/tools/hakari/src/toml_out.rs
@@ -430,6 +430,32 @@ pub(crate) fn write_toml(
                             );
                             itable.insert("registry", registry_name.into());
                         }
+                        Some(ExternalSource::Sparse(registry_url)) => {
+                            let registry_name = builder
+                                .registries
+                                .get_by_right(&format!(
+                                    "{}{}",
+                                    ExternalSource::SPARSE_PLUS,
+                                    registry_url
+                                ))
+                                .ok_or_else(|| TomlOutError::UnrecognizedRegistry {
+                                    package_id: dep.id().clone(),
+                                    registry_url: registry_url.to_owned(),
+                                })?;
+                            itable.insert(
+                                "version",
+                                format!(
+                                    "{}",
+                                    VersionDisplay::new(
+                                        dep.version(),
+                                        options.exact_versions,
+                                        dep_format < DepFormatVersion::V3
+                                    )
+                                )
+                                .into(),
+                            );
+                            itable.insert("registry", registry_name.into());
+                        }
                         _ => {
                             return Err(TomlOutError::UnrecognizedExternal {
                                 package_id: dep.id().clone(),


### PR DESCRIPTION
Registries that use the [sparse registry protocol] show up in `Cargo.lock` not as `registry+URL`, but as `sparse+URL`. This patch makes it so that guppy (and hakari in particular in my case) doesn't error out on lockfiles with dependencies from such registries.

For sparse registries, hakari will look for entries in `.config/hakari.toml` with `sparse+` in the listed URL:

```toml
[registries."reg"]
index = "sparse+https://whatever"
```

This matches what goes in `.cargo/config.toml`.

[sparse registry protocol]: https://doc.rust-lang.org/cargo/reference/registry-index.html#sparse-protocol