### PR TITLE
[guppy] pass PackageLinkContext/FeatureLinkContext to link visitors

### DIFF
--- a/cargo-guppy/src/core.rs
+++ b/cargo-guppy/src/core.rs
@@ -7,7 +7,10 @@ use clap::{Parser, ValueEnum};
 use color_eyre::eyre::{Result, WrapErr, ensure, eyre};
 use guppy::{
     PackageId,
-    graph::{DependencyDirection, DependencyReq, PackageGraph, PackageLink, PackageQuery},
+    graph::{
+        DependencyDirection, DependencyReq, PackageGraph, PackageLink, PackageLinkContext,
+        PackageQuery,
+    },
     platform::EnabledTernary,
 };
 use guppy_cmdlib::string_to_platform_spec;
@@ -119,14 +122,14 @@ impl FilterOptions {
     pub fn make_resolver<'g>(
         &'g self,
         pkg_graph: &'g PackageGraph,
-    ) -> Result<impl Fn(&PackageQuery<'g>, PackageLink<'g>) -> bool + 'g> {
+    ) -> Result<impl Fn(&PackageLinkContext<'g>, PackageLink<'g>) -> bool + 'g> {
         let omitted_package_ids: HashSet<_> =
             self.base_opts.omitted_package_ids(pkg_graph).collect();
 
         let platform_spec = string_to_platform_spec(self.target.as_deref())
             .wrap_err_with(|| "target platform isn't known")?;
 
-        let ret = move |_: &PackageQuery<'g>, link| {
+        let ret = move |_: &PackageLinkContext<'g>, link| {
             // filter by the kind of dependency (--kind)
             let include_kind = self.base_opts.kind.should_traverse(&link);
 

--- a/guppy/examples/cargo_set_link_filter.rs
+++ b/guppy/examples/cargo_set_link_filter.rs
@@ -16,7 +16,7 @@
 use guppy::{
     CargoMetadata, Error,
     graph::{
-        DependencyDirection, DependencyReq, PackageLink, PackageLinkVisitor, PackageQuery,
+        DependencyDirection, DependencyReq, PackageLink, PackageLinkContext, PackageLinkVisitor,
         cargo::{CargoOptions, CargoSet},
         feature::StandardFeatures,
     },
@@ -47,7 +47,7 @@ impl PlatformSetLinkVisitor {
 }
 
 impl<'g> PackageLinkVisitor<'g> for PlatformSetLinkVisitor {
-    fn visit_link(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+    fn visit_link(&mut self, _cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
         self.should_include_dependency_req(link.normal())
             || self.should_include_dependency_req(link.build())
     }

--- a/guppy/examples/remove_dev_only.rs
+++ b/guppy/examples/remove_dev_only.rs
@@ -52,11 +52,11 @@ fn main() -> Result<(), Error> {
     // Use `resolve_with` to filter out dev-only links.
     let resolve_with_len = query
         .clone()
-        .resolve_with_fn(|_query, link| {
+        .resolve_with_fn(|_cx, link| {
             // A package link visitor allows for fine-grained control over which links are followed. In general,
             // it is anything that implements the `PackageLinkVisitor` trait.
             //
-            // Functions with signature FnMut(&PackageQuery<'_>, PackageLink<'_>) -> bool can be
+            // Functions with signature FnMut(&PackageLinkContext<'_>, PackageLink<'_>) -> bool can be
             // used with `resolve_with_fn`.
             visitor_fn(link)
         })

--- a/guppy/src/graph/cargo/build.rs
+++ b/guppy/src/graph/cargo/build.rs
@@ -203,7 +203,7 @@ impl<'a> CargoSetBuildState<'a> {
         let target_platform = &self.opts.target_platform;
         let host_platform = &self.opts.host_platform;
 
-        let target_packages = target_query.resolve_with_fn(|query, link| {
+        let target_packages = target_query.resolve_with_fn(|cx, link| {
             let (from, to) = link.endpoints();
 
             if from.in_workspace() {
@@ -218,15 +218,14 @@ impl<'a> CargoSetBuildState<'a> {
 
             let accepted = visitor
                 .as_mut()
-                .map(|r| r.visit_link(query, link))
+                .map(|r| r.visit_link(cx, link))
                 .unwrap_or(true);
             if !accepted {
                 return false;
             }
 
             // Dev-dependencies are only considered if `from` is an initial.
-            let consider_dev =
-                self.opts.include_dev && query.starts_from(from.id()).expect("valid ID");
+            let consider_dev = self.opts.include_dev && cx.starts_from_initial(&link);
             // Build dependencies are only considered if there's a build script.
             let consider_build = from.has_build_script();
 
@@ -280,7 +279,7 @@ impl<'a> CargoSetBuildState<'a> {
         let host_packages = graph
             .package_graph
             .query_from_parts(host_ixs, DependencyDirection::Forward)
-            .resolve_with_fn(|query, link| {
+            .resolve_with_fn(|cx, link| {
                 let (from, to) = link.endpoints();
                 if self.is_omitted(to.package_ix()) {
                     // Pretend that the omitted set doesn't exist.
@@ -289,7 +288,7 @@ impl<'a> CargoSetBuildState<'a> {
 
                 let accepted = visitor
                     .as_mut()
-                    .map(|r| r.visit_link(query, link))
+                    .map(|r| r.visit_link(cx, link))
                     .unwrap_or(true);
                 if !accepted {
                     return false;
@@ -298,8 +297,7 @@ impl<'a> CargoSetBuildState<'a> {
                 // All relevant nodes in host_ixs have already been added to host_direct_deps at [a].
 
                 // Dev-dependencies are only considered if `from` is an initial.
-                let consider_dev =
-                    self.opts.include_dev && query.starts_from(from.id()).expect("valid ID");
+                let consider_dev = self.opts.include_dev && cx.starts_from_initial(&link);
                 let consider_build = from.has_build_script();
 
                 // Only normal and build dependencies are typically considered. Dev-dependencies of
@@ -357,15 +355,11 @@ impl<'a> CargoSetBuildState<'a> {
     ) -> CargoIntermediateSet<'g> {
         // Perform a "complete" feature query. This will provide more packages than will be
         // included in the final build, but for each package it will have the correct feature set.
-        let complete_set = query.resolve_with_fn(|query, link| {
+        let complete_set = query.resolve_with_fn(|cx, link| {
             if self.is_omitted(link.to().package_ix()) {
                 // Pretend that the omitted set doesn't exist.
                 false
-            } else if !avoid_dev_deps
-                && query
-                    .starts_from(link.from().feature_id())
-                    .expect("valid ID")
-            {
+            } else if !avoid_dev_deps && cx.starts_from_initial(&link) {
                 // Follow everything for initials.
                 true
             } else {
@@ -420,7 +414,7 @@ impl<'a> CargoSetBuildState<'a> {
         // 1. Perform a feature query for the target.
         let target_platform = &self.opts.target_platform;
         let host_platform = &self.opts.host_platform;
-        let target = target_query.resolve_with_fn(|query, link| {
+        let target = target_query.resolve_with_fn(|cx, link| {
             let (from, to) = link.endpoints();
 
             if self.is_omitted(to.package_ix()) {
@@ -428,8 +422,7 @@ impl<'a> CargoSetBuildState<'a> {
                 return false;
             }
 
-            let consider_dev =
-                self.opts.include_dev && query.starts_from(from.feature_id()).expect("valid ID");
+            let consider_dev = self.opts.include_dev && cx.starts_from_initial(&link);
             // This resolver doesn't check for whether this package has a build script.
             let mut follow_target = is_enabled(&link, DependencyKind::Normal, target_platform)
                 || (consider_dev

--- a/guppy/src/graph/feature/query.rs
+++ b/guppy/src/graph/feature/query.rs
@@ -322,7 +322,7 @@ impl<'g> FeatureQuery<'g> {
     /// determine which links are followed.
     pub fn resolve_with_fn(
         self,
-        visitor_fn: impl FnMut(&FeatureQuery<'g>, ConditionalLink<'g>) -> bool,
+        visitor_fn: impl FnMut(&FeatureLinkContext<'g>, ConditionalLink<'g>) -> bool,
     ) -> FeatureSet<'g> {
         self.resolve_with(LinkVisitorFn(visitor_fn))
     }
@@ -341,31 +341,64 @@ impl<'g> FeatureQuery<'g> {
     }
 }
 
+/// Context passed to a [`FeatureLinkVisitor`] for each link visited during a
+/// resolve operation.
+#[derive(Clone, Debug)]
+pub struct FeatureLinkContext<'g> {
+    query: FeatureQuery<'g>,
+}
+
+impl<'g> FeatureLinkContext<'g> {
+    pub(super) fn new(query: FeatureQuery<'g>) -> Self {
+        Self { query }
+    }
+
+    /// Returns the query this resolve operation was started from.
+    pub fn query(&self) -> &FeatureQuery<'g> {
+        &self.query
+    }
+
+    /// Returns the direction of the traversal.
+    pub fn direction(&self) -> DependencyDirection {
+        self.query.direction()
+    }
+
+    /// Returns true if the link's starting endpoint (`from` for forward
+    /// queries, `to` for reverse queries) is one of the query's initials.
+    pub fn starts_from_initial(&self, link: &ConditionalLink<'g>) -> bool {
+        let feature_ix = match self.direction() {
+            DependencyDirection::Forward => link.from().feature_ix(),
+            DependencyDirection::Reverse => link.to().feature_ix(),
+        };
+        self.query.params.has_initial(feature_ix)
+    }
+}
+
 /// Represents whether a particular link within a feature graph should be followed during a
 /// resolve operation.
 pub trait FeatureLinkVisitor<'g> {
     /// Returns true if this conditional link should be followed during a resolve operation.
-    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool;
+    fn visit_link(&mut self, cx: &FeatureLinkContext<'g>, link: ConditionalLink<'g>) -> bool;
 }
 
 impl<'g, T> FeatureLinkVisitor<'g> for &mut T
 where
     T: FeatureLinkVisitor<'g>,
 {
-    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &FeatureLinkContext<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
 impl<'g> FeatureLinkVisitor<'g> for Box<dyn FeatureLinkVisitor<'g> + '_> {
-    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &FeatureLinkContext<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
 impl<'g> FeatureLinkVisitor<'g> for &mut dyn FeatureLinkVisitor<'g> {
-    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &FeatureLinkContext<'g>, link: ConditionalLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
@@ -374,9 +407,9 @@ struct LinkVisitorFn<F>(pub F);
 
 impl<'g, F> FeatureLinkVisitor<'g> for LinkVisitorFn<F>
 where
-    F: FnMut(&FeatureQuery<'g>, ConditionalLink<'g>) -> bool,
+    F: FnMut(&FeatureLinkContext<'g>, ConditionalLink<'g>) -> bool,
 {
-    fn visit_link(&mut self, query: &FeatureQuery<'g>, link: ConditionalLink<'g>) -> bool {
-        (self.0)(query, link)
+    fn visit_link(&mut self, cx: &FeatureLinkContext<'g>, link: ConditionalLink<'g>) -> bool {
+        (self.0)(cx, link)
     }
 }

--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -10,8 +10,9 @@ use crate::{
         DependencyDirection, FeatureGraphSpec, FeatureIx, PackageIx, PackageMetadata, PackageSet,
         cargo::{CargoOptions, CargoSet},
         feature::{
-            ConditionalLink, FeatureEdge, FeatureGraph, FeatureId, FeatureLinkVisitor, FeatureList,
-            FeatureMetadata, FeatureQuery, build::FeatureEdgeReference,
+            ConditionalLink, FeatureEdge, FeatureGraph, FeatureId, FeatureLinkContext,
+            FeatureLinkVisitor, FeatureList, FeatureMetadata, FeatureQuery,
+            build::FeatureEdgeReference,
         },
         resolve_core::ResolveCore,
     },
@@ -95,12 +96,13 @@ impl<'g> FeatureSet<'g> {
     ) -> Self {
         let graph = query.graph;
         let params = query.params.clone();
+        let cx = FeatureLinkContext::new(query);
 
         // State used by the callback below.
         let mut buffer_states = graph
             .inner
             .weak
-            .new_buffer_states(|link| visitor.visit_link(&query, link));
+            .new_buffer_states(|link| visitor.visit_link(&cx, link));
 
         let filter_fn = |edge_ref: FeatureEdgeReference<'g>| {
             match graph.edge_to_conditional_link(

--- a/guppy/src/graph/proptest_helpers.rs
+++ b/guppy/src/graph/proptest_helpers.rs
@@ -4,7 +4,7 @@
 use crate::{
     PackageId,
     graph::{
-        PackageGraph, PackageLink, PackageLinkVisitor, PackageQuery, Workspace,
+        PackageGraph, PackageLink, PackageLinkContext, PackageLinkVisitor, Workspace,
         cargo::{CargoOptions, CargoResolverVersion, InitialsPlatform},
     },
     platform::PlatformSpec,
@@ -174,10 +174,10 @@ impl Prop010LinkVisitor {
 }
 
 impl<'g> PackageLinkVisitor<'g> for Prop010LinkVisitor {
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
         if self.check_depends_on {
             assert!(
-                query
+                cx.query()
                     .graph()
                     .depends_on(link.from().id(), link.to().id())
                     .expect("valid package IDs"),

--- a/guppy/src/graph/query.rs
+++ b/guppy/src/graph/query.rs
@@ -5,7 +5,7 @@ use crate::{
     Error, PackageId,
     graph::{
         DependencyDirection, LinkVisitorFn, PackageGraph, PackageIx, PackageLink,
-        PackageLinkVisitor, PackageMetadata, PackageSet,
+        PackageLinkContext, PackageLinkVisitor, PackageMetadata, PackageSet,
         feature::{FeatureFilter, FeatureQuery},
         query_core::QueryParams,
     },
@@ -199,7 +199,7 @@ impl<'g> PackageQuery<'g> {
     /// to determine which links are followed.
     pub fn resolve_with_fn(
         self,
-        visitor_fn: impl FnMut(&PackageQuery<'g>, PackageLink<'g>) -> bool,
+        visitor_fn: impl FnMut(&PackageLinkContext<'g>, PackageLink<'g>) -> bool,
     ) -> PackageSet<'g> {
         self.resolve_with(LinkVisitorFn(visitor_fn))
     }

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -183,11 +183,12 @@ impl<'g> PackageSet<'g> {
     ) -> Self {
         let graph = query.graph;
         let params = query.params.clone();
+        let cx = PackageLinkContext { query };
         Self {
             graph: DebugIgnore(graph),
             core: ResolveCore::with_edge_filter(graph.dep_graph(), params, |edge| {
                 let link = graph.edge_ref_to_link(edge);
-                visitor.visit_link(&query, link)
+                visitor.visit_link(&cx, link)
             }),
         }
     }
@@ -551,6 +552,35 @@ impl PartialEq for PackageSet<'_> {
 
 impl Eq for PackageSet<'_> {}
 
+/// Context passed to a [`PackageLinkVisitor`] for each link visited during a
+/// resolve operation.
+#[derive(Clone, Debug)]
+pub struct PackageLinkContext<'g> {
+    query: PackageQuery<'g>,
+}
+
+impl<'g> PackageLinkContext<'g> {
+    /// Returns the query this resolve operation was started from.
+    pub fn query(&self) -> &PackageQuery<'g> {
+        &self.query
+    }
+
+    /// Returns the direction of the traversal.
+    pub fn direction(&self) -> DependencyDirection {
+        self.query.direction()
+    }
+
+    /// Returns true if the link's starting endpoint (`from` for forward
+    /// queries, `to` for reverse queries) is one of the query's initials.
+    pub fn starts_from_initial(&self, link: &PackageLink<'g>) -> bool {
+        let package_ix = match self.direction() {
+            DependencyDirection::Forward => link.from().package_ix(),
+            DependencyDirection::Reverse => link.to().package_ix(),
+        };
+        self.query.params.has_initial(package_ix)
+    }
+}
+
 /// Represents whether a particular link within a package graph should be followed during a
 /// resolve operation.
 pub trait PackageLinkVisitor<'g> {
@@ -558,27 +588,27 @@ pub trait PackageLinkVisitor<'g> {
     ///
     /// Returning false does not prevent the `to` package (or `from` package with `query_reverse`)
     /// from being included if it's reachable through other means.
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool;
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool;
 }
 
 impl<'g, T> PackageLinkVisitor<'g> for &mut T
 where
     T: PackageLinkVisitor<'g>,
 {
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
 impl<'g> PackageLinkVisitor<'g> for Box<dyn PackageLinkVisitor<'g> + '_> {
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
 impl<'g> PackageLinkVisitor<'g> for &mut dyn PackageLinkVisitor<'g> {
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (**self).visit_link(query, link)
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
     }
 }
 
@@ -586,10 +616,10 @@ pub(super) struct LinkVisitorFn<F>(pub(super) F);
 
 impl<'g, F> PackageLinkVisitor<'g> for LinkVisitorFn<F>
 where
-    F: FnMut(&PackageQuery<'g>, PackageLink<'g>) -> bool,
+    F: FnMut(&PackageLinkContext<'g>, PackageLink<'g>) -> bool,
 {
-    fn visit_link(&mut self, query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
-        (self.0)(query, link)
+    fn visit_link(&mut self, cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
+        (self.0)(cx, link)
     }
 }
 

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -3,7 +3,7 @@
 
 use fixtures::json::JsonFixture;
 use guppy::graph::{
-    DependencyDirection, PackageLink, PackageLinkVisitor, PackageQuery,
+    DependencyDirection, PackageLink, PackageLinkContext, PackageLinkVisitor,
     cargo::{CargoOptions, CargoSet},
     feature::StandardFeatures,
 };
@@ -55,7 +55,7 @@ fn links_to_strings<'g>(links: impl IntoIterator<Item = PackageLink<'g>>) -> Vec
 }
 
 impl<'g> PackageLinkVisitor<'g> for PackageLinkVisitorForTesting<'_, 'g> {
-    fn visit_link(&mut self, _query: &PackageQuery<'g>, link: PackageLink<'g>) -> bool {
+    fn visit_link(&mut self, _cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
         self.trace.push(link_to_string(&link));
         self.link_filter.map(|f| f(link)).unwrap_or(true)
     }

--- a/guppy/tests/graph-tests/graph_tests.rs
+++ b/guppy/tests/graph-tests/graph_tests.rs
@@ -897,3 +897,68 @@ impl PackageDotVisitor for NameVisitor {
         write!(f, "{}", link.dep_name())
     }
 }
+
+mod link_context {
+    use super::*;
+
+    #[test]
+    fn package_link_context() {
+        let graph = JsonFixture::by_name("metadata_libra")
+            .expect("metadata_libra fixture exists")
+            .graph();
+        let workspace_ids: Vec<_> = graph.workspace().member_ids().collect();
+        for direction in [DependencyDirection::Forward, DependencyDirection::Reverse] {
+            let mut visited = 0;
+            graph
+                .query_directed(workspace_ids.iter().copied(), direction)
+                .unwrap()
+                .resolve_with_fn(|cx, link| {
+                    visited += 1;
+                    assert_eq!(cx.direction(), direction, "direction matches");
+                    let start = match direction {
+                        DependencyDirection::Forward => link.from(),
+                        DependencyDirection::Reverse => link.to(),
+                    };
+                    assert_eq!(
+                        cx.starts_from_initial(&link),
+                        cx.query().starts_from(start.id()).unwrap(),
+                        "starts_from_initial agrees with starts_from for {:?}",
+                        link
+                    );
+                    true
+                });
+            assert!(visited > 0, "at least one link visited in {direction:?}");
+        }
+    }
+
+    #[test]
+    fn feature_link_context() {
+        let graph = JsonFixture::by_name("metadata_libra")
+            .expect("metadata_libra fixture exists")
+            .graph();
+        let workspace_ids: Vec<_> = graph.workspace().member_ids().collect();
+        for direction in [DependencyDirection::Forward, DependencyDirection::Reverse] {
+            let mut visited = 0;
+            graph
+                .query_directed(workspace_ids.iter().copied(), direction)
+                .unwrap()
+                .to_feature_query(StandardFeatures::Default)
+                .resolve_with_fn(|cx, link| {
+                    visited += 1;
+                    assert_eq!(cx.direction(), direction, "direction matches");
+                    let start = match direction {
+                        DependencyDirection::Forward => link.from(),
+                        DependencyDirection::Reverse => link.to(),
+                    };
+                    assert_eq!(
+                        cx.starts_from_initial(&link),
+                        cx.query().starts_from(start.feature_id()).unwrap(),
+                        "starts_from_initial agrees with starts_from for {:?}",
+                        link
+                    );
+                    true
+                });
+            assert!(visited > 0, "at least one link visited in {direction:?}");
+        }
+    }
+}


### PR DESCRIPTION
Replace the bare `&PackageQuery`/`&FeatureQuery` argument to `visit_link` (and the `resolve_with_fn` closures) with a context struct. The context exposes the query, the direction, and `starts_from_initial`, and can grow more information about why a link is being visited without another breaking change.

Part of #497.