### PR TITLE
[guppy] restrict FeatureGraphWarning::SelfLoop to named-feature edges

### DIFF
--- a/1q
+++ b/1q
@@ -1,0 +1,27 @@
+[guppy] restrict FeatureGraphWarning::SelfLoop to named-feature edges
+
+The warning previously fired for *every* self-loop edge in the feature
+graph, including those introduced by legitimate Cargo constructs like a
+path dev-dependency on the package's own crate. Those aren't user
+errors -- Cargo accepts them -- and the warning was just noise.
+
+Restrict the warning to self-loops on edges like:
+
+```toml
+[features]
+a = ["a"]
+```
+
+where a self-reference really is a mistake worth surfacing.
+
+The existing `named_feature_self_loop` invalid-fixture test continues
+to pass unchanged; the `metadata_self_dev_cycle` fixture is updated to
+no longer expect a warning for its path-self dev-dep.
+
+JJ: Change ID: owuylxns
+JJ: This commit contains the following changes:
+JJ:     M fixtures/src/json.rs
+JJ:     M guppy/src/graph/feature/build.rs
+JJ:     M guppy/tests/graph-tests/graph_tests.rs
+JJ:
+JJ: Lines starting with "JJ:" (like this one) will be removed.

--- a/fixtures/src/json.rs
+++ b/fixtures/src/json.rs
@@ -947,19 +947,16 @@ impl FixtureDetails {
 
         // `base`'s path-self dev-dependency is a single-node SCC with a
         // self-loop, i.e., a cycle of length 1. `cycles().all_cycles()`
-        // reports it. The feature graph independently flags the
-        // dev-dependency as a self-loop warning on the package's `[base]`
-        // (package-only) feature.
+        // reports it. The feature graph does *not* emit a self-loop
+        // warning here: the loop comes from `[dev-dependencies]`, not
+        // from a `[features]` declaration, and is a legitimate Cargo
+        // construct.
         Self::new(details)
             .with_workspace_members(vec![
                 ("base", METADATA_SELF_DEV_CYCLE_BASE),
                 ("helper", METADATA_SELF_DEV_CYCLE_HELPER),
             ])
             .with_cycles(vec![vec![METADATA_SELF_DEV_CYCLE_BASE]])
-            .with_feature_graph_warnings(vec![FeatureGraphWarning::SelfLoop {
-                package_id: package_id(METADATA_SELF_DEV_CYCLE_BASE),
-                feature_name: "[base]".to_string(),
-            }])
     }
 
     pub(crate) fn metadata_cycle_features() -> Self {

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -402,11 +402,25 @@ impl FeatureGraphBuildState {
                 .unwrap_or_else(|| panic!("while adding feature edges, missing 'to': {to_node:?}"));
 
             if from_ix == to_ix {
-                let (package_id, feature_label) = from_node.package_id_and_feature_label(graph);
-                self.warnings.push(FeatureGraphWarning::SelfLoop {
-                    package_id: package_id.clone(),
-                    feature_name: feature_label.to_string(),
-                });
+                // Only named-feature self-loops are user errors -- e.g.,
+                // `[features] a = ["a"]`. Self-loops arising from a
+                // package's dependency declarations (such as a `path`
+                // dev-dependency on the package's own crate) are
+                // legitimate Cargo constructs and must not produce a
+                // warning.
+                let is_named_feature_loop = match &edge {
+                    FeatureEdge::NamedFeature
+                    | FeatureEdge::NamedFeatureDepColon(_)
+                    | FeatureEdge::NamedFeatureWithSlash { .. } => true,
+                    FeatureEdge::DependenciesSection(_) | FeatureEdge::FeatureToBase => false,
+                };
+                if is_named_feature_loop {
+                    let (package_id, feature_label) = from_node.package_id_and_feature_label(graph);
+                    self.warnings.push(FeatureGraphWarning::SelfLoop {
+                        package_id: package_id.clone(),
+                        feature_name: feature_label.to_string(),
+                    });
+                }
             }
 
             match self.graph.find_edge(from_ix, to_ix) {

--- a/guppy/tests/graph-tests/graph_tests.rs
+++ b/guppy/tests/graph-tests/graph_tests.rs
@@ -395,9 +395,10 @@ mod small {
         let helper_feature = FeatureId::new(&helper_id, FeatureLabel::Base);
 
         // The same contract for `directly_depends_on` holds in the feature
-        // graph: `base/[base]` has a self-loop (recorded as a `SelfLoop`
-        // warning by the feature graph builder), while `helper/[helper]`
-        // does not.
+        // graph: `base/[base]` has a self-loop (from the path dev-dep),
+        // while `helper/[helper]` does not. No `SelfLoop` warning is
+        // emitted here, since the loop comes from a dependency
+        // declaration rather than a `[features]` entry.
         assert!(
             feature_graph
                 .directly_depends_on(base_feature, base_feature)


### PR DESCRIPTION
The warning previously fired for *every* self-loop edge in the feature graph, including those introduced by legitimate Cargo constructs like a path dev-dependency on the package's own crate. Those aren't user errors -- Cargo accepts them -- and the warning was just noise.

Restrict the warning to self-loops on edges like:

```toml
[features]
a = ["a"]
```

where a self-reference really is a mistake worth surfacing.

The existing `named_feature_self_loop` invalid-fixture test continues to pass unchanged; the `metadata_self_dev_cycle` fixture is updated to no longer expect a warning for its path-self dev-dep.