### PR TITLE
Don't print empty diffs

### DIFF
--- a/tools/cargo-hakari/src/command.rs
+++ b/tools/cargo-hakari/src/command.rs
@@ -504,15 +504,15 @@ fn write_to_cargo_toml(
 ) -> Result<i32> {
     if diff {
         let patch = existing_toml.diff_toml(new_contents);
-        let mut formatter = PatchFormatter::new();
-        if output.color.is_enabled() {
-            formatter = formatter.with_color();
-        }
-        info!("\n{}", formatter.fmt_patch(&patch));
         if patch.hunks().is_empty() {
             // No differences.
             Ok(0)
         } else {
+            let mut formatter = PatchFormatter::new();
+            if output.color.is_enabled() {
+                formatter = formatter.with_color();
+            }
+            info!("\n{}", formatter.fmt_patch(&patch));
             Ok(1)
         }
     } else {


### PR DESCRIPTION
Previously, `cargo hakari generate --diff` would print

    info:
    --- original
    +++ modified

when generate doesn't need anything to change. This is noisy, and also somewhat confusing as a reader may assume that the presence of the header suggests _something_ changed and that it was the printing of the diff that got mixed up somehow. Or that the changes where whitespace changes or some such.

This change makes it so that if the diff is empty, the command produces nothing to STDOUT instead. This is also more in line with most other UNIX utilities.