### PR TITLE
[guppy-summaries, guppy] move to toml 1.1.4, keeping the summary format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,7 +386,7 @@ dependencies = [
  "http-auth",
  "ignore",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap",
  "itertools 0.14.0",
  "jiff",
  "jobserver",
@@ -2355,7 +2355,7 @@ dependencies = [
  "fixtures",
  "guppy-summaries",
  "guppy-workspace-hack",
- "indexmap 2.13.0",
+ "indexmap",
  "itertools 0.15.0",
  "nested",
  "once_cell",
@@ -2371,7 +2371,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "target-spec",
- "toml 0.5.11",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -2410,7 +2410,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ dependencies = [
  "getrandom 0.3.3",
  "hashbrown 0.16.1",
  "include_dir",
- "indexmap 2.13.0",
+ "indexmap",
  "libc",
  "log",
  "miette",
@@ -2444,6 +2444,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "syn",
+ "toml 1.1.4+spec-1.1.0",
  "windows-sys 0.59.0",
  "windows-sys 0.61.2",
 ]
@@ -2496,12 +2497,6 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2836,16 +2831,6 @@ name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -3667,7 +3652,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
- "indexmap 2.13.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -4722,7 +4707,6 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "indexmap 1.9.3",
  "serde",
 ]
 
@@ -4732,7 +4716,7 @@ version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4747,7 +4731,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4786,7 +4770,7 @@ version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 0.6.9",
  "toml_write",
  "winnow 0.7.14",
@@ -4798,7 +4782,7 @@ version = "0.24.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",

--- a/guppy-summaries/CHANGELOG.md
+++ b/guppy-summaries/CHANGELOG.md
@@ -5,7 +5,15 @@
 
 ### Changed
 
-- MSRV updated to Rust 1.62.
+- Updated `toml` to 1.1.4. The on-disk format written by `Summary::write_to_string` is unchanged: summaries are now written by the new `toml_compat` module, which reproduces the output of `toml` 0.5's pretty serializer, including its ordering of nested metadata tables.
+  - `Summary::metadata` is now `toml` 1.x's `Table`.
+  - `Summary::parse`, `Summary::with_metadata`, `Summary::to_string` and `Summary::write_to_string` return `toml` 1.x's error types.
+  - `Summary::with_metadata` no longer rejects metadata whose fields are declared out of TOML emission order; the fields are reordered when the summary is constructed instead.
+  - `SummaryDiff` is still serialized with `toml`'s own serializer, whose blank-line placement differs slightly from 0.5.
+
+  This is a breaking change for code that names those types.
+- Parsing now follows the TOML 1.1 specification strictly. Documents that were accepted by the lenient `toml` 0.5 parser but are not valid TOML are rejected.
+- MSRV updated to Rust 1.86.
 
 ## [0.7.1] - 2022-09-30
 

--- a/guppy-summaries/Cargo.toml
+++ b/guppy-summaries/Cargo.toml
@@ -37,7 +37,7 @@ ahash = "0.8.12"
 camino = { version = "1.2.1", features = ["serde1"] }
 cfg-if = "1.0.3"
 diffus = "0.10.0"
-toml = { version = "0.5.11", features = ["preserve_order"] }
+toml = { version = "1.1.4", features = ["preserve_order"] }
 semver = { version = "1.0.27", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
 guppy-workspace-hack.workspace = true

--- a/guppy-summaries/README.md
+++ b/guppy-summaries/README.md
@@ -17,7 +17,6 @@ use guppy_summaries::{Summary, SummaryId, SummarySource, PackageStatus};
 use pretty_assertions::assert_eq;
 use semver::Version;
 use std::collections::BTreeSet;
-use toml::Value;
 
 // A summary is a TOML file that has this format:
 static SUMMARY: &str = r#"

--- a/guppy-summaries/src/lib.rs
+++ b/guppy-summaries/src/lib.rs
@@ -16,7 +16,6 @@
 //! use pretty_assertions::assert_eq;
 //! use semver::Version;
 //! use std::collections::BTreeSet;
-//! use toml::Value;
 //!
 //! // A summary is a TOML file that has this format:
 //! static SUMMARY: &str = r#"
@@ -114,6 +113,7 @@ pub mod diff;
 // report::SummaryReport is exported through the diff module.
 mod report;
 mod summary;
+pub mod toml_compat;
 #[cfg(test)]
 mod unit_tests;
 

--- a/guppy-summaries/src/summary.rs
+++ b/guppy-summaries/src/summary.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::diff::SummaryDiff;
+use crate::{diff::SummaryDiff, toml_compat};
 use camino::{Utf8Path, Utf8PathBuf};
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -9,14 +9,12 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
 };
-use toml::{Serializer, value::Table};
+use toml::{Table, Value};
 
 /// A type representing a package map as used in `Summary` instances.
 pub type PackageMap = BTreeMap<SummaryId, PackageInfo>;
 
 /// An in-memory representation of a build summary.
-///
-/// The metadata parameter is customizable.
 ///
 /// For more, see the crate-level documentation.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
@@ -26,7 +24,7 @@ pub struct Summary {
     ///
     /// This may be used for storing extra information about the summary.
     ///
-    /// The type defaults to `toml::Value` but is customizable.
+    /// Populate it from any [`Serialize`] type through [`Self::with_metadata`].
     #[serde(default, skip_serializing_if = "Table::is_empty")]
     pub metadata: Table,
 
@@ -53,16 +51,26 @@ impl Summary {
     /// Constructs a new summary with the provided metadata, and an empty `target_packages` and
     /// `host_packages`.
     pub fn with_metadata(metadata: &impl Serialize) -> Result<Self, toml::ser::Error> {
+        // Serialize as a string, then deserialize as a table.
+        //
+        // This is a bit strange, right? Ordinarily we would use
+        // `Table::try_from`. But that doesn't work here, for two reasons:
+        //
+        // 1. It retains struct field order, while for compatibility reasons we must
+        //    reorder fields so that values are emitted before tables.
+        // 2. `Table::try_from` doesn't understand the special marker `toml_datetime`
+        //    uses to serialize `Datetime` values.
         let toml_str = toml::to_string(metadata)?;
-        let metadata =
-            toml::from_str(&toml_str).expect("toml::to_string creates a valid TOML string");
+        let metadata = toml_str
+            .parse()
+            .expect("toml::to_string creates a valid TOML string");
         Ok(Self {
             metadata,
             ..Self::default()
         })
     }
 
-    /// Deserializes a summary from the given string, with optional custom metadata.
+    /// Deserializes a summary from the given string.
     pub fn parse(s: &str) -> Result<Self, toml::de::Error> {
         toml::from_str(s)
     }
@@ -81,12 +89,52 @@ impl Summary {
         Ok(dst)
     }
 
-    /// Serializes this summary into the given TOML string, using pretty TOML syntax.
+    /// Serializes this summary into the given TOML string, using pretty TOML
+    /// syntax.
+    ///
+    /// This serializes the summary using the [`toml_compat`] module, for
+    /// byte-identical output against previous versions of guppy-summaries which
+    /// used toml 0.5.
     pub fn write_to_string(&self, dst: &mut String) -> Result<(), toml::ser::Error> {
-        let mut serializer = Serializer::pretty(dst);
-        serializer.pretty_array(false);
-        self.serialize(&mut serializer)
+        // toml 0.5 wrote the metadata map's entries in order but reordered
+        // every Value::Table below them, and wrote the package lists in struct
+        // order.
+        //
+        // Build the root table by hand rather than using Table::try_from(self).
+        // This also avoids mangling `Value::Datetime` instances stored in the
+        // metadata.
+        let mut table = Table::new();
+        if !self.metadata.is_empty() {
+            let metadata = self
+                .metadata
+                .iter()
+                .map(|(key, value)| (key.clone(), toml_compat::reorder_value(value)))
+                .collect();
+            table.insert("metadata".to_owned(), Value::Table(metadata));
+        }
+        table.extend(Table::try_from(SummaryPackages {
+            target_packages: &self.target_packages,
+            host_packages: &self.host_packages,
+        })?);
+        toml_compat::write_table(&table, dst)
     }
+}
+
+#[derive(Serialize)]
+struct SummaryPackages<'a> {
+    #[serde(
+        rename = "target-package",
+        with = "package_map_impl",
+        skip_serializing_if = "PackageMap::is_empty"
+    )]
+    target_packages: &'a PackageMap,
+
+    #[serde(
+        rename = "host-package",
+        with = "package_map_impl",
+        skip_serializing_if = "PackageMap::is_empty"
+    )]
+    host_packages: &'a PackageMap,
 }
 
 /// A unique identifier for a package in a build summary.

--- a/guppy-summaries/src/toml_compat.rs
+++ b/guppy-summaries/src/toml_compat.rs
@@ -1,0 +1,714 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A serializer that reproduces the output of `toml` 0.5's `Serializer::pretty`
+//! with `pretty_array(false)`.
+//!
+//! This is an internal module that is public only because it is shared by
+//! several guppy-related projects.
+//!
+//! The TOML output is part of the stable on-disk format for guppy-related
+//! projects. If you're not bound by backwards compatibility concerns, you
+//! probably want to use `toml` 1's serializer -- its output format is better.
+
+// Specific details that are preserved here (from toml 0.5.11's src/ser.rs):
+//
+// * toml 0.5's preserve_order feature (tables are emitted in iteration order)
+// * literal single-quoted strings
+// * headers for empty tables
+// * blank line placement around `[[...]]` entries
+//
+// The structure deliberately mirrors the original state machine in toml 0.5 so
+// that the two can be compared side by side.
+
+use std::{cell::Cell, fmt::Write};
+use toml::{Table, Value, ser::Error};
+
+/// Writes `table` to `out` in the toml 0.5 pretty format.
+///
+/// Returns an error if a non-table value follows a table or array of tables
+/// within the same parent. This matches toml 0.5's `ValueAfterTable` error.
+pub fn write_table(table: &Table, out: &mut String) -> Result<(), Error> {
+    emit_table(out, table, &State::End)
+}
+
+/// Reorders values within `value` to conform to what toml 0.5 does.
+///
+/// This mirrors toml 0.5.11's `value.rs:412-439` (`impl Serialize for
+/// Value::Table`), and reorders items as:
+///
+/// * plain values
+/// * then arrays of tables
+/// * then tables, recursively
+///
+/// toml 0.5 applies this reordering to `Value` trees only, not to structs or a
+/// directly serialized `Table` field, so callers are expected to only apply it
+/// in those cases.
+pub fn reorder_value(value: &Value) -> Value {
+    match value {
+        Value::String(_)
+        | Value::Integer(_)
+        | Value::Float(_)
+        | Value::Boolean(_)
+        | Value::Datetime(_) => value.clone(),
+        Value::Array(array) => Value::Array(array.iter().map(reorder_value).collect()),
+        Value::Table(table) => {
+            let mut reordered = Table::new();
+            for (key, value) in table {
+                if !value.is_table() && !is_array_of_tables(value) {
+                    reordered.insert(key.clone(), reorder_value(value));
+                }
+            }
+            for (key, value) in table {
+                if is_array_of_tables(value) {
+                    reordered.insert(key.clone(), reorder_value(value));
+                }
+            }
+            for (key, value) in table {
+                if value.is_table() {
+                    reordered.insert(key.clone(), reorder_value(value));
+                }
+            }
+            Value::Table(reordered)
+        }
+    }
+}
+
+// toml 0.5 treats an array as an array of tables if any element is a table.
+fn is_array_of_tables(value: &Value) -> bool {
+    match value {
+        Value::Array(array) => array.iter().any(Value::is_table),
+        Value::String(_)
+        | Value::Integer(_)
+        | Value::Float(_)
+        | Value::Boolean(_)
+        | Value::Datetime(_)
+        | Value::Table(_) => false,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ArrayState {
+    Started,
+    StartedAsATable,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum State<'a> {
+    End,
+    Table {
+        key: &'a str,
+        parent: &'a State<'a>,
+        first: &'a Cell<bool>,
+        table_emitted: &'a Cell<bool>,
+    },
+    Array {
+        parent: &'a State<'a>,
+        first: &'a Cell<bool>,
+        type_: &'a Cell<Option<ArrayState>>,
+    },
+}
+
+fn value_after_table() -> Error {
+    serde::ser::Error::custom("values must be emitted before tables")
+}
+
+fn emit_value(out: &mut String, value: &Value, state: &State<'_>) -> Result<(), Error> {
+    match value {
+        Value::String(s) => {
+            emit_key(out, state, ArrayState::Started)?;
+            emit_str(out, s, false);
+            newline_if_table(out, state);
+            Ok(())
+        }
+        Value::Integer(i) => display(out, i, state),
+        Value::Float(f) => {
+            emit_key(out, state, ArrayState::Started)?;
+            emit_float(out, *f);
+            newline_if_table(out, state);
+            Ok(())
+        }
+        Value::Boolean(b) => display(out, b, state),
+        // toml_datetime 1.x's Display matches toml 0.5 almost all the time,
+        // with two exceptions:
+        //
+        // 1. An explicit zero fractional second is kept (`07:32:00.0`, where
+        //    0.5 dropped it).
+        // 2. Negative offsets under an hour keep their sign (`-00:30`, which
+        //    0.5 mis-wrote as `+00:30`).
+        //
+        // We accept these divergences here in the interest of not
+        // overengineering a solution, especially since this metadata is
+        // unlikely to have toml datetime values in the first place.
+        Value::Datetime(dt) => display(out, dt, state),
+        Value::Array(array) => emit_array(out, array, state),
+        Value::Table(table) => emit_table(out, table, state),
+    }
+}
+
+fn display(
+    out: &mut String,
+    value: impl std::fmt::Display,
+    state: &State<'_>,
+) -> Result<(), Error> {
+    emit_key(out, state, ArrayState::Started)?;
+    write!(out, "{value}").expect("writing to a String cannot fail");
+    newline_if_table(out, state);
+    Ok(())
+}
+
+fn emit_float(out: &mut String, v: f64) {
+    match (v.is_sign_negative(), v.is_nan(), v == 0.0) {
+        (true, true, _) => out.push_str("-nan"),
+        (false, true, _) => out.push_str("nan"),
+        (true, false, true) => out.push_str("-0.0"),
+        (false, false, true) => out.push_str("0.0"),
+        (_, false, false) => {
+            write!(out, "{v}").expect("writing to a String cannot fail");
+            if v % 1.0 == 0.0 {
+                out.push_str(".0");
+            }
+        }
+    }
+}
+
+fn newline_if_table(out: &mut String, state: &State<'_>) {
+    match state {
+        State::Table { .. } => out.push('\n'),
+        State::End | State::Array { .. } => {}
+    }
+}
+
+fn emit_array(out: &mut String, array: &[Value], state: &State<'_>) -> Result<(), Error> {
+    array_type(state, ArrayState::Started);
+    let first = Cell::new(true);
+    let type_ = Cell::new(None);
+    for element in array {
+        emit_value(
+            out,
+            element,
+            &State::Array {
+                parent: state,
+                first: &first,
+                type_: &type_,
+            },
+        )?;
+        first.set(false);
+    }
+
+    match type_.get() {
+        Some(ArrayState::StartedAsATable) => return Ok(()),
+        Some(ArrayState::Started) => out.push(']'),
+        None => {
+            emit_key(out, state, ArrayState::Started)?;
+            out.push_str("[]");
+        }
+    }
+    newline_if_table(out, state);
+    Ok(())
+}
+
+fn emit_table(out: &mut String, table: &Table, state: &State<'_>) -> Result<(), Error> {
+    array_type(state, ArrayState::StartedAsATable);
+    let first = Cell::new(true);
+    let table_emitted = Cell::new(false);
+    for (key, value) in table {
+        emit_value(
+            out,
+            value,
+            &State::Table {
+                key,
+                parent: state,
+                first: &first,
+                table_emitted: &table_emitted,
+            },
+        )?;
+        first.set(false);
+    }
+
+    if first.get() {
+        emit_table_header(out, state);
+    }
+    Ok(())
+}
+
+fn emit_key(out: &mut String, state: &State<'_>, type_: ArrayState) -> Result<(), Error> {
+    array_type(state, type_);
+    emit_key_inner(out, state)
+}
+
+fn emit_key_inner(out: &mut String, state: &State<'_>) -> Result<(), Error> {
+    match *state {
+        State::End => Ok(()),
+        State::Array {
+            parent,
+            first,
+            type_,
+        } => {
+            assert!(
+                type_.get().is_some(),
+                "array_type is always called before emit_key_inner"
+            );
+            if first.get() {
+                emit_key_inner(out, parent)?;
+            }
+            if first.get() {
+                out.push('[');
+            } else {
+                out.push_str(", ");
+            }
+            Ok(())
+        }
+        State::Table {
+            key,
+            parent,
+            first,
+            table_emitted,
+        } => {
+            if table_emitted.get() {
+                return Err(value_after_table());
+            }
+            if first.get() {
+                emit_table_header(out, parent);
+                first.set(false);
+            }
+            escape_key(out, key);
+            out.push_str(" = ");
+            Ok(())
+        }
+    }
+}
+
+fn array_type(state: &State<'_>, type_: ArrayState) {
+    if let State::Array { type_: prev, .. } = state {
+        if prev.get().is_none() {
+            prev.set(Some(type_));
+        }
+    }
+}
+
+fn escape_key(out: &mut String, key: &str) {
+    let bare = !key.is_empty()
+        && key
+            .chars()
+            .all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_'));
+    if bare {
+        out.push_str(key);
+    } else {
+        emit_str(out, key, true);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StrType {
+    NewlineTriple,
+    OnelineTriple,
+    OnelineSingle,
+}
+
+enum StrRepr {
+    // A literal string using single quotes.
+    Literal(String, StrType),
+    // A basic string using double quotes and escapes.
+    Std(StrType),
+}
+
+fn str_repr(value: &str) -> StrRepr {
+    let mut out = String::with_capacity(value.len() * 2);
+    let mut ty = StrType::OnelineSingle;
+    let mut max_found_singles = 0;
+    let mut found_singles = 0;
+    let mut can_be_pretty = true;
+
+    for ch in value.chars() {
+        if can_be_pretty {
+            if ch == '\'' {
+                found_singles += 1;
+                if found_singles >= 3 {
+                    can_be_pretty = false;
+                }
+            } else {
+                if found_singles > max_found_singles {
+                    max_found_singles = found_singles;
+                }
+                found_singles = 0
+            }
+            match ch {
+                '\t' => {}
+                '\n' => ty = StrType::NewlineTriple,
+                c if c <= '\u{1f}' || c == '\u{7f}' => can_be_pretty = false,
+                _ => {}
+            }
+            out.push(ch);
+        } else if ch == '\n' {
+            ty = StrType::NewlineTriple;
+        }
+    }
+    if can_be_pretty && found_singles > 0 && value.ends_with('\'') {
+        can_be_pretty = false;
+    }
+    if !can_be_pretty {
+        debug_assert!(ty != StrType::OnelineTriple);
+        return StrRepr::Std(ty);
+    }
+    if found_singles > max_found_singles {
+        max_found_singles = found_singles;
+    }
+    debug_assert!(max_found_singles < 3);
+    if ty == StrType::OnelineSingle && max_found_singles >= 1 {
+        ty = StrType::OnelineTriple;
+    }
+    StrRepr::Literal(out, ty)
+}
+
+fn emit_str(out: &mut String, value: &str, is_key: bool) {
+    let repr = if is_key {
+        StrRepr::Std(StrType::OnelineSingle)
+    } else {
+        str_repr(value)
+    };
+    match repr {
+        StrRepr::Literal(literal, ty) => {
+            match ty {
+                StrType::NewlineTriple => out.push_str("'''\n"),
+                StrType::OnelineTriple => out.push_str("'''"),
+                StrType::OnelineSingle => out.push('\''),
+            }
+            out.push_str(&literal);
+            match ty {
+                StrType::OnelineSingle => out.push('\''),
+                StrType::NewlineTriple | StrType::OnelineTriple => out.push_str("'''"),
+            }
+        }
+        StrRepr::Std(ty) => {
+            match ty {
+                StrType::NewlineTriple => out.push_str("\"\"\"\n"),
+                StrType::OnelineSingle | StrType::OnelineTriple => out.push('"'),
+            }
+            for ch in value.chars() {
+                match ch {
+                    '\u{8}' => out.push_str("\\b"),
+                    '\u{9}' => out.push_str("\\t"),
+                    '\u{a}' => match ty {
+                        StrType::NewlineTriple => out.push('\n'),
+                        StrType::OnelineSingle => out.push_str("\\n"),
+                        StrType::OnelineTriple => {
+                            unreachable!("newlines always produce NewlineTriple")
+                        }
+                    },
+                    '\u{c}' => out.push_str("\\f"),
+                    '\u{d}' => out.push_str("\\r"),
+                    '\u{22}' => out.push_str("\\\""),
+                    '\u{5c}' => out.push_str("\\\\"),
+                    c if c <= '\u{1f}' || c == '\u{7f}' => {
+                        write!(out, "\\u{:04X}", ch as u32)
+                            .expect("writing to a String cannot fail");
+                    }
+                    ch => out.push(ch),
+                }
+            }
+            match ty {
+                StrType::NewlineTriple => out.push_str("\"\"\""),
+                StrType::OnelineSingle | StrType::OnelineTriple => out.push('"'),
+            }
+        }
+    }
+}
+
+fn emit_table_header(out: &mut String, state: &State<'_>) {
+    let array_of_tables = match state {
+        State::End => return,
+        State::Array { .. } => true,
+        State::Table { .. } => false,
+    };
+
+    // `[a.b]` headers can omit their `[a]` ancestor, but `[[a]]` ancestors
+    // cannot be omitted, so emit those first.
+    let mut p = state;
+    if let State::Array { first, parent, .. } = *state {
+        if first.get() {
+            p = parent;
+        }
+    }
+    while let State::Table { first, parent, .. } = *p {
+        p = parent;
+        if !first.get() {
+            break;
+        }
+        if let State::Array {
+            parent: State::Table { .. },
+            ..
+        } = *parent
+        {
+            emit_table_header(out, parent);
+            break;
+        }
+    }
+
+    match *state {
+        State::Table { first, .. } => {
+            if !first.get() {
+                out.push('\n');
+            }
+        }
+        State::Array { parent, first, .. } => {
+            if !first.get() {
+                out.push('\n');
+            } else if let State::Table { first, .. } = *parent {
+                if !first.get() {
+                    out.push('\n');
+                }
+            }
+        }
+        State::End => {}
+    }
+    out.push('[');
+    if array_of_tables {
+        out.push('[');
+    }
+    _ = emit_key_part(out, state);
+    if array_of_tables {
+        out.push(']');
+    }
+    out.push_str("]\n");
+}
+
+// Returns true if nothing was written, so that callers know whether to insert a
+// `.` separator.
+#[must_use]
+fn emit_key_part(out: &mut String, state: &State<'_>) -> bool {
+    match *state {
+        State::Array { parent, .. } => emit_key_part(out, parent),
+        State::End => true,
+        State::Table {
+            key,
+            parent,
+            table_emitted,
+            ..
+        } => {
+            table_emitted.set(true);
+            let first = emit_key_part(out, parent);
+            if !first {
+                out.push('.');
+            }
+            escape_key(out, key);
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(input: &str) -> Result<String, Error> {
+        let table: Table = toml::from_str(input).expect("valid TOML input");
+        let mut out = String::new();
+        write_table(&table, &mut out)?;
+        Ok(out)
+    }
+
+    // Expected outputs in this module were captured from toml 0.5.11's
+    // `Serializer::pretty` with `pretty_array(false)`.
+    #[test]
+    fn summary_shape() {
+        let input = r#"
+hakari-package = "workspace-hack"
+resolver = "2"
+output-single-feature = true
+platforms = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+empty = []
+[traversal-excludes]
+workspace-members = ["a"]
+[[traversal-excludes.ids]]
+name = "cargo-compare"
+version = "0.1.0"
+workspace-path = "internal-tools/cargo-compare"
+[[traversal-excludes.ids]]
+name = "serde"
+version = "1.0.0"
+crates-io = true
+[[traversal-excludes.third-party]]
+name = "quote"
+version = "1"
+crates-io = true
+[final-excludes]
+[registries.alt]
+index = "https://example.com/alt"
+[registries."my.registry"]
+index = "https://example.com/index"
+"#;
+        let expected = "\
+hakari-package = 'workspace-hack'
+resolver = '2'
+output-single-feature = true
+platforms = ['x86_64-unknown-linux-gnu', 'aarch64-apple-darwin']
+empty = []
+
+[traversal-excludes]
+workspace-members = ['a']
+
+[[traversal-excludes.ids]]
+name = 'cargo-compare'
+version = '0.1.0'
+workspace-path = 'internal-tools/cargo-compare'
+
+[[traversal-excludes.ids]]
+name = 'serde'
+version = '1.0.0'
+crates-io = true
+
+[[traversal-excludes.third-party]]
+name = 'quote'
+version = '1'
+crates-io = true
+
+[final-excludes]
+[registries.alt]
+index = 'https://example.com/alt'
+
+[registries.\"my.registry\"]
+index = 'https://example.com/index'
+";
+        assert_eq!(write(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn strings() {
+        let input = r#"
+plain = "abc"
+apostrophe = "it's"
+ends-with-apostrophe = "ends'"
+triple = "'''"
+double-quotes = "say \"hi\""
+escapes = "tab\there\u0001\u007f"
+multiline = "a\nb"
+multiline-apostrophe = "a'\nb"
+multiline-control = "a\r\nb"
+backslash = "C:\\dir"
+"#;
+        let expected = "\
+plain = 'abc'
+apostrophe = '''it's'''
+ends-with-apostrophe = \"ends'\"
+triple = \"'''\"
+double-quotes = 'say \"hi\"'
+escapes = \"tab\\there\\u0001\\u007F\"
+multiline = '''
+a
+b'''
+multiline-apostrophe = '''
+a'
+b'''
+multiline-control = \"\"\"
+a\\r
+b\"\"\"
+backslash = 'C:\\dir'
+";
+        assert_eq!(write(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn scalars_and_nesting() {
+        let input = r#"
+int = -42
+float = 1.0
+float2 = 2.5
+yes = false
+nested = [[1, 2], []]
+[a.b.c]
+x = 1
+[[aot]]
+[[aot]]
+y = 2
+[aot.sub]
+z = 3
+"#;
+        let expected = "\
+int = -42
+float = 1.0
+float2 = 2.5
+yes = false
+nested = [[1, 2], []]
+[a.b.c]
+x = 1
+
+[[aot]]
+
+[[aot]]
+y = 2
+
+[aot.sub]
+z = 3
+";
+        assert_eq!(write(input).unwrap(), expected);
+    }
+
+    #[test]
+    fn reorder_value_matches_toml_05() {
+        let input = r#"
+plain = [1, 2]
+v = true
+[t]
+x = 1
+[[aot]]
+[[aot]]
+sub = { inner = { y = 1 }, z = 2 }
+w = 3
+"#;
+        let table: Table = toml::from_str(input).expect("valid TOML input");
+        let reordered = match reorder_value(&Value::Table(table)) {
+            Value::Table(table) => table,
+            other => panic!("reordered a table into {other:?}"),
+        };
+        let keys: Vec<_> = reordered.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["plain", "v", "aot", "t"]);
+
+        let second = reordered["aot"][1]
+            .as_table()
+            .expect("array of tables element is a table");
+        let keys: Vec<_> = second.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["w", "sub"], "array elements are reordered");
+        let sub = second["sub"].as_table().expect("sub is a table");
+        let keys: Vec<_> = sub.keys().map(String::as_str).collect();
+        assert_eq!(keys, ["z", "inner"], "nested tables are reordered");
+
+        let mut out = String::new();
+        write_table(&reordered, &mut out).expect("reordered table serializes");
+        assert_eq!(
+            out,
+            "\
+plain = [1, 2]
+v = true
+
+[[aot]]
+
+[[aot]]
+w = 3
+
+[aot.sub]
+z = 2
+
+[aot.sub.inner]
+y = 1
+
+[t]
+x = 1
+"
+        );
+    }
+
+    #[test]
+    fn value_after_table_is_an_error() {
+        let mut table = Table::new();
+        table.insert("t".to_owned(), Value::Table(Table::new()));
+        table.insert("v".to_owned(), Value::Integer(1));
+        let mut out = String::new();
+        let err = write_table(&table, &mut out).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("values must be emitted before tables"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/guppy-summaries/src/unit_tests/basic_tests.rs
+++ b/guppy-summaries/src/unit_tests/basic_tests.rs
@@ -532,6 +532,7 @@ fn test_serialization() {
     status = "transitive"
     features = ["default"]
     optional-deps = ["dep2"]
+
     [[host-packages.changed]]
     name = "local-dep"
     version = "2.0.0"
@@ -575,7 +576,7 @@ fn test_serialization() {
 
     // TODO: add roundtrip test into the proper data structure. For now we just check that the output is valid TOML.
     let parsed = toml_out
-        .parse::<toml::Value>()
+        .parse::<toml::Table>()
         .expect("deserialization from value should work");
     println!("parsed output: {parsed:?}");
 }
@@ -602,4 +603,118 @@ fn make_summary(list: Vec<(SummaryId, PackageStatus, Vec<&str>, Vec<&str>)>) -> 
             )
         })
         .collect()
+}
+
+#[test]
+fn metadata_round_trips_match_toml_05() {
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "datetime",
+            "[metadata]\nd = 1979-05-27T07:32:00Z\n",
+            "[metadata]\nd = 1979-05-27T07:32:00Z\n",
+        ),
+        (
+            "array of tables declared before a plain array",
+            "[metadata.omitted-packages]\nids = [{ name = 'a' }]\nworkspace-members = ['b']\n",
+            "[metadata.omitted-packages]\nworkspace-members = ['b']\n\n\
+             [[metadata.omitted-packages.ids]]\nname = 'a'\n",
+        ),
+        (
+            "sub-table declared before an array of tables",
+            "[metadata.o.sub]\nx = 1\n[[metadata.o.aot]]\ny = 1\n",
+            "[[metadata.o.aot]]\ny = 1\n\n[metadata.o.sub]\nx = 1\n",
+        ),
+        (
+            "scalar declared after a nested sub-table",
+            "[metadata.outer.inner]\nx = 1\n[metadata.outer]\nflag = true\n",
+            "[metadata.outer]\nflag = true\n\n[metadata.outer.inner]\nx = 1\n",
+        ),
+        (
+            "misordered array of tables element",
+            "[[metadata.a]]\nsub = { x = 1 }\nv = 2\n",
+            "[[metadata.a]]\nv = 2\n\n[metadata.a.sub]\nx = 1\n",
+        ),
+        (
+            "metadata alongside packages",
+            "[metadata]\nname = 'n'\n[metadata.o.sub]\nx = 1\n[[metadata.o.aot]]\ny = 1\n\n\
+             [[target-package]]\nname = 'foo'\nversion = '1.2.3'\nworkspace-path = 'foo'\n\
+             status = 'initial'\nfeatures = ['a']\n",
+            "[metadata]\nname = 'n'\n[[metadata.o.aot]]\ny = 1\n\n[metadata.o.sub]\nx = 1\n\n\
+             [[target-package]]\nname = 'foo'\nversion = '1.2.3'\nworkspace-path = 'foo'\n\
+             status = 'initial'\nfeatures = ['a']\n",
+        ),
+    ];
+    for (name, input, expected) in cases {
+        let summary = Summary::parse(input).unwrap_or_else(|err| panic!("{name}: parsed: {err}"));
+        let actual = summary
+            .to_string()
+            .unwrap_or_else(|err| panic!("{name}: serialized: {err}"));
+        assert_eq!(&actual, expected, "{name}");
+        assert_eq!(
+            Summary::parse(&actual).unwrap_or_else(|err| panic!("{name}: reparsed: {err}")),
+            summary,
+            "{name}: round trip"
+        );
+    }
+}
+
+#[test]
+fn top_level_metadata_value_after_table_is_an_error() {
+    // toml 0.5 did not reorder the metadata map's own entries, so this was
+    // Err(ValueAfterTable) there too.
+    let summary = Summary::parse("[metadata.t]\nx = 1\n[metadata]\nv = 1\n").expect("parsed");
+    let err = summary.to_string().expect_err("value after table");
+    assert!(
+        err.to_string()
+            .contains("values must be emitted before tables"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn with_metadata_preserves_datetimes_and_reorders_fields() {
+    #[derive(serde::Serialize)]
+    struct Metadata {
+        nested: Nested,
+        when: toml::value::Datetime,
+        name: &'static str,
+        items: Vec<Nested>,
+    }
+
+    #[derive(serde::Serialize)]
+    struct Nested {
+        x: i64,
+        missing: Option<u32>,
+    }
+
+    let metadata = Metadata {
+        nested: Nested {
+            x: 1,
+            missing: None,
+        },
+        when: "1979-05-27T07:32:00Z".parse().expect("valid datetime"),
+        name: "n",
+        items: vec![Nested {
+            x: 2,
+            missing: None,
+        }],
+    };
+    let summary = Summary::with_metadata(&metadata).expect("metadata serialized");
+    assert!(
+        summary.metadata["when"].is_datetime(),
+        "datetime preserved: {:?}",
+        summary.metadata["when"]
+    );
+
+    let actual = summary.to_string().expect("summary serialized");
+    assert_eq!(
+        actual,
+        "[metadata]\nwhen = 1979-05-27T07:32:00Z\nname = 'n'\n\n[metadata.nested]\nx = 1\n\n\
+         [[metadata.items]]\nx = 2\n"
+    );
+    assert_eq!(
+        Summary::parse(&actual).expect("reparsed"),
+        summary,
+        "round trip"
+    );
 }

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -3,6 +3,12 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- With the `summaries` feature, `toml` is updated to 1.1.4. `Error::TomlSerializeError`
+  now wraps `toml` 1.x's `ser::Error`, a breaking change for code that names that type.
+  Summary parsing follows the TOML 1.1 specification strictly.
+
 ## [0.17.26] - 2026-05-21
 
 ### Fixed

--- a/guppy/Cargo.toml
+++ b/guppy/Cargo.toml
@@ -60,7 +60,7 @@ serde_json = "1.0.145"
 smallvec = "1.15.1"
 static_assertions = "1.1.0"
 target-spec = { version = "3.6.0", path = "../target-spec" }
-toml = { version = "0.5.11", optional = true, features = ["preserve_order"] }
+toml = { version = "1.1.4", optional = true, features = ["preserve_order"] }
 
 [dev-dependencies]
 fixtures = { path = "../fixtures" }

--- a/guppy/src/graph/summaries/package_set.rs
+++ b/guppy/src/graph/summaries/package_set.rs
@@ -920,11 +920,11 @@ mod tests {
             (
                 r#"
                 workspace-members = [ { name = "s" } ]"#,
-                "expected a string for key `workspace-members`",
+                "expected a string",
             ),
             (
                 r#"third-party = [ { git = "git-repo" } ]"#,
-                "missing field `name` for key `third-party`",
+                "missing field `name`",
             ),
             (
                 r#"

--- a/internal-tools/fixture-manager/src/context.rs
+++ b/internal-tools/fixture-manager/src/context.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use camino::{Utf8Path, Utf8PathBuf};
 use fixtures::json::JsonFixture;
 
@@ -19,7 +19,11 @@ pub trait ContextImpl<'g> {
     ) -> Box<dyn Iterator<Item = Self::IterItem> + 'g>;
 
     fn parse_existing(path: &Utf8Path, contents: String) -> Result<Self::Existing>;
-    fn is_changed(item: &Self::IterItem, existing: &Self::Existing) -> bool;
+    fn is_changed(
+        fixture: &'g JsonFixture,
+        item: &Self::IterItem,
+        existing: &Self::Existing,
+    ) -> Result<bool>;
     fn diff(
         fixture: &'g JsonFixture,
         item: &Self::IterItem,
@@ -105,12 +109,13 @@ impl<'g, T: ContextImpl<'g>> ContextItem<'g, T> {
         &self.path
     }
 
-    pub fn is_changed(&self) -> bool {
+    pub fn is_changed(&self) -> Result<bool> {
         match &self.existing {
-            Some(existing) => T::is_changed(&self.item, existing),
+            Some(existing) => T::is_changed(self.fixture, &self.item, existing)
+                .with_context(|| format!("error while checking {} for changes", self.path)),
             None => {
                 // File doesn't exist: treat as changed.
-                true
+                Ok(true)
             }
         }
     }

--- a/internal-tools/fixture-manager/src/hakari_toml.rs
+++ b/internal-tools/fixture-manager/src/hakari_toml.rs
@@ -73,8 +73,12 @@ impl<'g> ContextImpl<'g> for HakariTomlContext {
         Ok(HakariCargoToml::new_in_memory(path, contents)?)
     }
 
-    fn is_changed((_, item): &Self::IterItem, existing: &Self::Existing) -> bool {
-        existing.is_changed(&item.toml)
+    fn is_changed(
+        _fixture: &'g JsonFixture,
+        (_, item): &Self::IterItem,
+        existing: &Self::Existing,
+    ) -> Result<bool> {
+        Ok(existing.is_changed(&item.toml))
     }
 
     fn diff(

--- a/internal-tools/fixture-manager/src/lib.rs
+++ b/internal-tools/fixture-manager/src/lib.rs
@@ -158,7 +158,7 @@ impl GenerateOpts {
                 GenerateContext::new(fixture, &args, self.mode == GenerateMode::Force)?;
             for item in context {
                 let item = item?;
-                let is_changed = item.is_changed();
+                let is_changed = item.is_changed()?;
 
                 if is_changed {
                     num_changed += 1;

--- a/internal-tools/fixture-manager/src/summaries.rs
+++ b/internal-tools/fixture-manager/src/summaries.rs
@@ -10,16 +10,22 @@ use guppy::graph::{
     summaries::{Summary, diff::SummaryDiff},
 };
 use guppy_cmdlib::PackagesAndFeatures;
+use hakari::diffy::{PatchFormatter, create_patch};
 use once_cell::sync::Lazy;
 use proptest_ext::ValueGenerator;
 use std::fmt::Write;
 
 pub struct SummaryContext;
 
+pub struct ExistingSummary {
+    summary: Summary,
+    contents: String,
+}
+
 impl<'g> ContextImpl<'g> for SummaryContext {
     type IterArgs = usize;
     type IterItem = (usize, Summary);
-    type Existing = Summary;
+    type Existing = ExistingSummary;
 
     fn dir_name(fixture: &'g JsonFixture) -> Utf8PathBuf {
         fixture
@@ -76,29 +82,47 @@ impl<'g> ContextImpl<'g> for SummaryContext {
     }
 
     fn parse_existing(_: &Utf8Path, contents: String) -> Result<Self::Existing> {
-        Ok(Summary::parse(&contents)?)
+        let summary = Summary::parse(&contents)?;
+        Ok(ExistingSummary { summary, contents })
     }
 
-    fn is_changed((_, summary): &Self::IterItem, existing: &Self::Existing) -> bool {
-        let diff = SummaryDiff::new(existing, summary);
-        diff.is_changed() || existing.metadata != summary.metadata
+    fn is_changed(
+        fixture: &'g JsonFixture,
+        item: &Self::IterItem,
+        existing: &Self::Existing,
+    ) -> Result<bool> {
+        let mut rendered = String::new();
+        Self::write_to_string(fixture, item, &mut rendered)?;
+        Ok(existing.contents != rendered)
     }
 
     fn diff(
-        _fixture: &'g JsonFixture,
-        (_, summary): &Self::IterItem,
+        fixture: &'g JsonFixture,
+        item @ (_, summary): &Self::IterItem,
         existing: Option<&Self::Existing>,
     ) -> String {
         // Need to make this a static to allow lifetimes to work out.
         static EMPTY_SUMMARY: Lazy<Summary> = Lazy::new(Summary::default);
 
-        let existing = match existing {
-            Some(summary) => summary,
+        let existing_summary = match existing {
+            Some(existing) => &existing.summary,
             None => &*EMPTY_SUMMARY,
         };
 
-        let diff = SummaryDiff::new(existing, summary);
-        format!("{}", diff.report())
+        let diff = SummaryDiff::new(existing_summary, summary);
+        if diff.is_changed() {
+            return format!("{}", diff.report());
+        }
+
+        let existing_contents = existing.map_or("", |existing| existing.contents.as_str());
+        let mut rendered = String::new();
+        match Self::write_to_string(fixture, item, &mut rendered) {
+            Ok(()) => {
+                let patch = create_patch(existing_contents, &rendered);
+                format!("{}", PatchFormatter::new().fmt_patch(&patch))
+            }
+            Err(err) => format!("error while rendering summary: {err}"),
+        }
     }
 
     fn write_to_string(

--- a/internal-tools/fixture-manager/tests/unchanged_tests.rs
+++ b/internal-tools/fixture-manager/tests/unchanged_tests.rs
@@ -24,7 +24,7 @@ fn summaries_unchanged() -> Result<()> {
 
         for item in context {
             let item = item?;
-            let is_changed = item.is_changed();
+            let is_changed = item.is_changed()?;
             if is_changed {
                 num_changed += 1;
                 println!("** {}:\n{}", item.path(), item.diff());
@@ -55,7 +55,7 @@ fn hakari_unchanged() -> Result<()> {
 
         for item in context {
             let item = item?;
-            let is_changed = item.is_changed();
+            let is_changed = item.is_changed()?;
             if is_changed {
                 num_changed += 1;
                 println!("** (fixture {}) {}:\n{}", name, item.path(), item.diff());

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -39,6 +39,7 @@ regex-syntax = { version = "0.8.5" }
 serde = { version = "1.0.228", features = ["alloc", "derive"] }
 serde_core = { version = "1.0.228", features = ["alloc"] }
 serde_json = { version = "1.0.150", features = ["unbounded_depth"] }
+toml = { version = "1.1.4", features = ["preserve_order"] }
 
 [build-dependencies]
 proc-macro2 = { version = "1.0.101" }


### PR DESCRIPTION
Needing output to be byte-identical was a blocker for updating toml. Claude to the rescue -- I had it write a custom serializer, as well as differential proptests comparing the toml 0.5 and the new serializer (not included in this commit).

This is a breaking change and will need guppy-summaries 0.8.0, guppy 0.18.0, etc.