### PR TITLE
Expose `MetadataCommand::env` from `cargo_metadata`

### DIFF
--- a/guppy/src/metadata_command.rs
+++ b/guppy/src/metadata_command.rs
@@ -97,6 +97,17 @@ impl MetadataCommand {
         self
     }
 
+    /// Arbitrary environment variables to set when running cargo. These will be merged into the
+    /// calling environment, overriding any which clash.
+    pub fn env(
+        &mut self,
+        key: impl Into<std::ffi::OsString>,
+        val: impl Into<std::ffi::OsString>,
+    ) -> &mut Self {
+        self.inner.env(key, val);
+        self
+    }
+
     /// Builds a [`Command`] instance. This is the first part of calling
     /// [`exec`](Self::exec).
     pub fn cargo_command(&self) -> Command {


### PR DESCRIPTION
IIUC this PR will help to transition Chromium's `gnrt` tool from `cargo_metadata` to `guppy` - the old code propagates environment variables [here](https://source.chromium.org/chromium/chromium/src/+/main:tools/crates/gnrt/util.rs;l=103-105;drc=ed5473472de79c44e175be470064d0fa51db3190) - AFAIU this is only used [here](https://source.chromium.org/chromium/chromium/src/+/main:tools/crates/gnrt/gen.rs;l=76-81;drc=483a04befc1b7b754d78a22472cbd87e704eb760) to set `RUSTC_BOOTSTRAP=1` when processing the standard library build graph.