### PR TITLE
[target-spec-miette] make RustcVersionVerboseParseError a Diagnostic

### DIFF
--- a/.cargo/nightly-config.toml
+++ b/.cargo/nightly-config.toml
@@ -9,7 +9,15 @@
 #
 # To allow this lint for some statements, use
 # `#[cfg_attr(guppy_nightly, expect(non_exhaustive_omitted_patterns))]`.
+#
+# `-D warnings` is included here because cargo's `build.rustflags` is not
+# additive with the `RUSTFLAGS` environment variable, so a job-level
+# `RUSTFLAGS=-D warnings` in CI would silently drop every flag below. The CI
+# job that runs `just bootstrap clippy` does not set `RUSTFLAGS` so that this
+# config takes effect.
 rustflags = [
+    "-D",
+    "warnings",
     "--warn",
     "non_exhaustive_omitted_patterns",
     "-Zcrate-attr=feature(non_exhaustive_omitted_patterns_lint)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: -D warnings
+    # Note: RUSTFLAGS is intentionally not set here. See the comment in
+    # .cargo/nightly-config.toml for why.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@stable
@@ -39,6 +39,8 @@ jobs:
       # cargo hack might cause changes to Cargo.lock which can cause the git diff above to fail. Put
       # this at the end.
       - name: target-spec-powerset clippy
+        env:
+          RUSTFLAGS: -D warnings
         run: just target-spec-powerset clippy
 
   build:

--- a/target-spec-miette/CHANGELOG.md
+++ b/target-spec-miette/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- `IntoMietteDiagnostic` is now implemented for `RustcVersionVerboseParseError`.
+
 ## [0.4.6] - 2026-03-31
 
 ### Added

--- a/target-spec-miette/src/imp.rs
+++ b/target-spec-miette/src/imp.rs
@@ -5,7 +5,7 @@ use miette::{Diagnostic, LabeledSpan, SourceCode, SourceOffset, SourceSpan};
 use std::{error::Error as StdError, fmt};
 use target_spec::errors::{
     CustomTripleCreateError, Error as TargetSpecError, ExpressionParseError, PlainStringParseError,
-    TripleParseError,
+    RustcVersionVerboseParseError, TripleParseError,
 };
 
 /// Extension trait that converts errors into a [`miette::Diagnostic`].
@@ -30,6 +30,7 @@ impl IntoMietteDiagnostic for TargetSpecError {
             #[allow(deprecated)]
             Self::CustomTripleCreate(error) => Box::new(error.into_diagnostic()),
             Self::CustomPlatformCreate(error) => Box::new(error.into_diagnostic()),
+            Self::RustcVersionVerboseParse(error) => Box::new(error.into_diagnostic()),
             other => Box::<dyn Diagnostic + Send + Sync + 'static>::from(other.to_string()),
         }
     }
@@ -199,6 +200,76 @@ impl IntoMietteDiagnostic for PlainStringParseError {
 
     fn into_diagnostic(self) -> Self::IntoDiagnostic {
         PlainStringParseDiagnostic::new(self)
+    }
+}
+
+/// A wrapper around [`RustcVersionVerboseParseError`] that implements
+/// [`Diagnostic`].
+#[derive(Clone, Debug)]
+pub struct RustcVersionVerboseParseDiagnostic(RustcVersionVerboseParseError);
+
+impl RustcVersionVerboseParseDiagnostic {
+    /// Creates a new `RustcVersionVerboseParseDiagnostic`.
+    pub fn new(error: RustcVersionVerboseParseError) -> Self {
+        Self(error)
+    }
+}
+
+impl fmt::Display for RustcVersionVerboseParseDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            // The inner Display for `MissingHostLine` embeds the entire `rustc
+            // -vV` output, which duplicates the source code that miette already
+            // renders below. Here, we keep the headline message short, and let
+            // the labeled span display the `rustc -vV` output.
+            RustcVersionVerboseParseError::MissingHostLine { .. } => {
+                f.write_str("output from `rustc -vV` did not contain a `host:` line")
+            }
+            // The inner Display for `InvalidUtf8` is already short and
+            // self-contained.
+            RustcVersionVerboseParseError::InvalidUtf8(_) => fmt::Display::fmt(&self.0, f),
+            _ => fmt::Display::fmt(&self.0, f),
+        }
+    }
+}
+
+impl StdError for RustcVersionVerboseParseDiagnostic {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.0.source()
+    }
+}
+
+impl Diagnostic for RustcVersionVerboseParseDiagnostic {
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match &self.0 {
+            RustcVersionVerboseParseError::MissingHostLine { output } => {
+                Some(output as &dyn SourceCode)
+            }
+            RustcVersionVerboseParseError::InvalidUtf8(_) => None,
+            _ => None,
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match &self.0 {
+            RustcVersionVerboseParseError::MissingHostLine { output } => {
+                let label = LabeledSpan::new_with_span(
+                    Some("expected a `host: <triple>` line in this output".to_owned()),
+                    (0, output.len()),
+                );
+                Some(Box::new(std::iter::once(label)))
+            }
+            RustcVersionVerboseParseError::InvalidUtf8(_) => None,
+            _ => None,
+        }
+    }
+}
+
+impl IntoMietteDiagnostic for RustcVersionVerboseParseError {
+    type IntoDiagnostic = RustcVersionVerboseParseDiagnostic;
+
+    fn into_diagnostic(self) -> Self::IntoDiagnostic {
+        RustcVersionVerboseParseDiagnostic::new(self)
     }
 }
 

--- a/target-spec-miette/tests/integration/main.rs
+++ b/target-spec-miette/tests/integration/main.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use snapbox::{Data, data::DataFormat};
-use target_spec::errors::CustomTripleCreateError;
+use target_spec::errors::{
+    CustomTripleCreateError, Error as TargetSpecError, RustcVersionVerboseParseError,
+};
 use target_spec_miette::IntoMietteDiagnostic;
 
 #[test]
@@ -29,5 +31,41 @@ fn unavailable_snapshot() {
     b.eq(
         Data::binary(actual),
         snapbox::file!["snapshots/unavailable.ansi"],
+    );
+}
+
+#[test]
+fn rustc_version_verbose_missing_host_snapshot() {
+    // SAFETY: Tests are run under nextest where it's safe to alter the
+    // environment.
+    unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
+
+    // This is realistic `rustc -vV` output that is just missing the `host:` line.
+    let output = "\
+rustc 1.86.0 (05f9846f8 2025-03-31)
+binary: rustc
+commit-hash: 05f9846f893b09a1be1fc8560e11b1d4d2f085ef
+commit-date: 2025-03-31
+release: 1.86.0
+LLVM version: 19.1.7
+"
+    .to_owned();
+
+    let error =
+        TargetSpecError::RustcVersionVerboseParse(RustcVersionVerboseParseError::MissingHostLine {
+            output,
+        });
+    let report = miette::Report::new_boxed(error.into_diagnostic());
+    let actual = format!("{report:?}");
+
+    let b = snapbox::Assert::new().action_env("SNAPSHOTS");
+
+    b.eq(
+        Data::binary(actual.clone()).coerce_to(DataFormat::TermSvg),
+        snapbox::file!["snapshots/rustc_version_verbose_missing_host.svg"],
+    );
+    b.eq(
+        Data::binary(actual),
+        snapbox::file!["snapshots/rustc_version_verbose_missing_host.ansi"],
     );
 }

--- a/target-spec-miette/tests/integration/snapshots/rustc_version_verbose_missing_host.ansi
+++ b/target-spec-miette/tests/integration/snapshots/rustc_version_verbose_missing_host.ansi
@@ -1,0 +1,10 @@
+  [31m×[0m output from `rustc -vV` did not contain a `host:` line
+   ╭─[1:1]
+ [2m1[0m │ [35;1m╭[0m[35;1m─[0m[35;1m▶[0m rustc 1.86.0 (05f9846f8 2025-03-31)
+ [2m2[0m │ [35;1m│[0m   binary: rustc
+ [2m3[0m │ [35;1m│[0m   commit-hash: 05f9846f893b09a1be1fc8560e11b1d4d2f085ef
+ [2m4[0m │ [35;1m│[0m   commit-date: 2025-03-31
+ [2m5[0m │ [35;1m│[0m   release: 1.86.0
+ [2m6[0m │ [35;1m├[0m[35;1m─[0m[35;1m▶[0m LLVM version: 19.1.7
+   · [35;1m╰[0m[35;1m───[0m[35;1m─[0m [35;1mexpected a `host: <triple>` line in this output[0m
+   ╰────

--- a/target-spec-miette/tests/integration/snapshots/rustc_version_verbose_missing_host.svg
+++ b/target-spec-miette/tests/integration/snapshots/rustc_version_verbose_missing_host.svg
@@ -1,0 +1,47 @@
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-magenta { fill: #AA00AA }
+    .fg-red { fill: #AA0000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    .dimmed { opacity: 0.7; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>  </tspan><tspan class="fg-red">×</tspan><tspan> output from `rustc -vV` did not contain a `host:` line</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>   ╭─[1:1]</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan> </tspan><tspan class="dimmed">1</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">╭</tspan><tspan class="fg-magenta bold">─</tspan><tspan class="fg-magenta bold">▶</tspan><tspan> rustc 1.86.0 (05f9846f8 2025-03-31)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan> </tspan><tspan class="dimmed">2</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">│</tspan><tspan>   binary: rustc</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan> </tspan><tspan class="dimmed">3</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">│</tspan><tspan>   commit-hash: 05f9846f893b09a1be1fc8560e11b1d4d2f085ef</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan> </tspan><tspan class="dimmed">4</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">│</tspan><tspan>   commit-date: 2025-03-31</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan> </tspan><tspan class="dimmed">5</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">│</tspan><tspan>   release: 1.86.0</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="dimmed">6</tspan><tspan> │ </tspan><tspan class="fg-magenta bold">├</tspan><tspan class="fg-magenta bold">─</tspan><tspan class="fg-magenta bold">▶</tspan><tspan> LLVM version: 19.1.7</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>   · </tspan><tspan class="fg-magenta bold">╰</tspan><tspan class="fg-magenta bold">───</tspan><tspan class="fg-magenta bold">─</tspan><tspan> </tspan><tspan class="fg-magenta bold">expected a `host: &lt;triple&gt;` line in this output</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>   ╰────</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
Also ensure CI actually catches the missing enum variant (`RUSTFLAGS` was being overridden, sigh).