### PR TITLE
Add `specs()` accessor to the `PlatformEval` type.

### DIFF
--- a/guppy/src/platform/platform_eval.rs
+++ b/guppy/src/platform/platform_eval.rs
@@ -159,7 +159,7 @@ pub struct PlatformEval<'g> {
 
 assert_covariant!(PlatformEval);
 
-impl PlatformEval<'_> {
+impl<'g> PlatformEval<'g> {
     /// Runs this evaluator against the given platform.
     pub fn eval(&self, platform: &Platform) -> EnabledTernary {
         let mut res = EnabledTernary::Disabled;
@@ -172,6 +172,11 @@ impl PlatformEval<'_> {
             res = res | EnabledTernary::new(matches);
         }
         res
+    }
+
+    /// Returns the target specs.
+    pub fn specs<'a>(&'a self) -> impl Iterator<Item = &'g TargetSpec> + 'a {
+        self.specs.iter()
     }
 }
 


### PR DESCRIPTION
This helps `guppy` clients which don't want to `eval` the condition, and instead want to decompose and analyze the condition.  An example of one such client can be found in:

* https://crrev.com/c/6259145/9/tools/crates/gnrt/lib/deps.rs#406
* https://crrev.com/c/6259145/9/tools/crates/gnrt/lib/gn.rs#513