### PR TITLE
[guppy] make is_cyclic and all_cycles aware of self-loop cycles

### DIFF
--- a/fixtures/src/json.rs
+++ b/fixtures/src/json.rs
@@ -945,15 +945,17 @@ impl FixtureDetails {
         .with_named_features(vec!["extra"])
         .insert_into(&mut details);
 
-        // `cycles().all_cycles()` only reports cycles spanning more than
-        // one package, so no `with_cycles` entry is needed. The feature
-        // graph does flag the path-self dev-dependency as a self-loop
-        // warning on the package's `[base]` (package-only) feature.
+        // `base`'s path-self dev-dependency is a single-node SCC with a
+        // self-loop, i.e., a cycle of length 1. `cycles().all_cycles()`
+        // reports it. The feature graph independently flags the
+        // dev-dependency as a self-loop warning on the package's `[base]`
+        // (package-only) feature.
         Self::new(details)
             .with_workspace_members(vec![
                 ("base", METADATA_SELF_DEV_CYCLE_BASE),
                 ("helper", METADATA_SELF_DEV_CYCLE_HELPER),
             ])
+            .with_cycles(vec![vec![METADATA_SELF_DEV_CYCLE_BASE]])
             .with_feature_graph_warnings(vec![FeatureGraphWarning::SelfLoop {
                 package_id: package_id(METADATA_SELF_DEV_CYCLE_BASE),
                 feature_name: "[base]".to_string(),

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+guppy now correctly distinguishes single-node SCCs from single-node *cycles*. Previously, several APIs conflated the two:
+
+- `PackageGraph::directly_depends_on(x, x)` always returned `false`, and the feature-graph equivalent did the same. They now return `true` when `x` has a self-loop edge (e.g., a `path` dev-dependency on the package's own crate).
+- `Cycles::is_cyclic(x, x)` and `feature::Cycles::is_cyclic(x, x)` were reflexively `true` for every package or feature, regardless of cycle membership. They now return `true` only when `x` lies on an actual cycle, either in a multi-node SCC or via a self-loop edge.
+- `Cycles::all_cycles()` and `feature::Cycles::all_cycles()` reported only SCCs of 2 or more elements. They now also yield single-node SCCs whose node has a self-loop edge, in topological order alongside multi-node SCCs.
+
+These changes make the four APIs internally consistent and align their behavior with their documented semantics.
+
 ## [0.17.25] - 2026-01-30
 
 ### Added

--- a/guppy/src/graph/cycles.rs
+++ b/guppy/src/graph/cycles.rs
@@ -13,7 +13,10 @@ use crate::{
 
 /// Contains information about dependency cycles.
 ///
-/// More accurately, information about Strongly Connected Components with 2 or more elements.
+/// "Cycle" here means a non-trivial Strongly Connected Component: either a
+/// multi-node SCC (where every member is mutually reachable from every
+/// other), or a single-node SCC whose node has a self-loop edge (commonly
+/// produced by a path dev-dependency on the package's own crate).
 /// Constructed through `PackageGraph::cycles`.
 ///
 /// This page includes a bunch of detailed information on cycles, but here's the TLDR:
@@ -282,28 +285,59 @@ impl<'g> Cycles<'g> {
         }
     }
 
-    /// Returns true if these two IDs are in the same cycle.
+    /// Returns true if `a` and `b` lie on a common directed cycle in the
+    /// package graph.
     ///
-    /// This is equivalent to checking if they're in the same Strongly Connected Component.
+    /// "Lie on a common cycle" means: in the same Strongly Connected
+    /// Component *and* that SCC is non-trivial.
+    ///
+    /// * For distinct package IDs, that's the same as being in a multi-node SCC.
+    /// * For the same package ID, the node must either be in a multi-node SCC,
+    ///   or have a self-loop edge in the dependency graph (e.g., from a `path`
+    ///   dev-dependency on the package's own crate).
+    ///
+    /// In particular, `is_cyclic(a, a)` is *not* reflexively true: it
+    /// returns `false` for nodes that aren't on any cycle.
     pub fn is_cyclic(&self, a: &PackageId, b: &PackageId) -> Result<bool, Error> {
         let a_ix = self.package_graph.package_ix(a)?;
         let b_ix = self.package_graph.package_ix(b)?;
-        Ok(self.sccs.is_same_scc(a_ix, b_ix))
+
+        if a_ix != b_ix {
+            // Different nodes lie on a common cycle iff they're in the
+            // same SCC -- which, for distinct nodes, can only be a multi-
+            // node SCC.
+            return Ok(self.sccs.is_same_scc(a_ix, b_ix));
+        }
+
+        // Same node: on a cycle iff its SCC is non-trivial.
+        Ok(self.sccs.in_multi_scc(a_ix) || self.package_graph.dep_graph.contains_edge(a_ix, a_ix))
     }
 
-    /// Returns all the Strongly Connected Components (SCCs) of 2 or more elements in this graph.
+    /// Returns all the cyclic Strongly Connected Components (SCCs) of this
+    /// graph: every multi-node SCC, plus every single-node SCC whose node
+    /// has a self-loop edge.
     ///
-    /// SCCs are returned in topological order: if packages in SCC B depend on packages in SCC
-    /// A, A is returned before B.
+    /// SCCs are returned in topological order: if packages in SCC B depend
+    /// on packages in SCC A, A is returned before B.
     ///
-    /// Within an SCC, nodes are returned in non-dev order: if package Foo has a dependency on Bar,
-    /// and Bar has a cyclic dev-dependency on Foo, then Foo is returned before Bar.
+    /// Within an SCC, nodes are returned in non-dev order: if package Foo
+    /// has a dependency on Bar, and Bar has a cyclic dev-dependency on
+    /// Foo, then Foo is returned before Bar.
     ///
     /// See the type-level docs for details.
     pub fn all_cycles(&self) -> impl DoubleEndedIterator<Item = Vec<&'g PackageId>> + 'g + use<'g> {
         let dep_graph = &self.package_graph.dep_graph;
-        self.sccs
-            .multi_sccs()
-            .map(move |scc| scc.iter().map(move |ix| &dep_graph[*ix]).collect())
+        self.sccs.all_sccs().filter_map(move |scc| {
+            let is_cyclic = match scc {
+                // Multi-node SCCs are non-trivial by definition.
+                [_, _, ..] => true,
+                // Single-node SCC is cyclic iff there's a self-loop edge.
+                &[ix] => dep_graph.contains_edge(ix, ix),
+                // SCCs always have at least one element; the empty case is
+                // unreachable from `kosaraju_scc`.
+                [] => false,
+            };
+            is_cyclic.then(|| scc.iter().map(move |ix| &dep_graph[*ix]).collect())
+        })
     }
 }

--- a/guppy/src/graph/feature/cycles.rs
+++ b/guppy/src/graph/feature/cycles.rs
@@ -31,7 +31,19 @@ impl<'g> Cycles<'g> {
         }
     }
 
-    /// Returns true if these two IDs are in the same cycle.
+    /// Returns true if `a` and `b` lie on a common directed cycle in the
+    /// feature graph.
+    ///
+    /// "Lie on a common cycle" means: in the same Strongly Connected
+    /// Component *and* that SCC is non-trivial.
+    ///
+    /// * For distinct feature IDs, that's the same as being in a multi-node SCC.
+    /// * For the same feature ID, the node must either be in a multi-node SCC,
+    ///   or have a self-loop edge in the dependency graph (e.g., from a `path`
+    ///   dev-dependency on the package's own crate).
+    ///
+    /// In particular, `is_cyclic(a, a)` is *not* reflexively true: it
+    /// returns `false` for features that aren't on any cycle.
     pub fn is_cyclic<'a>(
         &self,
         a: impl Into<FeatureId<'a>>,
@@ -41,24 +53,48 @@ impl<'g> Cycles<'g> {
         let b = b.into();
         let a_ix = self.feature_graph.feature_ix(a)?;
         let b_ix = self.feature_graph.feature_ix(b)?;
-        Ok(self.sccs.is_same_scc(a_ix, b_ix))
+
+        if a_ix != b_ix {
+            // Different features lie on a common cycle iff they're in the
+            // same SCC -- which, for distinct features, can only be a
+            // multi-node SCC.
+            return Ok(self.sccs.is_same_scc(a_ix, b_ix));
+        }
+
+        // Same feature: on a cycle iff its SCC is non-trivial.
+        Ok(
+            self.sccs.in_multi_scc(a_ix)
+                || self.feature_graph.dep_graph().contains_edge(a_ix, a_ix),
+        )
     }
 
-    /// Returns all the cycles of 2 or more elements in this graph.
+    /// Returns all the cyclic Strongly Connected Components of this graph:
+    /// every multi-node SCC, plus every single-node SCC whose feature has
+    /// a self-loop edge.
     ///
-    /// Cycles are returned in topological order: if features in cycle B depend on features in cycle
-    /// A, A is returned before B.
+    /// Cycles are returned in topological order: if features in cycle B
+    /// depend on features in cycle A, A is returned before B.
     ///
-    /// Within a cycle, nodes are returned in non-dev order: if feature Foo has a dependency on Bar,
-    /// and Bar has a dev-dependency on Foo, then Foo is returned before Bar.
+    /// Within a cycle, nodes are returned in non-dev order: if feature Foo
+    /// has a dependency on Bar, and Bar has a dev-dependency on Foo, then
+    /// Foo is returned before Bar.
     pub fn all_cycles(&self) -> impl Iterator<Item = Vec<FeatureId<'g>>> + 'g + use<'g> {
         let dep_graph = self.feature_graph.dep_graph();
         let package_graph = self.feature_graph.package_graph;
-        self.sccs.multi_sccs().map(move |class| {
-            class
-                .iter()
-                .map(move |feature_ix| FeatureId::from_node(package_graph, &dep_graph[*feature_ix]))
-                .collect()
+        self.sccs.all_sccs().filter_map(move |class| {
+            let is_cyclic = match class {
+                [_, _, ..] => true,
+                &[ix] => dep_graph.contains_edge(ix, ix),
+                [] => false,
+            };
+            is_cyclic.then(|| {
+                class
+                    .iter()
+                    .map(move |feature_ix| {
+                        FeatureId::from_node(package_graph, &dep_graph[*feature_ix])
+                    })
+                    .collect()
+            })
         })
     }
 }

--- a/guppy/src/petgraph_support/scc.rs
+++ b/guppy/src/petgraph_support/scc.rs
@@ -52,6 +52,13 @@ impl<Ix: IndexType> Sccs<Ix> {
     }
 
     /// Returns true if `a` and `b` are in the same scc.
+    ///
+    /// Every node is in its own (possibly single-element) SCC, so this is
+    /// reflexive: `is_same_scc(a, a)` is always `true`. This is the SCC
+    /// equivalence relation; it is *not* a cycle-membership predicate.
+    /// Callers that want to know whether two nodes lie on a common cycle
+    /// should additionally check [`Sccs::in_multi_scc`] and/or whether the
+    /// node has a self-loop edge.
     pub fn is_same_scc(&self, a: NodeIndex<Ix>, b: NodeIndex<Ix>) -> bool {
         if a == b {
             return true;
@@ -62,9 +69,24 @@ impl<Ix: IndexType> Sccs<Ix> {
         }
     }
 
-    /// Returns all the SCCs with more than one element.
-    pub fn multi_sccs(&self) -> impl DoubleEndedIterator<Item = &[NodeIndex<Ix>]> {
-        self.sccs.iter().filter(|scc| scc.len() > 1)
+    /// Returns true if `ix` belongs to an SCC with more than one element.
+    ///
+    /// A multi-node SCC is, by definition, non-trivial: every pair of its
+    /// members lies on a directed cycle. Combined with a self-loop check on
+    /// `ix`, this is enough to decide whether a node lies on any cycle.
+    pub fn in_multi_scc(&self, ix: NodeIndex<Ix>) -> bool {
+        self.multi_map.contains_key(&ix)
+    }
+
+    /// Returns all the SCCs of this graph in forward topological order,
+    /// including single-node SCCs.
+    ///
+    /// [`Sccs`] does not store edge information, so callers that care
+    /// about *cyclic* SCCs -- multi-node SCCs plus single-node SCCs with a
+    /// self-loop -- must consult the underlying graph for the self-loop
+    /// check themselves.
+    pub fn all_sccs(&self) -> impl DoubleEndedIterator<Item = &[NodeIndex<Ix>]> {
+        self.sccs.iter()
     }
 
     /// Returns all the nodes of this graph that have no incoming edges to them, and all the nodes

--- a/guppy/tests/graph-tests/graph_tests.rs
+++ b/guppy/tests/graph-tests/graph_tests.rs
@@ -275,14 +275,25 @@ mod small {
         let base_id = package_id(json::METADATA_SELF_DEV_CYCLE_BASE);
         let helper_id = package_id(json::METADATA_SELF_DEV_CYCLE_HELPER);
 
-        // There aren't any multi-node SCCs in this graph, so `base` (with its
-        // self-loop) and `helper` are each in their own single-node SCCs.
-        assert_eq!(graph.cycles().all_cycles().count(), 0);
+        // There aren't any multi-node SCCs in this graph, but `base`'s
+        // single-node SCC has a self-loop, which is a cycle of length 1.
+        // `all_cycles()` reports it; `helper` has no self-loop and is not
+        // on any cycle.
+        let cycles: Vec<Vec<&PackageId>> = graph.cycles().all_cycles().collect();
+        assert_eq!(cycles, vec![vec![&base_id]]);
+
+        let cycles = graph.cycles();
         assert!(
-            !graph
-                .cycles()
-                .is_cyclic(&base_id, &helper_id)
-                .expect("known ids")
+            cycles.is_cyclic(&base_id, &base_id).expect("known id"),
+            "base is on a self-loop cycle",
+        );
+        assert!(
+            !cycles.is_cyclic(&helper_id, &helper_id).expect("known id"),
+            "helper has no self-loop and is not on any cycle",
+        );
+        assert!(
+            !cycles.is_cyclic(&base_id, &helper_id).expect("known ids"),
+            "base and helper are in different SCCs",
         );
 
         let direct: HashSet<(PackageId, PackageId)> = graph
@@ -410,6 +421,34 @@ mod small {
         assert!(
             feature_forward_roots.contains(&base_feature),
             "feature graph forward roots should contain base/[base], got {feature_forward_roots:?}",
+        );
+
+        // Feature-graph cycle membership mirrors the package graph: the
+        // self-loop on `base/[base]` makes it cyclic; `helper/[helper]`
+        // has no self-loop and is not on any cycle.
+        let feature_cycles = feature_graph.cycles();
+        assert!(
+            feature_cycles
+                .is_cyclic(base_feature, base_feature)
+                .expect("base/[base] is a valid feature id"),
+            "base/[base] is on a self-loop cycle in the feature graph",
+        );
+        assert!(
+            !feature_cycles
+                .is_cyclic(helper_feature, helper_feature)
+                .expect("helper/[helper] is a valid feature id"),
+            "helper/[helper] has no self-loop and is not on any cycle",
+        );
+        // Two feature nodes self-loop: `base/[base]` from the package-
+        // level dev-dep, and `base/extra` because the dev-dep declares
+        // `features = ["extra"]`, which makes `extra` reachable from
+        // itself via the dev-dep edge.
+        let base_extra_feature = FeatureId::new(&base_id, FeatureLabel::Named("extra"));
+        let feature_cycle_members: HashSet<FeatureId<'_>> =
+            feature_graph.cycles().all_cycles().flatten().collect();
+        assert_eq!(
+            feature_cycle_members,
+            HashSet::from([base_feature, base_extra_feature]),
         );
     }
 


### PR DESCRIPTION
Previously the `Cycles` APIs conflated SCC equivalence with cycle membership: `is_cyclic(a, a)` was reflexively true for every node, and `all_cycles()` only reported SCCs with two or more elements. The two disagreed for single-node SCCs with a self-loop (e.g., a path-self dev-dep): `is_cyclic(base, base)` returned true while `all_cycles()` omitted it.

This commit moves the cycle-membership logic to the `Cycles` layer: keep `Sccs::is_same_scc` as the SCC equivalence relation (this is reflexive by definition), and have `Cycles::is_cyclic` check "same SCC AND that SCC is non-trivial". `Cycles::all_cycles` now also yields single-node self-loop SCCs in topological order alongside multi-node ones.