### PR TITLE
Support passing `PackageResolver` to `CargoSet::new^H^H^Hwith_resolver`.

### DIFF
--- a/guppy/examples/cargo_set_link_filter.rs
+++ b/guppy/examples/cargo_set_link_filter.rs
@@ -1,0 +1,196 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Demonstration how `CargoSet` algorithm can accept links that are present on:
+//!
+//! 1) any/all platforms (using default `CargoOptions` and `CargoSet::new`)
+//! 2) a single platform (using `CargoOptions::set_target_platform`)
+//! 3) a set of platforms (using `CargoSet::with_resolver`)
+//!
+//! The last example uses `PackageResolver` as a filter - this is a very
+//! generic mechanism and can be used to not only filter by platforms,
+//! but also implement a variety of other filtering options.  For example,
+//! `CargoOptions::add_omitted_packages` could also be implemented using
+//! `CargoSet::with_resolver` and an appropriate `PackageResolver`.
+
+use guppy::{
+    CargoMetadata, Error,
+    graph::{
+        DependencyDirection, DependencyReq, PackageLink, PackageQuery, PackageResolver,
+        cargo::{CargoOptions, CargoSet},
+        feature::StandardFeatures,
+    },
+    platform::{EnabledTernary, PlatformSpec, PlatformStatus, Triple},
+};
+
+/// Custom `guppy::graph::PackageResolver` that will only accept `PackageLink`s
+/// that are enabled on at least one from the given set of platforms.
+struct PackageResolverForPlatformSet(Vec<PlatformSpec>);
+
+impl PackageResolverForPlatformSet {
+    fn new(platform_set: Vec<PlatformSpec>) -> Self {
+        Self(platform_set)
+    }
+
+    fn can_platform_status_be_true(&self, platform_status: PlatformStatus) -> bool {
+        self.0.iter().any(|platform_spec| {
+            let is_enabled = platform_status.enabled_on(platform_spec);
+            is_enabled == EnabledTernary::Enabled
+        })
+    }
+
+    fn should_include_dependency_req(&self, dependency_req: DependencyReq) -> bool {
+        dependency_req.is_present()
+            && (self.can_platform_status_be_true(dependency_req.status().optional_status())
+                || self.can_platform_status_be_true(dependency_req.status().required_status()))
+    }
+}
+
+impl<'g> PackageResolver<'g> for PackageResolverForPlatformSet {
+    fn accept(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+        self.should_include_dependency_req(link.normal())
+            || self.should_include_dependency_req(link.build())
+    }
+}
+
+fn win32_platform_spec() -> PlatformSpec {
+    PlatformSpec::Platform(std::sync::Arc::new(target_spec::Platform::from_triple(
+        Triple::new_strict("i686-pc-windows-gnu").unwrap(),
+        target_spec::TargetFeatures::features([
+            // The full feature list for this target triple can be found with
+            // `rustc --target i686-pc-windows-gnu --print=cfg`, but for
+            // simplicity we only list ones that are relevant for `region` and
+            // `winapi` dependency selection).
+            "windows",
+        ]),
+    )))
+}
+
+fn win64_platform_spec() -> PlatformSpec {
+    PlatformSpec::Platform(std::sync::Arc::new(target_spec::Platform::from_triple(
+        Triple::new_strict("x86_64-pc-windows-gnu").unwrap(),
+        target_spec::TargetFeatures::features([
+            // The full feature list for this target triple can be found with
+            // `rustc --target x86_64-pc-windows-gnu --print=cfg`, but for
+            // simplicity we only list ones that are relevant for `region` and
+            // `winapi` dependency selection).
+            "windows",
+        ]),
+    )))
+}
+
+fn cargo_set_to_package_names(cargo_set: CargoSet) -> Vec<String> {
+    let mut result = cargo_set
+        .target_features()
+        .packages_with_features(DependencyDirection::Forward)
+        .map(|feature_list| {
+            format!(
+                "{}-{}",
+                feature_list.package().name(),
+                feature_list.package().version(),
+            )
+        })
+        .collect::<Vec<_>>();
+    result.sort();
+    result
+}
+
+fn main() -> Result<(), Error> {
+    // `guppy` accepts as input the JSON output from `cargo metadata`.
+    // In this example we use a pre-recorded metadata that has been stored in `metadata1.json`.
+    // In this example metadata:
+    //
+    // * The `winapi` crate depends on either `winapi-i686-pc-windows-gnu` or
+    //   `winapi-x86_64-pc-windows-gnu` crate:
+    //
+    //     ```
+    //     [target.i686-pc-windows-gnu.dependencies.winapi-i686-pc-windows-gnu]
+    //     version = "0.4"
+    //     [target.x86_64-pc-windows-gnu.dependencies.winapi-x86_64-pc-windows-gnu]
+    //     version = "0.4"
+    //     ```
+    //
+    // * The `region-2.1.2` package depends on either `mach` or `winapi`:
+    //
+    //     ```
+    //     [target."cfg(any(target_os = \"macos\", target_os = \"ios\"))".dependencies.mach]
+    //     version = "0.2"
+    //     [target."cfg(windows)".dependencies.winapi]
+    //     version = "0.3"
+    //     ```
+    let metadata = CargoMetadata::parse_json(include_str!("../../fixtures/small/metadata1.json"))?;
+    let package_graph = metadata.build_graph()?;
+    let initials = package_graph
+        .resolve_package_name("region")
+        .to_feature_set(StandardFeatures::Default);
+    let no_extra_features = package_graph
+        .resolve_none()
+        .to_feature_set(StandardFeatures::Default);
+
+    // First, we get a set of packages that will be built on **any/all** possible platforms.
+    let all_platforms_package_names = {
+        let cargo_options = CargoOptions::new();
+        let cargo_set = CargoSet::new(initials.clone(), no_extra_features.clone(), &cargo_options)?;
+        cargo_set_to_package_names(cargo_set)
+    };
+    assert_eq!(
+        all_platforms_package_names,
+        vec![
+            "bitflags-1.1.0",
+            "libc-0.2.62",
+            "mach-0.2.3",
+            "region-2.1.2",
+            "winapi-0.3.8",
+            "winapi-i686-pc-windows-gnu-0.4.0",
+            "winapi-x86_64-pc-windows-gnu-0.4.0"
+        ],
+    );
+
+    // Then, get a set of packages for a **single** platform (by using
+    // `CargoOptions.set_target_platform`).
+    let single_platform_package_names = {
+        let mut cargo_options = CargoOptions::new();
+        cargo_options.set_target_platform(win32_platform_spec());
+        let cargo_set = CargoSet::new(initials.clone(), no_extra_features.clone(), &cargo_options)?;
+        cargo_set_to_package_names(cargo_set)
+    };
+    assert_eq!(
+        single_platform_package_names,
+        vec![
+            "bitflags-1.1.0",
+            "libc-0.2.62",
+            // No "mach-0.2.3" on `win32_platform_spec`.
+            "region-2.1.2",
+            "winapi-0.3.8",
+            // No "winapi-x86_64-pc-windows-gnu-0.4.0" on `win32_platform_spec`.
+            "winapi-i686-pc-windows-gnu-0.4.0",
+        ],
+    );
+
+    // Finally, get a set of packages for a set of target platforms
+    // (by passing a custom resolver to `CargoSet::with_resolver`).
+    let platform_set_package_names = {
+        let cargo_options = CargoOptions::new();
+        let resolver =
+            PackageResolverForPlatformSet::new(vec![win32_platform_spec(), win64_platform_spec()]);
+        let cargo_set =
+            CargoSet::with_resolver(initials, no_extra_features, resolver, &cargo_options)?;
+        cargo_set_to_package_names(cargo_set)
+    };
+    assert_eq!(
+        platform_set_package_names,
+        vec![
+            "bitflags-1.1.0",
+            "libc-0.2.62",
+            // No "mach-0.2.3" in a union of `win32_platform_spec` and `win64_platform_spec`.
+            "region-2.1.2",
+            "winapi-0.3.8",
+            // Both `winapi-i686-...` and `winapi-x86_64-...` crates are present in
+            // a union of `win32_platform_spec` and `win64_platform_spec`.
+            "winapi-i686-pc-windows-gnu-0.4.0",
+            "winapi-x86_64-pc-windows-gnu-0.4.0"
+        ],
+    );
+
+    Ok(())
+}

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -1,0 +1,283 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use fixtures::json::JsonFixture;
+use guppy::graph::{
+    DependencyDirection, PackageLink, PackageQuery, PackageResolver,
+    cargo::{CargoOptions, CargoSet},
+    feature::StandardFeatures,
+};
+use std::collections::HashSet;
+
+struct PackageResolverForTesting<'a, 'g> {
+    /// Optional filter of `link`s.  If `None`, then all links are accepted.
+    link_filter: Option<&'a dyn Fn(PackageLink<'g>) -> bool>,
+
+    /// The `trace` field stores `link`s that were passed to `fn accept`.
+    /// The links are formatted as `"foo@1.2.3 => bar@4.5.6"`.
+    /// The links are stored in the order of `fn accept` calls.
+    trace: Vec<String>,
+}
+
+impl<'a, 'g> PackageResolverForTesting<'a, 'g> {
+    fn new() -> Self {
+        Self {
+            link_filter: None,
+            trace: vec![],
+        }
+    }
+
+    fn with_filter(f: &'a impl Fn(PackageLink<'g>) -> bool) -> Self {
+        Self {
+            link_filter: Some(f),
+            trace: vec![],
+        }
+    }
+}
+
+fn link_to_string(link: &PackageLink) -> String {
+    format!(
+        "{}@{} => {}@{}",
+        link.from().name(),
+        link.from().version(),
+        link.to().name(),
+        link.to().version(),
+    )
+}
+
+fn links_to_strings<'g>(links: impl IntoIterator<Item = PackageLink<'g>>) -> Vec<String> {
+    let mut result = links
+        .into_iter()
+        .map(|link| link_to_string(&link))
+        .collect::<Vec<_>>();
+    result.sort();
+    result
+}
+
+impl<'g> PackageResolver<'g> for PackageResolverForTesting<'_, 'g> {
+    fn accept(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+        self.trace.push(link_to_string(&link));
+        self.link_filter.map(|f| f(link)).unwrap_or(true)
+    }
+}
+
+fn cargo_set_with_resolver<'g>(
+    test_fixture: &'g JsonFixture,
+    root_package_name: &str,
+    resolver: &mut dyn PackageResolver<'g>,
+) -> CargoSet<'g> {
+    let package_graph = test_fixture.graph();
+
+    /* DO NOT SUBMIT
+        let roots = package_graph
+            .packages()
+            .filter(|p| p.reverse_direct_links().next().is_none())
+            .map(|p| p.name().to_string())
+            .collect::<Vec<_>>();
+        dbg!(roots);
+    */
+
+    let initials = package_graph
+        .resolve_package_name(root_package_name)
+        .to_feature_set(StandardFeatures::Default);
+    let no_extra_features = package_graph
+        .resolve_none()
+        .to_feature_set(StandardFeatures::Default);
+
+    let cargo_options = CargoOptions::new();
+    CargoSet::with_resolver(initials, no_extra_features, resolver, &cargo_options).unwrap()
+}
+
+fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {
+    let mut result = cargo_set
+        .target_features()
+        .union(cargo_set.host_features())
+        .packages_with_features(DependencyDirection::Forward)
+        .map(|feature_list| feature_list.package().name().to_string())
+        .collect::<Vec<_>>();
+    result.sort();
+    result
+}
+
+#[test]
+fn test_package_resolver_visits() {
+    let mut resolver = PackageResolverForTesting::new();
+    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+    assert_eq!(
+        cargo_set_package_names(&cargo_set),
+        vec![
+            "aho-corasick",
+            "bitflags",
+            "ctor",
+            "datatest",
+            "datatest-derive",
+            "dtoa",
+            "lazy_static",
+            "libc",
+            "linked-hash-map",
+            "mach",
+            "memchr",
+            "proc-macro2",
+            "quote",
+            "regex",
+            "regex-syntax",
+            "region",
+            "same-file",
+            "serde",
+            "serde_yaml",
+            "syn",
+            "testcrate",
+            "thread_local",
+            "unicode-xid",
+            "version_check",
+            "walkdir",
+            "winapi",
+            "winapi-i686-pc-windows-gnu",
+            "winapi-util",
+            "winapi-x86_64-pc-windows-gnu",
+            "yaml-rust",
+        ],
+    );
+    assert_eq!(
+        resolver.trace,
+        vec![
+            "testcrate@0.1.0 => datatest@0.4.2",
+            "datatest@0.4.2 => yaml-rust@0.4.3",
+            "datatest@0.4.2 => walkdir@2.2.9",
+            "datatest@0.4.2 => version_check@0.9.1",
+            "datatest@0.4.2 => serde_yaml@0.8.9",
+            "datatest@0.4.2 => serde@1.0.100",
+            "datatest@0.4.2 => region@2.1.2",
+            "datatest@0.4.2 => regex@1.3.1",
+            "datatest@0.4.2 => datatest-derive@0.4.0",
+            "datatest@0.4.2 => ctor@0.1.10",
+            "regex@1.3.1 => thread_local@0.3.6",
+            "regex@1.3.1 => regex-syntax@0.6.12",
+            "regex@1.3.1 => memchr@2.2.1",
+            "regex@1.3.1 => aho-corasick@0.7.6",
+            "aho-corasick@0.7.6 => memchr@2.2.1",
+            "thread_local@0.3.6 => lazy_static@1.4.0",
+            "region@2.1.2 => winapi@0.3.8",
+            "region@2.1.2 => mach@0.2.3",
+            "region@2.1.2 => libc@0.2.62",
+            "region@2.1.2 => bitflags@1.1.0",
+            "mach@0.2.3 => libc@0.2.62",
+            "winapi@0.3.8 => winapi-x86_64-pc-windows-gnu@0.4.0",
+            "winapi@0.3.8 => winapi-i686-pc-windows-gnu@0.4.0",
+            "serde_yaml@0.8.9 => yaml-rust@0.4.3",
+            "serde_yaml@0.8.9 => serde@1.0.100",
+            "serde_yaml@0.8.9 => linked-hash-map@0.5.2",
+            "serde_yaml@0.8.9 => dtoa@0.4.4",
+            "yaml-rust@0.4.3 => linked-hash-map@0.5.2",
+            "walkdir@2.2.9 => winapi-util@0.1.2",
+            "walkdir@2.2.9 => winapi@0.3.8",
+            "walkdir@2.2.9 => same-file@1.0.5",
+            "same-file@1.0.5 => winapi-util@0.1.2",
+            "winapi-util@0.1.2 => winapi@0.3.8",
+            "ctor@0.1.10 => syn@1.0.5",
+            "ctor@0.1.10 => quote@1.0.2",
+            "quote@1.0.2 => proc-macro2@1.0.3",
+            "proc-macro2@1.0.3 => unicode-xid@0.2.0",
+            "syn@1.0.5 => unicode-xid@0.2.0",
+            "syn@1.0.5 => quote@1.0.2",
+            "syn@1.0.5 => proc-macro2@1.0.3",
+            "datatest-derive@0.4.0 => syn@1.0.5",
+            "datatest-derive@0.4.0 => quote@1.0.2",
+            "datatest-derive@0.4.0 => proc-macro2@1.0.3",
+        ],
+    );
+
+    assert_eq!(
+        links_to_strings(cargo_set.proc_macro_links()),
+        vec![
+            "datatest@0.4.2 => ctor@0.1.10",
+            "datatest@0.4.2 => datatest-derive@0.4.0",
+        ],
+    );
+    assert_eq!(
+        links_to_strings(cargo_set.build_dep_links()),
+        vec!["datatest@0.4.2 => version_check@0.9.1",],
+    );
+}
+
+#[test]
+fn test_package_resolver_filtering_normal_links_on_target() {
+    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+        // Remove `winapi` and `winapu-util` links.  This should transitively remove `winapi =>
+        // winapi-x86_64-pc-windows-gnu` and `winapi => winapi-i686-pc-windows-gnu`.
+        //
+        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // in all required cases.  The filter may or may not make sense in practice (here we
+        // can pretend that we are filtering all packages that are only needed on Windows).
+        !link.to().name().starts_with("winapi")
+    });
+    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+
+    // No `winapi...` packages (unlike in `test_package_resolver_visits`).
+    let package_names = cargo_set_package_names(&cargo_set)
+        .into_iter()
+        .collect::<HashSet<_>>();
+    assert!(!package_names.contains("winapi"));
+    assert!(!package_names.contains("winapi-util"));
+
+    // No `winapi...` => ... links (unlike in `test_package_resolver_visits`).
+    let trace = resolver.trace.into_iter().collect::<HashSet<_>>();
+    assert!(!trace.contains("winapi@0.3.8 => winapi-x86_64-pc-windows-gnu@0.4.0"));
+    assert!(!trace.contains("winapi@0.3.8 => winapi-i686-pc-windows-gnu@0.4.0"));
+    assert!(!trace.contains("winapi-util@0.1.2 => winapi@0.3.8"));
+}
+
+#[test]
+fn test_package_resolver_filtering_build_links_on_target() {
+    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+        // Remove `datatest` => `version_check` build dependency.
+        //
+        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // in all required cases.  The filter may or may not make sense in practice (here
+        // the trimmed down graph would fail to build...).
+        link.to().name() != "version_check"
+    });
+    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+
+    // No `version_check...` packages (unlike in `test_package_resolver_visits`).
+    let package_names = cargo_set_package_names(&cargo_set)
+        .into_iter()
+        .collect::<HashSet<_>>();
+    assert!(!package_names.contains("version_check"));
+
+    // If `version_check` has transitive dependencies, then we would test here that
+    // they were not visited/consulted by the `resolver`.
+}
+
+#[test]
+fn test_package_resolver_filtering_links_on_host() {
+    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+        // Remove dependencies of `ctor` and `datatest-derive` packages.  This should transitively
+        // remove `proc-macro2`, `quote`, `syn`, and `unicode-xid` packages.
+        //
+        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // in all required cases.  The filter may or may not make sense in practice (here
+        // the trimmed down graph would fail to build...).
+        link.from().name() != "ctor" && link.from().name() != "datatest-derive"
+    });
+    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+
+    // No `ctor` not `datatest-derive` dependencies (unlike in `test_package_resolver_visits`).
+    let package_names = cargo_set_package_names(&cargo_set)
+        .into_iter()
+        .collect::<HashSet<_>>();
+    assert!(!package_names.contains("proc-macro2"));
+    assert!(!package_names.contains("quote"));
+    assert!(!package_names.contains("syn"));
+    assert!(!package_names.contains("unicode-xid"));
+
+    // No `syn` => ... links (unlike in `test_package_resolver_visits`).
+    // No `quote` => ... links (unlike in `test_package_resolver_visits`).
+    // No `proc-macro2` ... => links (unlike in `test_package_resolver_visits`).
+    let trace = resolver.trace.into_iter().collect::<HashSet<_>>();
+    assert!(!trace.contains("syn@1.0.5 => unicode-xid@0.2.0"));
+    assert!(!trace.contains("syn@1.0.5 => quote@1.0.2"));
+    assert!(!trace.contains("syn@1.0.5 => proc-macro2@1.0.3"));
+    assert!(!trace.contains("quote@1.0.2 => proc-macro2@1.0.3"));
+    assert!(!trace.contains("proc-macro2@1.0.3 => unicode-xid@0.2.0"));
+}

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -68,15 +68,6 @@ fn cargo_set_with_resolver<'g>(
 ) -> CargoSet<'g> {
     let package_graph = test_fixture.graph();
 
-    /* DO NOT SUBMIT
-        let roots = package_graph
-            .packages()
-            .filter(|p| p.reverse_direct_links().next().is_none())
-            .map(|p| p.name().to_string())
-            .collect::<Vec<_>>();
-        dbg!(roots);
-    */
-
     let initials = package_graph
         .resolve_package_name(root_package_name)
         .to_feature_set(StandardFeatures::Default);

--- a/guppy/tests/graph-tests/main.rs
+++ b/guppy/tests/graph-tests/main.rs
@@ -12,6 +12,7 @@ macro_rules! proptest_suite {
     };
 }
 
+mod cargo_set_tests;
 mod feature_helpers;
 mod graph_tests;
 mod invalid_tests;


### PR DESCRIPTION
This commit adds a new `CargoSet::with_resolver` API that is very similar to the already existing `CargoSet::new`, but supports passing an extra `PackageResolver`.  This helps to support additional trimming of dependency edges as discussed in
https://github.com/guppy-rs/guppy/issues/438

-----------------

Any feedback welcomed!  Some notes:

* I have smoke-tested these changes by using them from https://crrev.com/c/6259145.  I haven't yet run the full test suite, but it seems that it "works on my machine".
* It is a bit weird that the custom resolver doesn't have the full available information - `CargoSetBuildState::build_set` knows if it calls `PackageResolver::accept` when trying to traverse a normal/build/dev dependency edge, but `accept` only sees a generic `PackageLink` (1-3 of normal+build+dev may be present).  OTOH this has been sufficient for my use case so far.
* This is a bit more involved change than my last 2 `guppy` PRs.  Maybe I should try to add some test coverage for the new API?  OTOH there are no existing tests (I tried grepping for `CargoSet::new`) so maybe this shouldn't block this PR / can be done as a follow-up?  FWIW the unit tests in my project are based on a persisted sample package (e.g. see [here](https://source.chromium.org/chromium/chromium/src/+/main:tools/crates/gnrt/lib/deps.rs;l=979-982;drc=c96c7754a8567a004a5f3ae28af31835b83f569f), [here](https://source.chromium.org/chromium/chromium/src/+/main:tools/crates/gnrt/sample_package/Cargo.toml;drc=212f32ad671188a8f445009e0094824c2aab77bf), and [here](https://chromium-review.googlesource.com/c/chromium/src/+/6259145/21/tools/crates/gnrt/lib/deps.rs#638)).