### PR TITLE
[guppy] rename PackageResolver/FeatureResolver to PackageLinkVisitor/FeatureLinkVisitor

### DIFF
--- a/guppy/examples/cargo_set_link_filter.rs
+++ b/guppy/examples/cargo_set_link_filter.rs
@@ -5,29 +5,29 @@
 //!
 //! 1) any/all platforms (using default `CargoOptions` and `CargoSet::new`)
 //! 2) a single platform (using `CargoOptions::set_target_platform`)
-//! 3) a set of platforms (using `CargoSet::with_resolver`)
+//! 3) a set of platforms (using `CargoSet::with_cargo_link_visitor`)
 //!
-//! The last example uses `PackageResolver` as a filter - this is a very
+//! The last example uses `PackageLinkVisitor` as a filter - this is a very
 //! generic mechanism and can be used to not only filter by platforms,
 //! but also implement a variety of other filtering options.  For example,
 //! `CargoOptions::add_omitted_packages` could also be implemented using
-//! `CargoSet::with_resolver` and an appropriate `PackageResolver`.
+//! `CargoSet::with_cargo_link_visitor` and an appropriate `PackageLinkVisitor`.
 
 use guppy::{
     CargoMetadata, Error,
     graph::{
-        DependencyDirection, DependencyReq, PackageLink, PackageQuery, PackageResolver,
+        DependencyDirection, DependencyReq, PackageLink, PackageLinkVisitor, PackageQuery,
         cargo::{CargoOptions, CargoSet},
         feature::StandardFeatures,
     },
     platform::{EnabledTernary, PlatformSpec, PlatformStatus, Triple},
 };
 
-/// Custom `guppy::graph::PackageResolver` that will only accept `PackageLink`s
+/// Custom `guppy::graph::PackageLinkVisitor` that will only accept `PackageLink`s
 /// that are enabled on at least one from the given set of platforms.
-struct PackageResolverForPlatformSet(Vec<PlatformSpec>);
+struct PlatformSetLinkVisitor(Vec<PlatformSpec>);
 
-impl PackageResolverForPlatformSet {
+impl PlatformSetLinkVisitor {
     fn new(platform_set: Vec<PlatformSpec>) -> Self {
         Self(platform_set)
     }
@@ -46,8 +46,8 @@ impl PackageResolverForPlatformSet {
     }
 }
 
-impl<'g> PackageResolver<'g> for PackageResolverForPlatformSet {
-    fn accept(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+impl<'g> PackageLinkVisitor<'g> for PlatformSetLinkVisitor {
+    fn visit_link(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
         self.should_include_dependency_req(link.normal())
             || self.should_include_dependency_req(link.build())
     }
@@ -168,13 +168,17 @@ fn main() -> Result<(), Error> {
     );
 
     // Finally, get a set of packages for a set of target platforms
-    // (by passing a custom resolver to `CargoSet::with_resolver`).
+    // (by passing a custom visitor to `CargoSet::with_cargo_link_visitor`).
     let platform_set_package_names = {
         let cargo_options = CargoOptions::new();
-        let resolver =
-            PackageResolverForPlatformSet::new(vec![win32_platform_spec(), win64_platform_spec()]);
-        let cargo_set =
-            CargoSet::with_package_resolver(initials, no_extra_features, resolver, &cargo_options)?;
+        let visitor =
+            PlatformSetLinkVisitor::new(vec![win32_platform_spec(), win64_platform_spec()]);
+        let cargo_set = CargoSet::with_cargo_link_visitor(
+            initials,
+            no_extra_features,
+            visitor,
+            &cargo_options,
+        )?;
         cargo_set_to_package_names(cargo_set)
     };
     assert_eq!(

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Error> {
         .count();
     println!("number of packages before: {before_count}");
 
-    let resolver_fn = |link: PackageLink<'_>| {
+    let visitor_fn = |link: PackageLink<'_>| {
         if link.dev_only() {
             println!(
                 "*** filtering out dev-only link: {} -> {}",
@@ -53,12 +53,12 @@ fn main() -> Result<(), Error> {
     let resolve_with_len = query
         .clone()
         .resolve_with_fn(|_query, link| {
-            // A package resolver allows for fine-grained control over which links are followed. In general,
-            // it is anything that implements the `PackageResolver` trait.
+            // A package link visitor allows for fine-grained control over which links are followed. In general,
+            // it is anything that implements the `PackageLinkVisitor` trait.
             //
             // Functions with signature FnMut(&PackageQuery<'_>, PackageLink<'_>) -> bool can be
             // used with `resolve_with_fn`.
-            resolver_fn(link)
+            visitor_fn(link)
         })
         .package_ids(DependencyDirection::Forward)
         .len();

--- a/guppy/src/graph/cargo/build.rs
+++ b/guppy/src/graph/cargo/build.rs
@@ -4,7 +4,7 @@
 use crate::{
     DependencyKind, Error,
     graph::{
-        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageResolver, PackageSet,
+        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkVisitor, PackageSet,
         cargo::{
             CargoIntermediateSet, CargoOptions, CargoResolverVersion, CargoSet, InitialsPlatform,
         },
@@ -39,17 +39,17 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        resolver: Option<&mut dyn PackageResolver<'g>>,
+        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
     ) -> CargoSet<'g> {
         match self.opts.resolver {
-            CargoResolverVersion::V1 => self.new_v1(initials, features_only, resolver, false),
+            CargoResolverVersion::V1 => self.new_v1(initials, features_only, visitor, false),
             CargoResolverVersion::V1Install => {
                 let avoid_dev_deps = !self.opts.include_dev;
-                self.new_v1(initials, features_only, resolver, avoid_dev_deps)
+                self.new_v1(initials, features_only, visitor, avoid_dev_deps)
             }
             // V2 and V3 do the same feature resolution.
             CargoResolverVersion::V2 | CargoResolverVersion::V3 => {
-                self.new_v2(initials, features_only, resolver)
+                self.new_v2(initials, features_only, visitor)
             }
         }
     }
@@ -69,10 +69,10 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        resolver: Option<&mut dyn PackageResolver<'g>>,
+        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
         avoid_dev_deps: bool,
     ) -> CargoSet<'g> {
-        self.build_set(initials, features_only, resolver, |query| {
+        self.build_set(initials, features_only, visitor, |query| {
             self.new_v1_intermediate(query, avoid_dev_deps)
         })
     }
@@ -81,9 +81,9 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        resolver: Option<&mut dyn PackageResolver<'g>>,
+        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
     ) -> CargoSet<'g> {
-        self.build_set(initials, features_only, resolver, |query| {
+        self.build_set(initials, features_only, visitor, |query| {
             self.new_v2_intermediate(query)
         })
     }
@@ -100,7 +100,7 @@ impl<'a> CargoSetBuildState<'a> {
         &self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        mut resolver: Option<&mut dyn PackageResolver<'g>>,
+        mut visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
         intermediate_fn: impl FnOnce(FeatureQuery<'g>) -> CargoIntermediateSet<'g>,
     ) -> CargoSet<'g> {
         // Prepare a package query for step 2.
@@ -216,9 +216,9 @@ impl<'a> CargoSetBuildState<'a> {
                 return false;
             }
 
-            let accepted = resolver
+            let accepted = visitor
                 .as_mut()
-                .map(|r| r.accept(query, link))
+                .map(|r| r.visit_link(query, link))
                 .unwrap_or(true);
             if !accepted {
                 return false;
@@ -287,9 +287,9 @@ impl<'a> CargoSetBuildState<'a> {
                     return false;
                 }
 
-                let accepted = resolver
+                let accepted = visitor
                     .as_mut()
-                    .map(|r| r.accept(query, link))
+                    .map(|r| r.visit_link(query, link))
                     .unwrap_or(true);
                 if !accepted {
                     return false;

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -4,7 +4,7 @@
 use crate::{
     Error, PackageId,
     graph::{
-        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageResolver, PackageSet,
+        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkVisitor, PackageSet,
         cargo::build::CargoSetBuildState,
         feature::{FeatureGraph, FeatureSet},
     },
@@ -260,34 +260,35 @@ impl<'g> CargoSet<'g> {
         Self::new_internal(initials, features_only, None, opts)
     }
 
-    /// Like `Cargo.new`, but takes an additional [`PackageResolver`] which can
+    /// Like `Cargo.new`, but takes an additional [`PackageLinkVisitor`] which can
     /// be used to filter out some dependency edges, or to collect additional
     /// information.
     ///
-    /// [`resolver.accept`] is called for both target and host dependencies. It
+    /// [`visitor.visit_link`] is called for both target and host dependencies. It
     /// is called after static filtering through
     /// [`CargoOptions::add_omitted_packages`], but before any other decisions
     /// are made.
     ///
-    /// [`resolver.accept`]: PackageResolver::accept
-    pub fn with_package_resolver(
+    /// [`visitor.visit_link`]: PackageLinkVisitor::visit_link
+    pub fn with_cargo_link_visitor(
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        mut resolver: impl PackageResolver<'g>,
+        mut visitor: impl PackageLinkVisitor<'g>,
         opts: &CargoOptions<'_>,
     ) -> Result<Self, Error> {
-        Self::new_internal(initials, features_only, Some(&mut resolver), opts)
+        Self::new_internal(initials, features_only, Some(&mut visitor), opts)
     }
 
-    /// Internal helper to deduplicate code across `CargoSet::new` and `CargoSet::with_resolver`.
+    /// Internal helper to deduplicate code across `CargoSet::new` and
+    /// `CargoSet::with_cargo_link_visitor`.
     fn new_internal(
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        resolver: Option<&mut dyn PackageResolver<'g>>,
+        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
         opts: &CargoOptions<'_>,
     ) -> Result<Self, Error> {
         let build_state = CargoSetBuildState::new(initials.graph().package_graph, opts)?;
-        Ok(build_state.build(initials, features_only, resolver))
+        Ok(build_state.build(initials, features_only, visitor))
     }
 
     /// Creates a new `CargoIntermediateSet` based on the given query and options.

--- a/guppy/src/graph/feature/query.rs
+++ b/guppy/src/graph/feature/query.rs
@@ -312,19 +312,19 @@ impl<'g> FeatureQuery<'g> {
         FeatureSet::new(self)
     }
 
-    /// Resolves this query into a set of known feature IDs, using the provided resolver to
+    /// Resolves this query into a set of known feature IDs, using the provided visitor to
     /// determine which links are followed.
-    pub fn resolve_with(self, resolver: impl FeatureResolver<'g>) -> FeatureSet<'g> {
-        FeatureSet::with_resolver(self, resolver)
+    pub fn resolve_with(self, visitor: impl FeatureLinkVisitor<'g>) -> FeatureSet<'g> {
+        FeatureSet::with_link_visitor(self, visitor)
     }
 
-    /// Resolves this query into a set of known feature IDs, using the provided resolver function to
+    /// Resolves this query into a set of known feature IDs, using the provided visitor function to
     /// determine which links are followed.
     pub fn resolve_with_fn(
         self,
-        resolver_fn: impl FnMut(&FeatureQuery<'g>, ConditionalLink<'g>) -> bool,
+        visitor_fn: impl FnMut(&FeatureQuery<'g>, ConditionalLink<'g>) -> bool,
     ) -> FeatureSet<'g> {
-        self.resolve_with(ResolverFn(resolver_fn))
+        self.resolve_with(LinkVisitorFn(visitor_fn))
     }
 
     // ---
@@ -343,40 +343,40 @@ impl<'g> FeatureQuery<'g> {
 
 /// Represents whether a particular link within a feature graph should be followed during a
 /// resolve operation.
-pub trait FeatureResolver<'g> {
+pub trait FeatureLinkVisitor<'g> {
     /// Returns true if this conditional link should be followed during a resolve operation.
-    fn accept(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool;
+    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool;
 }
 
-impl<'g, T> FeatureResolver<'g> for &mut T
+impl<'g, T> FeatureLinkVisitor<'g> for &mut T
 where
-    T: FeatureResolver<'g>,
+    T: FeatureLinkVisitor<'g>,
 {
-    fn accept(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).accept(query, link)
+    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
-impl<'g> FeatureResolver<'g> for Box<dyn FeatureResolver<'g> + '_> {
-    fn accept(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).accept(query, link)
+impl<'g> FeatureLinkVisitor<'g> for Box<dyn FeatureLinkVisitor<'g> + '_> {
+    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
-impl<'g> FeatureResolver<'g> for &mut dyn FeatureResolver<'g> {
-    fn accept(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).accept(query, link)
+impl<'g> FeatureLinkVisitor<'g> for &mut dyn FeatureLinkVisitor<'g> {
+    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
 #[derive(Clone, Debug)]
-struct ResolverFn<F>(pub F);
+struct LinkVisitorFn<F>(pub F);
 
-impl<'g, F> FeatureResolver<'g> for ResolverFn<F>
+impl<'g, F> FeatureLinkVisitor<'g> for LinkVisitorFn<F>
 where
     F: FnMut(&FeatureQuery<'g>, ConditionalLink<'g>) -> bool,
 {
-    fn accept(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
+    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
         (self.0)(query, link)
     }
 }

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -10,8 +10,8 @@ use crate::{
         DependencyDirection, FeatureGraphSpec, FeatureIx, PackageIx, PackageMetadata, PackageSet,
         cargo::{CargoOptions, CargoSet},
         feature::{
-            ConditionalLink, FeatureEdge, FeatureGraph, FeatureId, FeatureList, FeatureMetadata,
-            FeatureQuery, FeatureResolver, build::FeatureEdgeReference,
+            ConditionalLink, FeatureEdge, FeatureGraph, FeatureId, FeatureLinkVisitor, FeatureList,
+            FeatureMetadata, FeatureQuery, build::FeatureEdgeReference,
         },
         resolve_core::ResolveCore,
     },
@@ -89,9 +89,9 @@ impl<'g> FeatureSet<'g> {
         }
     }
 
-    pub(super) fn with_resolver(
+    pub(super) fn with_link_visitor(
         query: FeatureQuery<'g>,
-        mut resolver: impl FeatureResolver<'g>,
+        mut visitor: impl FeatureLinkVisitor<'g>,
     ) -> Self {
         let graph = query.graph;
         let params = query.params.clone();
@@ -100,7 +100,7 @@ impl<'g> FeatureSet<'g> {
         let mut buffer_states = graph
             .inner
             .weak
-            .new_buffer_states(|link| resolver.accept(&query, link));
+            .new_buffer_states(|link| visitor.visit_link(&query, link));
 
         let filter_fn = |edge_ref: FeatureEdgeReference<'g>| {
             match graph.edge_to_conditional_link(

--- a/guppy/src/graph/proptest_helpers.rs
+++ b/guppy/src/graph/proptest_helpers.rs
@@ -4,7 +4,7 @@
 use crate::{
     PackageId,
     graph::{
-        PackageGraph, PackageLink, PackageQuery, PackageResolver, Workspace,
+        PackageGraph, PackageLink, PackageLinkVisitor, PackageQuery, Workspace,
         cargo::{CargoOptions, CargoResolverVersion, InitialsPlatform},
     },
     platform::PlatformSpec,
@@ -57,12 +57,14 @@ impl PackageGraph {
         })
     }
 
-    /// Returns a `Strategy` that generates a random `PackageResolver` instance from this graph.
+    /// Returns a `Strategy` that generates a random `PackageLinkVisitor` instance from this graph.
     ///
     /// Requires the `proptest1` feature to be enabled.
-    pub fn proptest1_resolver_strategy(&self) -> impl Strategy<Value = Prop010Resolver> + use<> {
+    pub fn proptest1_link_visitor_strategy(
+        &self,
+    ) -> impl Strategy<Value = Prop010LinkVisitor> + use<> {
         // Generate a FixedBitSet to filter based off of.
-        fixedbitset_strategy(self.dep_graph.edge_count()).prop_map(Prop010Resolver::new)
+        fixedbitset_strategy(self.dep_graph.edge_count()).prop_map(Prop010LinkVisitor::new)
     }
 
     /// Returns a `Strategy` that generates a random `CargoOptions` from this graph.
@@ -141,17 +143,17 @@ impl<'g> Workspace<'g> {
     }
 }
 
-/// A randomly generated package resolver.
+/// A randomly generated package link visitor.
 ///
-/// Created by `PackageGraph::proptest1_resolver_strategy`. Requires the `proptest1` feature to be
+/// Created by `PackageGraph::proptest1_link_visitor_strategy`. Requires the `proptest1` feature to be
 /// enabled.
 #[derive(Clone, Debug)]
-pub struct Prop010Resolver {
+pub struct Prop010LinkVisitor {
     included_edges: FixedBitSet,
     check_depends_on: bool,
 }
 
-impl Prop010Resolver {
+impl Prop010LinkVisitor {
     fn new(included_edges: FixedBitSet) -> Self {
         Self {
             included_edges,
@@ -159,20 +161,20 @@ impl Prop010Resolver {
         }
     }
 
-    /// If called with true, this resolver will then verify that any links passed in are in the
+    /// If called with true, this visitor will then verify that any links passed in are in the
     /// correct direction.
     pub fn check_depends_on(&mut self, check: bool) {
         self.check_depends_on = check;
     }
 
-    /// Returns true if the given link is accepted by this resolver.
+    /// Returns true if the given link is accepted by this visitor.
     pub fn accept_link(&self, link: PackageLink<'_>) -> bool {
         self.included_edges.is_visited(&link.edge_ix().index())
     }
 }
 
-impl<'g> PackageResolver<'g> for Prop010Resolver {
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+impl<'g> PackageLinkVisitor<'g> for Prop010LinkVisitor {
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
         if self.check_depends_on {
             assert!(
                 query

--- a/guppy/src/graph/query.rs
+++ b/guppy/src/graph/query.rs
@@ -4,8 +4,8 @@
 use crate::{
     Error, PackageId,
     graph::{
-        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageMetadata,
-        PackageResolver, PackageSet, ResolverFn,
+        DependencyDirection, LinkVisitorFn, PackageGraph, PackageIx, PackageLink,
+        PackageLinkVisitor, PackageMetadata, PackageSet,
         feature::{FeatureFilter, FeatureQuery},
         query_core::QueryParams,
     },
@@ -189,18 +189,18 @@ impl<'g> PackageQuery<'g> {
         PackageSet::new(self)
     }
 
-    /// Resolves this query into a set of known packages, using the provided resolver to
+    /// Resolves this query into a set of known packages, using the provided visitor to
     /// determine which links are followed.
-    pub fn resolve_with(self, resolver: impl PackageResolver<'g>) -> PackageSet<'g> {
-        PackageSet::with_resolver(self, resolver)
+    pub fn resolve_with(self, visitor: impl PackageLinkVisitor<'g>) -> PackageSet<'g> {
+        PackageSet::with_link_visitor(self, visitor)
     }
 
-    /// Resolves this query into a set of known packages, using the provided resolver function
+    /// Resolves this query into a set of known packages, using the provided visitor function
     /// to determine which links are followed.
     pub fn resolve_with_fn(
         self,
-        resolver_fn: impl FnMut(&PackageQuery<'g>, PackageLink<'g>) -> bool,
+        visitor_fn: impl FnMut(&PackageQuery<'g>, PackageLink<'g>) -> bool,
     ) -> PackageSet<'g> {
-        self.resolve_with(ResolverFn(resolver_fn))
+        self.resolve_with(LinkVisitorFn(visitor_fn))
     }
 }

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -177,9 +177,9 @@ impl<'g> PackageSet<'g> {
         }
     }
 
-    pub(super) fn with_resolver(
+    pub(super) fn with_link_visitor(
         query: PackageQuery<'g>,
-        mut resolver: impl PackageResolver<'g>,
+        mut visitor: impl PackageLinkVisitor<'g>,
     ) -> Self {
         let graph = query.graph;
         let params = query.params.clone();
@@ -187,7 +187,7 @@ impl<'g> PackageSet<'g> {
             graph: DebugIgnore(graph),
             core: ResolveCore::with_edge_filter(graph.dep_graph(), params, |edge| {
                 let link = graph.edge_ref_to_link(edge);
-                resolver.accept(&query, link)
+                visitor.visit_link(&query, link)
             }),
         }
     }
@@ -553,42 +553,42 @@ impl Eq for PackageSet<'_> {}
 
 /// Represents whether a particular link within a package graph should be followed during a
 /// resolve operation.
-pub trait PackageResolver<'g> {
+pub trait PackageLinkVisitor<'g> {
     /// Returns true if this link should be followed during a resolve operation.
     ///
     /// Returning false does not prevent the `to` package (or `from` package with `query_reverse`)
     /// from being included if it's reachable through other means.
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool;
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool;
 }
 
-impl<'g, T> PackageResolver<'g> for &mut T
+impl<'g, T> PackageLinkVisitor<'g> for &mut T
 where
-    T: PackageResolver<'g>,
+    T: PackageLinkVisitor<'g>,
 {
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).accept(query, link)
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
-impl<'g> PackageResolver<'g> for Box<dyn PackageResolver<'g> + '_> {
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).accept(query, link)
+impl<'g> PackageLinkVisitor<'g> for Box<dyn PackageLinkVisitor<'g> + '_> {
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
-impl<'g> PackageResolver<'g> for &mut dyn PackageResolver<'g> {
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).accept(query, link)
+impl<'g> PackageLinkVisitor<'g> for &mut dyn PackageLinkVisitor<'g> {
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(query, link)
     }
 }
 
-pub(super) struct ResolverFn<F>(pub(super) F);
+pub(super) struct LinkVisitorFn<F>(pub(super) F);
 
-impl<'g, F> PackageResolver<'g> for ResolverFn<F>
+impl<'g, F> PackageLinkVisitor<'g> for LinkVisitorFn<F>
 where
     F: FnMut(&PackageQuery<'g>, PackageLink<'g>) -> bool,
 {
-    fn accept(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
         (self.0)(query, link)
     }
 }

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -3,23 +3,23 @@
 
 use fixtures::json::JsonFixture;
 use guppy::graph::{
-    DependencyDirection, PackageLink, PackageQuery, PackageResolver,
+    DependencyDirection, PackageLink, PackageLinkVisitor, PackageQuery,
     cargo::{CargoOptions, CargoSet},
     feature::StandardFeatures,
 };
 use std::collections::HashSet;
 
-struct PackageResolverForTesting<'a, 'g> {
+struct PackageLinkVisitorForTesting<'a, 'g> {
     /// Optional filter of `link`s.  If `None`, then all links are accepted.
     link_filter: Option<&'a dyn Fn(PackageLink<'g>) -> bool>,
 
-    /// The `trace` field stores `link`s that were passed to `fn accept`.
+    /// The `trace` field stores `link`s that were passed to `fn visit_link`.
     /// The links are formatted as `"foo@1.2.3 => bar@4.5.6"`.
-    /// The links are stored in the order of `fn accept` calls.
+    /// The links are stored in the order of `fn visit_link` calls.
     trace: Vec<String>,
 }
 
-impl<'a, 'g> PackageResolverForTesting<'a, 'g> {
+impl<'a, 'g> PackageLinkVisitorForTesting<'a, 'g> {
     fn new() -> Self {
         Self {
             link_filter: None,
@@ -54,17 +54,17 @@ fn links_to_strings<'g>(links: impl IntoIterator<Item = PackageLink<'g>>) -> Vec
     result
 }
 
-impl<'g> PackageResolver<'g> for PackageResolverForTesting<'_, 'g> {
-    fn accept(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+impl<'g> PackageLinkVisitor<'g> for PackageLinkVisitorForTesting<'_, 'g> {
+    fn visit_link(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
         self.trace.push(link_to_string(&link));
         self.link_filter.map(|f| f(link)).unwrap_or(true)
     }
 }
 
-fn cargo_set_with_resolver<'g>(
+fn cargo_set_with_visitor<'g>(
     test_fixture: &'g JsonFixture,
     root_package_name: &str,
-    resolver: &mut dyn PackageResolver<'g>,
+    visitor: &mut dyn PackageLinkVisitor<'g>,
 ) -> CargoSet<'g> {
     let package_graph = test_fixture.graph();
 
@@ -76,7 +76,7 @@ fn cargo_set_with_resolver<'g>(
         .to_feature_set(StandardFeatures::Default);
 
     let cargo_options = CargoOptions::new();
-    CargoSet::with_package_resolver(initials, no_extra_features, resolver, &cargo_options).unwrap()
+    CargoSet::with_cargo_link_visitor(initials, no_extra_features, visitor, &cargo_options).unwrap()
 }
 
 fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {
@@ -91,9 +91,9 @@ fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {
 }
 
 #[test]
-fn test_package_resolver_visits() {
-    let mut resolver = PackageResolverForTesting::new();
-    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+fn test_package_link_visitor_visits() {
+    let mut visitor = PackageLinkVisitorForTesting::new();
+    let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
     assert_eq!(
         cargo_set_package_names(&cargo_set),
         vec![
@@ -130,7 +130,7 @@ fn test_package_resolver_visits() {
         ],
     );
     assert_eq!(
-        resolver.trace,
+        visitor.trace,
         vec![
             "testcrate@0.1.0 => datatest@0.4.2",
             "datatest@0.4.2 => yaml-rust@0.4.3",
@@ -179,12 +179,12 @@ fn test_package_resolver_visits() {
     );
 
     // In this test input none of the links are trimmed by cargo algorithm.
-    let count_of_links_visited_by_resolver = resolver.trace.len();
+    let count_of_links_visited_by_visitor = visitor.trace.len();
     let count_of_cargo_set_links = cargo_set.proc_macro_links().count()
         + cargo_set.build_dep_links().count()
         + cargo_set.target_links().count()
         + cargo_set.host_links().count();
-    assert_eq!(count_of_links_visited_by_resolver, count_of_cargo_set_links);
+    assert_eq!(count_of_links_visited_by_visitor, count_of_cargo_set_links);
 
     assert_eq!(
         links_to_strings(cargo_set.proc_macro_links()),
@@ -250,32 +250,32 @@ fn test_package_resolver_visits() {
 }
 
 #[test]
-fn test_package_resolver_filtering_normal_links_on_target() {
-    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+fn test_package_link_visitor_filtering_normal_links_on_target() {
+    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
         // Remove `winapi` and `winapu-util` links.  This should transitively remove `winapi =>
         // winapi-x86_64-pc-windows-gnu` and `winapi => winapi-i686-pc-windows-gnu`.
         //
-        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // This filter is meant to test whether `CargoSet` algotithm consults the `visitor`
         // in all required cases.  The filter may or may not make sense in practice (here we
         // can pretend that we are filtering all packages that are only needed on Windows).
         !link.to().name().starts_with("winapi")
     });
-    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+    let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
 
-    // No `winapi...` packages (unlike in `test_package_resolver_visits`).
+    // No `winapi...` packages (unlike in `test_package_link_visitor_visits`).
     let package_names = cargo_set_package_names(&cargo_set)
         .into_iter()
         .collect::<HashSet<_>>();
     assert!(!package_names.contains("winapi"));
     assert!(!package_names.contains("winapi-util"));
 
-    // No `winapi...` => ... links (unlike in `test_package_resolver_visits`).
-    let trace = resolver.trace.into_iter().collect::<HashSet<_>>();
+    // No `winapi...` => ... links (unlike in `test_package_link_visitor_visits`).
+    let trace = visitor.trace.into_iter().collect::<HashSet<_>>();
     assert!(!trace.contains("winapi@0.3.8 => winapi-x86_64-pc-windows-gnu@0.4.0"));
     assert!(!trace.contains("winapi@0.3.8 => winapi-i686-pc-windows-gnu@0.4.0"));
     assert!(!trace.contains("winapi-util@0.1.2 => winapi@0.3.8"));
 
-    // The resolver was asked about these links, but didn't `accept` them.
+    // The visitor was asked about these links, but didn't accept them.
     // Therefore these links should be present in the `trace`, but missing from
     // the final `cargo_set`.
     let cargo_set_links = links_to_strings(cargo_set.target_links())
@@ -290,30 +290,30 @@ fn test_package_resolver_filtering_normal_links_on_target() {
 }
 
 #[test]
-fn test_package_resolver_filtering_build_links_on_target() {
-    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+fn test_package_link_visitor_filtering_build_links_on_target() {
+    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
         // Remove `datatest` => `version_check` build dependency.
         //
-        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // This filter is meant to test whether `CargoSet` algotithm consults the `visitor`
         // in all required cases.  The filter may or may not make sense in practice (here
         // the trimmed down graph would fail to build...).
         link.to().name() != "version_check"
     });
-    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+    let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
 
-    // No `version_check...` packages (unlike in `test_package_resolver_visits`).
+    // No `version_check...` packages (unlike in `test_package_link_visitor_visits`).
     let package_names = cargo_set_package_names(&cargo_set)
         .into_iter()
         .collect::<HashSet<_>>();
     assert!(!package_names.contains("version_check"));
 
     // If `version_check` has transitive dependencies, then we would test here that
-    // they were not visited/consulted by the `resolver`.
+    // they were not visited/consulted by the `visitor`.
 
-    // The resolver was asked about these links, but didn't `accept` them.
+    // The visitor was asked about these links, but didn't accept them.
     // Therefore these links should be present in the `trace`, but missing from
     // the final `cargo_set`.
-    let trace = resolver.trace.into_iter().collect::<HashSet<_>>();
+    let trace = visitor.trace.into_iter().collect::<HashSet<_>>();
     let cargo_set_links = links_to_strings(cargo_set.build_dep_links())
         .into_iter()
         .collect::<HashSet<_>>();
@@ -323,19 +323,19 @@ fn test_package_resolver_filtering_build_links_on_target() {
 }
 
 #[test]
-fn test_package_resolver_filtering_links_on_host() {
-    let mut resolver = PackageResolverForTesting::with_filter(&|link| {
+fn test_package_link_visitor_filtering_links_on_host() {
+    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
         // Remove dependencies of `ctor` and `datatest-derive` packages.  This should transitively
         // remove `proc-macro2`, `quote`, `syn`, and `unicode-xid` packages.
         //
-        // This filter is meant to test whether `CargoSet` algotithm consults the `resolver`
+        // This filter is meant to test whether `CargoSet` algotithm consults the `visitor`
         // in all required cases.  The filter may or may not make sense in practice (here
         // the trimmed down graph would fail to build...).
         link.from().name() != "ctor" && link.from().name() != "datatest-derive"
     });
-    let cargo_set = cargo_set_with_resolver(JsonFixture::metadata1(), "testcrate", &mut resolver);
+    let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
 
-    // No `ctor` not `datatest-derive` dependencies (unlike in `test_package_resolver_visits`).
+    // No `ctor` not `datatest-derive` dependencies (unlike in `test_package_link_visitor_visits`).
     let package_names = cargo_set_package_names(&cargo_set)
         .into_iter()
         .collect::<HashSet<_>>();
@@ -344,17 +344,17 @@ fn test_package_resolver_filtering_links_on_host() {
     assert!(!package_names.contains("syn"));
     assert!(!package_names.contains("unicode-xid"));
 
-    // No `syn` => ... links (unlike in `test_package_resolver_visits`).
-    // No `quote` => ... links (unlike in `test_package_resolver_visits`).
-    // No `proc-macro2` ... => links (unlike in `test_package_resolver_visits`).
-    let trace = resolver.trace.into_iter().collect::<HashSet<_>>();
+    // No `syn` => ... links (unlike in `test_package_link_visitor_visits`).
+    // No `quote` => ... links (unlike in `test_package_link_visitor_visits`).
+    // No `proc-macro2` ... => links (unlike in `test_package_link_visitor_visits`).
+    let trace = visitor.trace.into_iter().collect::<HashSet<_>>();
     assert!(!trace.contains("syn@1.0.5 => unicode-xid@0.2.0"));
     assert!(!trace.contains("syn@1.0.5 => quote@1.0.2"));
     assert!(!trace.contains("syn@1.0.5 => proc-macro2@1.0.3"));
     assert!(!trace.contains("quote@1.0.2 => proc-macro2@1.0.3"));
     assert!(!trace.contains("proc-macro2@1.0.3 => unicode-xid@0.2.0"));
 
-    // The resolver was asked about these links, but didn't `accept` them.
+    // The visitor was asked about these links, but didn't accept them.
     // Therefore these links should be present in the `trace`, but missing from
     // the final `cargo_set`.
     let cargo_set_links = links_to_strings(cargo_set.host_links())

--- a/guppy/tests/graph-tests/proptest_helpers.rs
+++ b/guppy/tests/graph-tests/proptest_helpers.rs
@@ -5,7 +5,7 @@ use fixtures::dep_helpers::{GraphAssert, GraphMetadata, GraphQuery, GraphSet, as
 use guppy::{
     PackageId,
     graph::{
-        DependencyDirection, PackageGraph, Prop010Resolver,
+        DependencyDirection, PackageGraph, Prop010LinkVisitor,
         feature::{FeatureId, FeatureLabel, FeatureSet, StandardFeatures},
     },
 };
@@ -295,16 +295,16 @@ pub(super) fn run_package_feature_set_roundtrip(package_graph: &'static PackageG
     proptest!(|(
         query_ids in vec(package_graph.proptest1_id_strategy(), 1..16),
         query_direction in any::<DependencyDirection>(),
-        mut resolver in package_graph.proptest1_resolver_strategy(),
+        mut visitor in package_graph.proptest1_link_visitor_strategy(),
         test_ids in vec(feature_graph.proptest1_id_strategy(), 1..16),
         test_direction in any::<DependencyDirection>(),
     )| {
-        resolver.check_depends_on(true);
+        visitor.check_depends_on(true);
         package_feature_set_roundtrip(
             package_graph,
             query_ids,
             query_direction,
-            resolver,
+            visitor,
             test_ids,
             test_direction,
         );
@@ -671,14 +671,14 @@ pub(super) fn package_feature_set_roundtrip(
     package_graph: &PackageGraph,
     query_ids: Vec<&PackageId>,
     query_direction: DependencyDirection,
-    mut resolver: Prop010Resolver,
+    mut visitor: Prop010LinkVisitor,
     test_ids: Vec<FeatureId>,
     test_direction: DependencyDirection,
 ) {
     let package_set = package_graph
         .query_directed(query_ids.iter().copied(), query_direction)
         .expect("valid package IDs")
-        .resolve_with(&mut resolver);
+        .resolve_with(&mut visitor);
     let all_feature_set = package_set.to_feature_set(StandardFeatures::All);
     let no_feature_set = package_set.to_feature_set(StandardFeatures::None);
 


### PR DESCRIPTION
"Resolver" is easily confused with the Cargo feature resolver, and the callback visits links, not packages.

No functional changes.

Part of #497.