### PR TITLE
[meta] prepare guppy release

### DIFF
--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.17.18] - 2025-04-29
+
+### Added
+
+- `CargoSet::with_package_resolver` supports passing in a `PackageResolver` for additional dynamic filtering of dependency edges.
+- `CargoSet::target_links` and `host_links` return the set of `PackageLink` instances followed on the target and host platforms, respectively.
+
+Thanks to [anforowicz](https://github.com/anforowicz) for these contributions!
+
 ## [0.17.17] - 2025-02-21
 
 ### Added
@@ -761,6 +770,7 @@ lazy_static = "0.2"
 
 - Initial release.
 
+[0.17.18]: https://github.com/guppy-rs/guppy/releases/tag/guppy-0.17.18
 [0.17.17]: https://github.com/guppy-rs/guppy/releases/tag/guppy-0.17.17
 [0.17.16]: https://github.com/guppy-rs/guppy/releases/tag/guppy-0.17.16
 [0.17.15]: https://github.com/guppy-rs/guppy/releases/tag/guppy-0.17.15

--- a/guppy/examples/cargo_set_link_filter.rs
+++ b/guppy/examples/cargo_set_link_filter.rs
@@ -174,7 +174,7 @@ fn main() -> Result<(), Error> {
         let resolver =
             PackageResolverForPlatformSet::new(vec![win32_platform_spec(), win64_platform_spec()]);
         let cargo_set =
-            CargoSet::with_resolver(initials, no_extra_features, resolver, &cargo_options)?;
+            CargoSet::with_package_resolver(initials, no_extra_features, resolver, &cargo_options)?;
         cargo_set_to_package_names(cargo_set)
     };
     assert_eq!(

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -260,9 +260,17 @@ impl<'g> CargoSet<'g> {
         Self::new_internal(initials, features_only, None, opts)
     }
 
-    /// Like `Cargo.new`, but takes an additional `resolver` which can be used
-    /// to filter out some dependency edges.
-    pub fn with_resolver(
+    /// Like `Cargo.new`, but takes an additional [`PackageResolver`] which can
+    /// be used to filter out some dependency edges, or to collect additional
+    /// information.
+    ///
+    /// [`resolver.accept`] is called for both target and host dependencies. It
+    /// is called after static filtering through
+    /// [`CargoOptions::add_omitted_packages`], but before any other decisions
+    /// are made.
+    ///
+    /// [`resolver.accept`]: PackageResolver::accept
+    pub fn with_package_resolver(
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
         mut resolver: impl PackageResolver<'g>,

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -26,8 +26,8 @@ use semver::{Version, VersionReq};
 use smallvec::SmallVec;
 use std::{
     collections::{BTreeMap, HashSet},
-    fmt, iter,
-    iter::FromIterator,
+    fmt,
+    iter::{self, FromIterator},
 };
 
 use super::feature::{FeatureFilter, FeatureSet};

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -76,7 +76,7 @@ fn cargo_set_with_resolver<'g>(
         .to_feature_set(StandardFeatures::Default);
 
     let cargo_options = CargoOptions::new();
-    CargoSet::with_resolver(initials, no_extra_features, resolver, &cargo_options).unwrap()
+    CargoSet::with_package_resolver(initials, no_extra_features, resolver, &cargo_options).unwrap()
 }
 
 fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {


### PR DESCRIPTION
Rename `with_resolver` to `with_package_resolver` to make it clear that this is different from the Cargo feature resolver.