### PR TITLE
feat: Allow (de)serialization of `PackageGraph`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.3",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -2403,6 +2404,7 @@ dependencies = [
 name = "guppy-workspace-hack"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "aho-corasick",
  "bit-set",
  "bit-vec",
@@ -2429,6 +2431,7 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
+ "smallvec",
  "syn",
  "toml 0.5.11",
  "windows-sys 0.59.0",
@@ -2842,6 +2845,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3653,6 +3658,8 @@ dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
  "indexmap 2.13.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4312,6 +4319,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snapbox"

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -61,6 +61,15 @@ pretty_assertions = "1.4.1"
 [features]
 proptest1 = ["proptest", "proptest-derive", "target-spec/proptest1"]
 rayon1 = ["rayon"]
+serde1 = [
+    "ahash/serde",
+    "petgraph/serde-1",
+    "indexmap/serde",
+    "smallvec/serde",
+    "camino/serde1",
+    "semver/serde",
+    "target-spec/serde1",
+]
 summaries = ["guppy-summaries", "target-spec/summaries", "toml"]
 
 [lints]

--- a/guppy/README.md
+++ b/guppy/README.md
@@ -54,6 +54,7 @@ which is essentially two `FeatureSet`s along with some more useful information.
 * `rayon1`: Support for parallel iterators through [Rayon](docs.rs/rayon/1) (preliminary work
   so far, more parallel iterators to be added in the future).
 * `summaries`: Support for writing out [build summaries](https://github.com/guppy-rs/guppy/tree/main/guppy-summaries).
+* `serde1`: Support for (de)serializing [`PackageGraph`](crate::graph::PackageGraph) via [`serde`](docs.rs/serde/1).
 
 ## Examples
 

--- a/guppy/src/graph/build_targets.rs
+++ b/guppy/src/graph/build_targets.rs
@@ -232,6 +232,7 @@ impl<'g> BuildTargetKind<'g> {
 
 /// Stored data in a `BuildTarget`.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) struct BuildTargetImpl {
     pub(super) kind: BuildTargetKindImpl,
     // This is only set if the id is BuildTargetId::Library.
@@ -247,6 +248,7 @@ pub(super) struct BuildTargetImpl {
 /// Owned version of `BuildTargetId`.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(all(test, feature = "proptest1"), derive(proptest_derive::Arbitrary))]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) enum OwnedBuildTargetId {
     Library,
     BuildScript,
@@ -270,6 +272,7 @@ impl OwnedBuildTargetId {
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub(super) enum BuildTargetKindImpl {
     LibraryOrExample(SortedSet<String>),

--- a/guppy/src/graph/graph_impl.rs
+++ b/guppy/src/graph/graph_impl.rs
@@ -39,12 +39,15 @@ use super::feature::{FeatureFilter, FeatureSet};
 /// [the `examples` directory](https://github.com/guppy-rs/guppy/tree/main/guppy/examples)
 /// in this crate.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct PackageGraph {
     // Source of truth data.
     pub(super) dep_graph: Graph<PackageId, PackageLinkImpl, Directed, PackageIx>,
     // The strongly connected components of the graph, computed on demand.
+    #[cfg_attr(feature = "serde1", serde(skip))]
     pub(super) sccs: OnceCell<Sccs<PackageIx>>,
     // Feature graph, computed on demand.
+    #[cfg_attr(feature = "serde1", serde(skip))]
     pub(super) feature_graph: OnceCell<FeatureGraphImpl>,
     // XXX Should this be in an Arc for quick cloning? Not clear how this would work with node
     // filters though.
@@ -53,6 +56,7 @@ pub struct PackageGraph {
 
 /// Per-package data for a PackageGraph instance.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) struct PackageGraphData {
     pub(super) packages: AHashMap<PackageId, PackageMetadataImpl>,
     pub(super) workspace: WorkspaceImpl,
@@ -704,6 +708,7 @@ mod workspace_rayon {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) struct WorkspaceImpl {
     pub(super) root: Utf8PathBuf,
     pub(super) target_directory: Utf8PathBuf,
@@ -715,6 +720,7 @@ pub(super) struct WorkspaceImpl {
     pub(super) default_members: Vec<PackageId>,
     // Cache for members by name (only used for proptests)
     #[cfg(feature = "proptest1")]
+    #[cfg_attr(feature = "serde1", serde(skip))]
     pub(super) name_list: OnceCell<Vec<Box<str>>>,
 }
 
@@ -1217,6 +1223,7 @@ impl PartialEq for PackageMetadata<'_> {
 impl Eq for PackageMetadata<'_> {}
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct PackageMetadataImpl {
     // Implementation note: we use Box<str> and Box<Path> to save on memory use when possible.
 
@@ -1247,6 +1254,10 @@ pub(crate) struct PackageMetadataImpl {
     // Other information.
     pub(super) package_ix: NodeIndex<PackageIx>,
     pub(super) source: PackageSourceImpl,
+    #[cfg_attr(
+        feature = "serde1",
+        serde(with = "crate::graph::serde_helpers::btree_map_as_seq")
+    )]
     pub(super) build_targets: BTreeMap<OwnedBuildTargetId, BuildTargetImpl>,
     pub(super) has_default_feature: bool,
 }
@@ -1688,6 +1699,7 @@ pub enum GitReq<'g> {
 
 /// Internal representation of the source of a package.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) enum PackageSourceImpl {
     Workspace(Box<Utf8Path>),
     Path(Box<Utf8Path>),
@@ -1798,6 +1810,7 @@ impl<'g> PackagePublish<'g> {
 
 /// Internal representation of PackagePublish.
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) enum PackagePublishImpl {
     Unrestricted,
     Registries(Box<[String]>),
@@ -1971,6 +1984,7 @@ pub struct PackageLinkPtrs {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) struct PackageLinkImpl {
     pub(super) dep_name: String,
     pub(super) resolved_name: String,
@@ -2146,6 +2160,7 @@ impl<'g> EnabledStatus<'g> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) enum NamedFeatureDep {
     NamedFeature(Box<str>),
     OptionalDependency(Box<str>),
@@ -2205,6 +2220,7 @@ impl fmt::Display for NamedFeatureDep {
 
 /// Information about dependency requirements.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) struct DependencyReqImpl {
     pub(super) required: DepRequiredOrOptional,
     pub(super) optional: DepRequiredOrOptional,
@@ -2252,6 +2268,7 @@ impl DependencyReqImpl {
 /// Information about dependency requirements, scoped to either the dependency being required or
 /// optional.
 #[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(super) struct DepRequiredOrOptional {
     pub(super) build_if: PlatformStatusImpl,
     pub(super) default_features_if: PlatformStatusImpl,

--- a/guppy/src/graph/mod.rs
+++ b/guppy/src/graph/mod.rs
@@ -22,6 +22,8 @@ mod query;
 mod query_core;
 mod resolve;
 mod resolve_core;
+#[cfg(feature = "serde1")]
+pub(crate) mod serde_helpers;
 #[cfg(feature = "summaries")]
 pub mod summaries;
 
@@ -79,10 +81,12 @@ impl From<DependencyDirection> for Direction {
 
 /// Index for PackageGraph. Used for newtype wrapping.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 struct PackageIx(u32);
 
 /// Index for FeatureGraph. Used for newtype wrapping.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 struct FeatureIx(u32);
 
 macro_rules! graph_ix {

--- a/guppy/src/graph/serde_helpers.rs
+++ b/guppy/src/graph/serde_helpers.rs
@@ -1,0 +1,31 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Serde helpers for types that need custom serialization.
+
+/// Serialize/deserialize a `BTreeMap` with non-string keys as a
+/// sequence of `(key, value)` pairs for JSON compatibility.
+pub(crate) mod btree_map_as_seq {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use std::collections::BTreeMap;
+
+    pub fn serialize<S, K, V>(map: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        K: Serialize + Ord,
+        V: Serialize,
+    {
+        let entries: Vec<(&K, &V)> = map.iter().collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D, K, V>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
+    where
+        D: Deserializer<'de>,
+        K: Deserialize<'de> + Ord,
+        V: Deserialize<'de>,
+    {
+        let entries = Vec::<(K, V)>::deserialize(deserializer)?;
+        Ok(entries.into_iter().collect())
+    }
+}

--- a/guppy/src/lib.rs
+++ b/guppy/src/lib.rs
@@ -53,6 +53,7 @@
 //! * `rayon1`: Support for parallel iterators through [Rayon](docs.rs/rayon/1) (preliminary work
 //!   so far, more parallel iterators to be added in the future).
 //! * `summaries`: Support for writing out [build summaries](https://github.com/guppy-rs/guppy/tree/main/guppy-summaries).
+//! * `serde1`: Support for (de)serializing [`PackageGraph`](crate::graph::PackageGraph) via [`serde`](docs.rs/serde/1).
 //!
 //! # Examples
 //!

--- a/guppy/src/package_id.rs
+++ b/guppy/src/package_id.rs
@@ -5,6 +5,8 @@ use std::fmt;
 
 /// An "opaque" identifier for a package.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde1", serde(transparent))]
 #[allow(clippy::derived_hash_with_manual_eq)] // safe because the same PartialEq impl is used everywhere
 pub struct PackageId {
     /// The underlying string representation of an ID.

--- a/guppy/src/platform/platform_eval.rs
+++ b/guppy/src/platform/platform_eval.rs
@@ -185,6 +185,7 @@ impl<'g> PlatformEval<'g> {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum PlatformStatusImpl {
     Always,
     // Empty vector means never.

--- a/guppy/src/sorted_set.rs
+++ b/guppy/src/sorted_set.rs
@@ -5,6 +5,7 @@ use std::{fmt, iter::FromIterator, ops::Deref};
 
 /// An immutable set stored as a sorted vector.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub struct SortedSet<T> {
     inner: Box<[T]>,
 }

--- a/guppy/tests/serde_roundtrip.rs
+++ b/guppy/tests/serde_roundtrip.rs
@@ -1,0 +1,35 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![cfg(feature = "serde1")]
+
+use fixtures::json::JsonFixture;
+use guppy::graph::PackageGraph;
+
+#[test]
+fn serde_roundtrip_json() {
+    let graph = JsonFixture::metadata1().graph();
+
+    let json = serde_json::to_string(&graph).expect("serialization failed");
+    let graph2: PackageGraph = serde_json::from_str(&json).expect("deserialization failed");
+
+    // Verify internal invariants on the deserialized graph.
+    graph2.verify().expect("verification failed");
+
+    // Basic structural checks, since `PackageGraph` doesn't implement `PartialEq`.
+    assert_eq!(
+        graph.package_count(),
+        graph2.package_count(),
+        "package count mismatch"
+    );
+    assert_eq!(
+        graph.link_count(),
+        graph2.link_count(),
+        "link count mismatch"
+    );
+    assert_eq!(
+        graph.workspace().root(),
+        graph2.workspace().root(),
+        "workspace root mismatch"
+    );
+}

--- a/target-spec/Cargo.toml
+++ b/target-spec/Cargo.toml
@@ -34,6 +34,7 @@ toml = "0.5.11"
 [features]
 custom = ["dep:serde", "dep:serde_json"]
 proptest1 = ["proptest"]
+serde1 = ["dep:serde"]
 summaries = ["dep:serde"]
 
 [lints]

--- a/target-spec/README.md
+++ b/target-spec/README.md
@@ -51,6 +51,7 @@ For more advanced usage, see `Platform` and `TargetSpec`.
   `TargetFeatures`.
 * **`proptest1`**: Enables support for property-based testing of `Platform` and
   `TargetFeatures` using `proptest`.
+* **`serde1`**: Support for (de)serializing `TargetSpec` via [`serde`](docs.rs/serde/1).
 
 ### Minimum supported Rust version
 

--- a/target-spec/src/lib.rs
+++ b/target-spec/src/lib.rs
@@ -45,6 +45,7 @@
 //!   [`TargetFeatures`].
 //! * **`proptest1`**: Enables support for property-based testing of [`Platform`] and
 //!   [`TargetFeatures`] using [`proptest`].
+//! * **`serde1`**: Support for (de)serializing [`TargetSpec`] via [`serde`](docs.rs/serde/1).
 //!
 //! ## Minimum supported Rust version
 //!

--- a/target-spec/src/spec.rs
+++ b/target-spec/src/spec.rs
@@ -68,6 +68,7 @@ use std::{borrow::Cow, fmt, str::FromStr, sync::Arc};
 /// assert_eq!(spec.eval(&i686_linux), Some(true), "i686 Linux matches some features");
 /// ```
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
 pub enum TargetSpec {
     /// A complex expression.
     ///
@@ -237,10 +238,27 @@ impl fmt::Display for TargetSpecExpression {
     }
 }
 
+#[cfg(feature = "serde1")]
+impl serde::Serialize for TargetSpecExpression {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.expression_str().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde1")]
+impl<'de> serde::Deserialize<'de> for TargetSpecExpression {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
+        TargetSpecExpression::new(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 /// A plain string as contained within a [`TargetSpec::PlainString`].
 ///
 /// For more information, see [`TargetSpec`].
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde1", serde(transparent))]
 pub struct TargetSpecPlainString(Cow<'static, str>);
 
 impl TargetSpecPlainString {

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2024"
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+ahash = { version = "0.8.12", features = ["serde"] }
 aho-corasick = { version = "1.1.3" }
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
@@ -26,19 +27,20 @@ clap_builder = { version = "4.5.56", default-features = false, features = ["colo
 getrandom = { version = "0.3.3", default-features = false, features = ["std"] }
 hashbrown = { version = "0.16.1", default-features = false, features = ["allocator-api2", "inline-more"] }
 include_dir = { version = "0.7.4", features = ["glob"] }
-indexmap = { version = "2.13.0" }
+indexmap = { version = "2.13.0", features = ["serde"] }
 log = { version = "0.4.28", default-features = false, features = ["std"] }
 miette = { version = "7.6.0", features = ["fancy"] }
 num-traits = { version = "0.2.19" }
 once_cell = { version = "1.21.3" }
 owo-colors = { version = "3.5.0", default-features = false, features = ["supports-colors"] }
-petgraph = { version = "0.8.3", default-features = false, features = ["graphmap", "std"] }
+petgraph = { version = "0.8.3", default-features = false, features = ["graphmap", "serde-1", "std"] }
 regex = { version = "1.12.2", default-features = false, features = ["perf", "std"] }
 regex-automata = { version = "0.4.13", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
 regex-syntax = { version = "0.8.5" }
 serde = { version = "1.0.228", features = ["alloc", "derive"] }
 serde_core = { version = "1.0.228", features = ["alloc"] }
 serde_json = { version = "1.0.145", features = ["unbounded_depth"] }
+smallvec = { version = "1.15.1", default-features = false, features = ["serde"] }
 toml = { version = "0.5.11", features = ["preserve_order"] }
 
 [build-dependencies]


### PR DESCRIPTION
Computing a `PackageGraph` from the "raw" output of `cargo metadata` can be rather expensive. 
When I profiled [`pavex`](https://github.com/LukeMathWalker/pavex) UI test suite, I found out that about ~15% of the overall CPU time was going into building `PackageGraph`s, since each test ends up re-building the same graph over and over again starting from a cached `metadata.json` file.

So, I wondered, why don't I cache `PackageGraph` directly? And that's how this PR came to be 😁 

It adds two new optional features:
- `serde1` to the `guppy` crate
- `serde1` to the `target-spec` crate

All `serde` implementations are derived, with a few notable exceptions:
- We use a manual implementation in `TargetSpecExpression` since `Expression`, from `cfg_expr`, doesn't implement `serde`'s traits
- `build_targets`, in `PackageMetadataImpl`, is serialized as a `Vec` of pairs in order to make its representation JSON-compatible