### PR TITLE
[determinator] move to toml 1.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
  "petgraph",
  "rayon",
  "serde",
- "toml 0.5.11",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]

--- a/tools/determinator/CHANGELOG.md
+++ b/tools/determinator/CHANGELOG.md
@@ -3,6 +3,12 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- Updated `toml` to 1.1.4. `DeterminatorRules::parse` now returns `toml` 1.x's
+  `de::Error`, a breaking change for code that names that type. Rules files are
+  parsed strictly according to the TOML 1.1 specification.
+
 ## [0.12.0] - 2023-06-25
 
 ### Changed

--- a/tools/determinator/Cargo.toml
+++ b/tools/determinator/Cargo.toml
@@ -46,7 +46,7 @@ petgraph = { version = "0.8.3", default-features = false, features = [
 ] }
 rayon = "1.10.0"
 serde = { version = "1.0.228", features = ["derive"] }
-toml = "0.5.11"
+toml = "1.1.4"
 guppy-workspace-hack.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
determinator only parses rules files, so the only visible change is the error type returned by `DeterminatorRules::parse` and the stricter TOML 1.1 parser.