### PR TITLE
Remove two unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4127,7 +4127,6 @@ dependencies = [
  "target-lexicon",
  "test-case",
  "toml 0.5.11",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ cfg-expr = "0.17.2"
 datatest-stable = { version = "0.3.2", features = ["include-dir"] }
 guppy-workspace-hack = "0.1.0"
 include_dir = "0.7.4"
-insta = "1.42.1"
 miette = "7.4.0"
 snapbox = { version = "0.6.21", features = ["term-svg"] }
 

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -25,7 +25,6 @@ proptest = { version = "1.6.0", optional = true }
 serde = { version = "1.0.217", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.138", optional = true }
 target-lexicon = { version = "0.12.16", features = ["std"] }
-unicode-ident = "1.0.16"
 guppy-workspace-hack.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
I noticed that target-spec declares a dependency on unicode-ident but doesn't seem to actually use it (since 84117fb95932bdfbaff6abb90f2d8e335933ed0c if some cursory git archeology did not lead me astray).

Then I threw cargo-machete and cargo-shear at the workspace to see if there's anything else. The only true positive is the *workspace* dependency on insta not being inherited anywhere. Pretty harmless but might as well remove it while I'm here.