### PR TITLE
[target-spec-miette] switch fixtures to snapbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "anstyle-lossy"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "934ff8719effd2023a48cf63e69536c1c3ced9d3895068f6f5cc9a4ff845e59b"
+dependencies = [
+ "anstyle",
+]
+
+[[package]]
 name = "anstyle-parse"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +116,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-svg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3607949e9f6de49ea4bafe12f5e4fd73613ebf24795e48587302a8cc0e4bb35"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-lossy",
+ "html-escape",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2337,7 +2359,6 @@ dependencies = [
  "camino",
  "clap 4.5.22",
  "clap_builder",
- "console",
  "getrandom",
  "include_dir",
  "indexmap 1.9.3",
@@ -2504,6 +2525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http-auth"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,18 +2639,6 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
-
-[[package]]
-name = "insta"
-version = "1.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
-dependencies = [
- "console",
- "lazy_static",
- "linked-hash-map",
- "similar",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2823,12 +2841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +2976,12 @@ checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "normpath"
@@ -3837,6 +3855,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "snapbox"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "anstyle-svg",
+ "normalize-line-endings",
+ "serde_json",
+ "similar",
+ "snapbox-macros",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16569f53ca23a41bb6f62e0a5084aa1661f4814a67fa33696a79073e03a664af"
+dependencies = [
+ "anstream",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4020,8 +4062,8 @@ dependencies = [
  "datatest-stable",
  "guppy-workspace-hack",
  "include_dir",
- "insta",
  "miette",
+ "snapbox",
  "target-spec",
 ]
 
@@ -4454,6 +4496,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ guppy-workspace-hack = "0.1.0"
 include_dir = "0.7.4"
 insta = "1.41.1"
 miette = "7.4.0"
+snapbox = { version = "0.6.21", features = ["term-svg"] }
 
 [workspace.package]
 # Note: we commit to supporting the last 6 months of Rust releases. This

--- a/target-spec-miette/Cargo.toml
+++ b/target-spec-miette/Cargo.toml
@@ -23,8 +23,8 @@ target-spec = { version = "3.3.1", path = "../target-spec" }
 
 [dev-dependencies]
 datatest-stable.workspace = true
-insta.workspace = true
 miette = { workspace = true, features = ["fancy"] }
+snapbox.workspace = true
 target-spec = { version = "3.3.1", path = "../target-spec", features = [
     "custom",
 ] }

--- a/target-spec-miette/tests/datatest-snapshot/custom.rs
+++ b/target-spec-miette/tests/datatest-snapshot/custom.rs
@@ -6,7 +6,7 @@
 //! These tests live here because they depend on target-spec with the custom
 //! feature enabled, as well as target-spec-miette.
 
-use crate::helpers::bind_insta_settings;
+use crate::helpers::snapbox_assert_ansi;
 use datatest_stable::Utf8Path;
 use target_spec::TargetFeatures;
 use target_spec_miette::IntoMietteDiagnostic;
@@ -14,20 +14,13 @@ use target_spec_miette::IntoMietteDiagnostic;
 pub(crate) fn custom_invalid(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
     std::env::set_var("CLICOLOR_FORCE", "1");
 
-    let (_guard, insta_prefix) =
-        bind_insta_settings(path, "../datatest-snapshot/snapshots/custom-invalid");
-
     let error = target_spec::Platform::new_custom("my-target", &contents, TargetFeatures::none())
         .expect_err("expected input to fail");
-
     let diagnostic = error.into_diagnostic();
-    insta::assert_snapshot!(
-        format!("{insta_prefix}-display"),
-        // This displays fancy output. Note the use of assert_snapshot, not
-        // assert_debug_snapshot, since the latter uses the pretty-printed Debug
-        // (which doesn't do what you would expect with miette/anyhow etc).
-        format!("{:?}", miette::Report::new_boxed(diagnostic)),
-    );
 
+    // Use Debug output on the report to get the nicely formatted output.
+    let output = format!("{:?}", miette::Report::new_boxed(diagnostic));
+
+    snapbox_assert_ansi("custom-invalid", path, output);
     Ok(())
 }

--- a/target-spec-miette/tests/datatest-snapshot/expr.rs
+++ b/target-spec-miette/tests/datatest-snapshot/expr.rs
@@ -1,27 +1,20 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::helpers::bind_insta_settings;
+use crate::helpers::snapbox_assert_ansi;
 use datatest_stable::Utf8Path;
 use target_spec_miette::IntoMietteDiagnostic;
 
 pub(crate) fn expr_invalid(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
     std::env::set_var("CLICOLOR_FORCE", "1");
 
-    let (_guard, insta_prefix) =
-        bind_insta_settings(path, "../datatest-snapshot/snapshots/expr-invalid");
-
     let error = target_spec::TargetSpec::new(contents.trim_end().to_owned())
         .expect_err("expected input to fail");
 
     let diagnostic = error.into_diagnostic();
-    insta::assert_snapshot!(
-        format!("{insta_prefix}-display"),
-        // This displays fancy output. Note the use of assert_snapshot, not
-        // assert_debug_snapshot, since the latter uses the pretty-printed Debug
-        // (which doesn't do what you would expect with miette/anyhow etc).
-        format!("{:?}", miette::Report::new_boxed(diagnostic)),
-    );
+    // Use Debug output on the report to get the nicely formatted output.
+    let output = format!("{:?}", miette::Report::new_boxed(diagnostic));
 
+    snapbox_assert_ansi("expr-invalid", path, output);
     Ok(())
 }

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-arch.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-arch.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
    ╭─[2:13]
  [2m1[0m │ {

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-arch.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-arch.svg
@@ -1,0 +1,45 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   ╭─[2:13]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ {</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │   "arch": 123,</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   · </tspan><tspan class="fg-magenta bold">            ▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ·             </tspan><tspan class="fg-magenta bold">╰── invalid type: integer `123`, expected a string</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">3</tspan><tspan> │   "cpu": "x86-64",</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-endian.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-endian.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
     ╭─[32:29]
  [2m31[0m │     },

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-endian.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-endian.svg
@@ -1,0 +1,45 @@
+<svg width="776px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    ╭─[32:29]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">31</tspan><tspan> │     },</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">32</tspan><tspan> │     "target-endian": "middle",</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    · </tspan><tspan class="fg-magenta bold">                            ▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    ·                             </tspan><tspan class="fg-magenta bold">╰── unknown variant `middle`, expected `little` or `big`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">33</tspan><tspan> │     "target-family": ["unix"],</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>    ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-family.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-family.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
     ╭─[33:27]
  [2m32[0m │     "target-endian": "big",

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-family.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-family.svg
@@ -1,0 +1,45 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    ╭─[33:27]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">32</tspan><tspan> │     "target-endian": "big",</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">33</tspan><tspan> │     "target-family": "none",</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    · </tspan><tspan class="fg-magenta bold">                          ▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    ·                           </tspan><tspan class="fg-magenta bold">╰── invalid type: string "none", expected a sequence</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">34</tspan><tspan> │     "target-mcount": "_mcount",</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>    ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-target-pointer-width.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-target-pointer-width.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
     ╭─[52:30]
  [2m51[0m │   ],

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-target-pointer-width.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/invalid-target-pointer-width.svg
@@ -1,0 +1,45 @@
+<svg width="810px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    ╭─[52:30]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">51</tspan><tspan> │   ],</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">52</tspan><tspan> │   "target-pointer-width": "xx",</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    · </tspan><tspan class="fg-magenta bold">                             ▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    ·                              </tspan><tspan class="fg-magenta bold">╰── error parsing as integer: invalid digit found in string</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">53</tspan><tspan> │   "supports-xray": true,</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>    ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/missing-arch.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/missing-arch.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
     ╭─[35:1]
  [2m34[0m │     "target-pointer-width": "64"

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/missing-arch.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/missing-arch.svg
@@ -1,0 +1,43 @@
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    ╭─[35:1]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">34</tspan><tspan> │     "target-pointer-width": "64"</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">35</tspan><tspan> │ }</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    · </tspan><tspan class="fg-magenta bold">▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    · </tspan><tspan class="fg-magenta bold">╰── missing field `arch`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>    ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/syntax-error.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/syntax-error.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/custom.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error deserializing custom target JSON for `my-target`
     ╭─[40:13]
  [2m39[0m │     "leak",

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/syntax-error.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/custom-invalid/syntax-error.svg
@@ -1,0 +1,43 @@
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error deserializing custom target JSON for `my-target`</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>    ╭─[40:13]</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">39</tspan><tspan> │     "leak",</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">40</tspan><tspan> │     "memory",</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>    · </tspan><tspan class="fg-magenta bold">            ▲</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>    ·             </tspan><tspan class="fg-magenta bold">╰── EOF while parsing a value</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>    ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/multiline-output.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/multiline-output.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/expr.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error parsing cfg() expression
    ╭────
  [2m1[0m │ cfg(target_does_not_exist = "unix")

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/multiline-output.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/multiline-output.svg
@@ -1,0 +1,41 @@
+<svg width="1684px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error parsing cfg() expression</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   ╭────</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ cfg(target_does_not_exist = "unix")</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   · </tspan><tspan class="fg-magenta bold">    ──────────┬──────────</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   ·               </tspan><tspan class="fg-magenta bold">╰── expected one of `target_arch`, `target_feature`, `target_os`, `target_family`, `target_env`, `target_endian`, `target_has_atomic`, `target_pointer_width`, `target_vendor` here</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unclosed-delimiter.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unclosed-delimiter.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/expr.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error parsing cfg() expression
    ╭────
  [2m1[0m │ cfg(unix

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unclosed-delimiter.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unclosed-delimiter.svg
@@ -1,0 +1,41 @@
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error parsing cfg() expression</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   ╭────</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ cfg(unix</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   · </tspan><tspan class="fg-magenta bold">   ┬</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   ·    </tspan><tspan class="fg-magenta bold">╰── expected one of `=`, `,`, `)` here</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unquoted-value.ansi
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unquoted-value.ansi
@@ -1,8 +1,4 @@
----
-source: target-spec-miette/tests/datatest-snapshot/expr.rs
-expression: "format!(\"{:?}\", miette::Report::new_boxed(diagnostic))"
-snapshot_kind: text
----
+
   [31m×[0m error parsing cfg() expression
    ╭────
  [2m1[0m │ cfg(target_os = none)

--- a/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unquoted-value.svg
+++ b/target-spec-miette/tests/datatest-snapshot/snapshots/expr-invalid/unquoted-value.svg
@@ -1,0 +1,41 @@
+<svg width="740px" height="164px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> error parsing cfg() expression</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>   ╭────</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ cfg(target_os = none)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>   · </tspan><tspan class="fg-magenta bold">                ──┬─</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>   ·                   </tspan><tspan class="fg-magenta bold">╰── expected a `"` here</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+  </text>
+
+</svg>

--- a/target-spec-miette/tests/integration/main.rs
+++ b/target-spec-miette/tests/integration/main.rs
@@ -1,12 +1,30 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use snapbox::{data::DataFormat, Data};
 use target_spec::errors::CustomTripleCreateError;
 use target_spec_miette::IntoMietteDiagnostic;
 
 #[test]
 fn unavailable_snapshot() {
+    std::env::set_var("CLICOLOR_FORCE", "1");
+
     // Test that the unavailable diagnostic shows properly as a report.
     let report = miette::Report::new(CustomTripleCreateError::Unavailable.into_diagnostic());
-    insta::assert_snapshot!(format!("{report:?}"));
+    // Use the Debug format to get the report ace the fancy displayer would show
+    // it.
+    let actual = format!("{:?}", report);
+
+    let b = snapbox::Assert::new().action_env("SNAPSHOTS");
+
+    // Store SVG and ANSI snapshots. Use the binary representation to ensure
+    // that no post-processing of text happens.
+    b.eq(
+        Data::binary(actual.clone()).coerce_to(DataFormat::TermSvg),
+        snapbox::file!["snapshots/unavailable.svg"],
+    );
+    b.eq(
+        Data::binary(actual),
+        snapbox::file!["snapshots/unavailable.ansi"],
+    );
 }

--- a/target-spec-miette/tests/integration/snapshots/integration__unavailable_snapshot.snap
+++ b/target-spec-miette/tests/integration/snapshots/integration__unavailable_snapshot.snap
@@ -1,7 +1,0 @@
----
-source: target-spec-miette/tests/integration/main.rs
-expression: "format!(\"{report:?}\")"
-snapshot_kind: text
----
-  × custom platforms are currently unavailable: to enable them, add the
-  │ `custom` feature to target-spec

--- a/target-spec-miette/tests/integration/snapshots/unavailable.ansi
+++ b/target-spec-miette/tests/integration/snapshots/unavailable.ansi
@@ -1,0 +1,3 @@
+
+  [31m×[0m custom platforms are currently unavailable: to enable them, add the
+  [31m│[0m `custom` feature to target-spec

--- a/target-spec-miette/tests/integration/snapshots/unavailable.svg
+++ b/target-spec-miette/tests/integration/snapshots/unavailable.svg
@@ -1,0 +1,30 @@
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> custom platforms are currently unavailable: to enable them, add the</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>  </tspan><tspan class="fg-red">│</tspan><tspan> `custom` feature to target-spec</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -22,7 +22,6 @@ backtrace = { version = "0.3.69", features = ["gimli-symbolize"] }
 camino = { version = "1.1.9", default-features = false, features = ["serde1"] }
 clap = { version = "4.5.22", features = ["derive"] }
 clap_builder = { version = "4.5.22", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
-console = { version = "0.15.8" }
 getrandom = { version = "0.2.12", default-features = false, features = ["std"] }
 include_dir = { version = "0.7.4", features = ["glob"] }
 indexmap = { version = "1.9.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
I like `cargo insta`, but snapbox's SVGs are awesome and worth recommending.