### PR TITLE
[guppy] add CargoLinkVisitor and CargoLinkContext

### DIFF
--- a/guppy/examples/cargo_set_link_filter.rs
+++ b/guppy/examples/cargo_set_link_filter.rs
@@ -1,30 +1,32 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Demonstration how `CargoSet` algorithm can accept links that are present on:
+//! Demonstration of how the `CargoSet` algorithm can accept links that ar
+//! present on:
 //!
 //! 1) any/all platforms (using default `CargoOptions` and `CargoSet::new`)
 //! 2) a single platform (using `CargoOptions::set_target_platform`)
 //! 3) a set of platforms (using `CargoSet::with_cargo_link_visitor`)
 //!
-//! The last example uses `PackageLinkVisitor` as a filter - this is a very
+//! The last example uses `CargoLinkVisitor` as a filter - this is a very
 //! generic mechanism and can be used to not only filter by platforms,
 //! but also implement a variety of other filtering options.  For example,
 //! `CargoOptions::add_omitted_packages` could also be implemented using
-//! `CargoSet::with_cargo_link_visitor` and an appropriate `PackageLinkVisitor`.
+//! `CargoSet::with_cargo_link_visitor` and an appropriate `CargoLinkVisitor`.
 
 use guppy::{
     CargoMetadata, Error,
     graph::{
-        DependencyDirection, DependencyReq, PackageLink, PackageLinkContext, PackageLinkVisitor,
-        cargo::{CargoOptions, CargoSet},
+        DependencyDirection, DependencyReq, PackageLink,
+        cargo::{CargoLinkContext, CargoLinkVisitor, CargoOptions, CargoSet},
         feature::StandardFeatures,
     },
     platform::{EnabledTernary, PlatformSpec, PlatformStatus, Triple},
 };
 
-/// Custom `guppy::graph::PackageLinkVisitor` that will only accept `PackageLink`s
-/// that are enabled on at least one from the given set of platforms.
+/// Custom `guppy::graph::cargo::CargoLinkVisitor` that will only accept
+/// `PackageLink`s that are enabled on at least one from the given set of
+/// platforms.
 struct PlatformSetLinkVisitor(Vec<PlatformSpec>);
 
 impl PlatformSetLinkVisitor {
@@ -46,10 +48,13 @@ impl PlatformSetLinkVisitor {
     }
 }
 
-impl<'g> PackageLinkVisitor<'g> for PlatformSetLinkVisitor {
-    fn visit_link(&mut self, _cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
+impl<'g> CargoLinkVisitor<'g> for PlatformSetLinkVisitor {
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool {
+        // Apply the same rules that the `CargoSet` algorithm does around dev
+        // and build deps.
         self.should_include_dependency_req(link.normal())
-            || self.should_include_dependency_req(link.build())
+            || (cx.considers_dev_deps(&link) && self.should_include_dependency_req(link.dev()))
+            || (cx.considers_build_deps(&link) && self.should_include_dependency_req(link.build()))
     }
 }
 

--- a/guppy/src/graph/cargo/build.rs
+++ b/guppy/src/graph/cargo/build.rs
@@ -4,9 +4,10 @@
 use crate::{
     DependencyKind, Error,
     graph::{
-        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkVisitor, PackageSet,
+        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageSet,
         cargo::{
-            CargoIntermediateSet, CargoOptions, CargoResolverVersion, CargoSet, InitialsPlatform,
+            BuildPlatform, CargoIntermediateSet, CargoLinkContext, CargoLinkVisitor, CargoOptions,
+            CargoResolverVersion, CargoSet, InitialsPlatform,
         },
         feature::{ConditionalLink, FeatureLabel, FeatureQuery, FeatureSet, StandardFeatures},
     },
@@ -39,7 +40,7 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
+        visitor: Option<&mut dyn CargoLinkVisitor<'g>>,
     ) -> CargoSet<'g> {
         match self.opts.resolver {
             CargoResolverVersion::V1 => self.new_v1(initials, features_only, visitor, false),
@@ -69,7 +70,7 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
+        visitor: Option<&mut dyn CargoLinkVisitor<'g>>,
         avoid_dev_deps: bool,
     ) -> CargoSet<'g> {
         self.build_set(initials, features_only, visitor, |query| {
@@ -81,7 +82,7 @@ impl<'a> CargoSetBuildState<'a> {
         self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
+        visitor: Option<&mut dyn CargoLinkVisitor<'g>>,
     ) -> CargoSet<'g> {
         self.build_set(initials, features_only, visitor, |query| {
             self.new_v2_intermediate(query)
@@ -100,7 +101,7 @@ impl<'a> CargoSetBuildState<'a> {
         &self,
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        mut visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
+        mut visitor: Option<&mut dyn CargoLinkVisitor<'g>>,
         intermediate_fn: impl FnOnce(FeatureQuery<'g>) -> CargoIntermediateSet<'g>,
     ) -> CargoSet<'g> {
         // Prepare a package query for step 2.
@@ -216,18 +217,19 @@ impl<'a> CargoSetBuildState<'a> {
                 return false;
             }
 
+            let cargo_cx = CargoLinkContext::new(cx, BuildPlatform::Target, self.opts);
             let accepted = visitor
                 .as_mut()
-                .map(|r| r.visit_link(cx, link))
+                .map(|r| r.visit_link(&cargo_cx, link))
                 .unwrap_or(true);
             if !accepted {
                 return false;
             }
 
             // Dev-dependencies are only considered if `from` is an initial.
-            let consider_dev = self.opts.include_dev && cx.starts_from_initial(&link);
+            let consider_dev = cargo_cx.considers_dev_deps(&link);
             // Build dependencies are only considered if there's a build script.
-            let consider_build = from.has_build_script();
+            let consider_build = cargo_cx.considers_build_deps(&link);
 
             let mut follow_target =
                 is_enabled(target_set, &link, DependencyKind::Normal, target_platform)
@@ -286,9 +288,10 @@ impl<'a> CargoSetBuildState<'a> {
                     return false;
                 }
 
+                let cargo_cx = CargoLinkContext::new(cx, BuildPlatform::Host, self.opts);
                 let accepted = visitor
                     .as_mut()
-                    .map(|r| r.visit_link(cx, link))
+                    .map(|r| r.visit_link(&cargo_cx, link))
                     .unwrap_or(true);
                 if !accepted {
                     return false;
@@ -297,8 +300,8 @@ impl<'a> CargoSetBuildState<'a> {
                 // All relevant nodes in host_ixs have already been added to host_direct_deps at [a].
 
                 // Dev-dependencies are only considered if `from` is an initial.
-                let consider_dev = self.opts.include_dev && cx.starts_from_initial(&link);
-                let consider_build = from.has_build_script();
+                let consider_dev = cargo_cx.considers_dev_deps(&link);
+                let consider_build = cargo_cx.considers_build_deps(&link);
 
                 // Only normal and build dependencies are typically considered. Dev-dependencies of
                 // initials are also considered.

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -4,7 +4,7 @@
 use crate::{
     Error, PackageId,
     graph::{
-        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkVisitor, PackageSet,
+        DependencyDirection, PackageGraph, PackageIx, PackageLink, PackageLinkContext, PackageSet,
         cargo::build::CargoSetBuildState,
         feature::{FeatureGraph, FeatureSet},
     },
@@ -117,6 +117,109 @@ impl<'a> CargoOptions<'a> {
 impl Default for CargoOptions<'_> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Represents whether a particular link within a package graph should be
+/// followed while building a [`CargoSet`].
+///
+/// This is similar to [`PackageLinkVisitor`], but is passed a
+/// [`CargoLinkContext`] with additional information about the Cargo build.
+///
+/// [`PackageLinkVisitor`]: crate::graph::PackageLinkVisitor
+pub trait CargoLinkVisitor<'g> {
+    /// Returns true if this link should be followed.
+    ///
+    /// Returning false does not prevent the `to` package from being included
+    /// if it's reachable through other means.
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool;
+}
+
+impl<'g, T> CargoLinkVisitor<'g> for &mut T
+where
+    T: CargoLinkVisitor<'g>,
+{
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
+    }
+}
+
+impl<'g> CargoLinkVisitor<'g> for Box<dyn CargoLinkVisitor<'g> + '_> {
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
+    }
+}
+
+impl<'g> CargoLinkVisitor<'g> for &mut dyn CargoLinkVisitor<'g> {
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool {
+        (**self).visit_link(cx, link)
+    }
+}
+
+/// Context passed to a [`CargoLinkVisitor`] for each link visited while
+/// building a [`CargoSet`].
+#[derive(Clone, Debug)]
+pub struct CargoLinkContext<'a, 'g> {
+    package_context: &'a PackageLinkContext<'g>,
+    build_platform: BuildPlatform,
+    platform_spec: &'a PlatformSpec,
+    build_dep_platform_spec: &'a PlatformSpec,
+    include_dev: bool,
+}
+
+impl<'a, 'g> CargoLinkContext<'a, 'g> {
+    pub(super) fn new(
+        package_context: &'a PackageLinkContext<'g>,
+        build_platform: BuildPlatform,
+        opts: &'a CargoOptions<'_>,
+    ) -> Self {
+        let (platform_spec, build_dep_platform_spec) = match build_platform {
+            BuildPlatform::Target => (&opts.target_platform, &opts.host_platform),
+            BuildPlatform::Host => (&opts.host_platform, &opts.host_platform),
+        };
+        Self {
+            package_context,
+            build_platform,
+            platform_spec,
+            build_dep_platform_spec,
+            include_dev: opts.include_dev,
+        }
+    }
+
+    /// Returns the context for the underlying package graph traversal.
+    pub fn package_context(&self) -> &PackageLinkContext<'g> {
+        self.package_context
+    }
+
+    /// Returns the platform this link is being evaluated for: the target pass
+    /// or the host pass.
+    pub fn build_platform(&self) -> BuildPlatform {
+        self.build_platform
+    }
+
+    /// Returns the platform spec that normal and dev dependencies are
+    /// evaluated against in this pass.
+    pub fn platform_spec(&self) -> &PlatformSpec {
+        self.platform_spec
+    }
+
+    /// Returns the platform spec that build dependencies are evaluated against
+    /// in this pass (always the host platform).
+    pub fn build_dep_platform_spec(&self) -> &PlatformSpec {
+        self.build_dep_platform_spec
+    }
+
+    /// Returns true if dev-dependencies of this link may be followed:
+    /// [`CargoOptions::set_include_dev`] is set and the `from` package is an
+    /// initial.
+    pub fn considers_dev_deps(&self, link: &PackageLink<'g>) -> bool {
+        self.include_dev && self.package_context.starts_from_initial(link)
+    }
+
+    /// Returns true if build-dependencies of this link may be followed: the
+    /// `from` package has a build script.
+    pub fn considers_build_deps(&self, link: &PackageLink<'g>) -> bool {
+        link.from().has_build_script()
     }
 }
 
@@ -260,7 +363,7 @@ impl<'g> CargoSet<'g> {
         Self::new_internal(initials, features_only, None, opts)
     }
 
-    /// Like `Cargo.new`, but takes an additional [`PackageLinkVisitor`] which can
+    /// Like `Cargo.new`, but takes an additional [`CargoLinkVisitor`] which can
     /// be used to filter out some dependency edges, or to collect additional
     /// information.
     ///
@@ -269,11 +372,11 @@ impl<'g> CargoSet<'g> {
     /// [`CargoOptions::add_omitted_packages`], but before any other decisions
     /// are made.
     ///
-    /// [`visitor.visit_link`]: PackageLinkVisitor::visit_link
+    /// [`visitor.visit_link`]: CargoLinkVisitor::visit_link
     pub fn with_cargo_link_visitor(
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        mut visitor: impl PackageLinkVisitor<'g>,
+        mut visitor: impl CargoLinkVisitor<'g>,
         opts: &CargoOptions<'_>,
     ) -> Result<Self, Error> {
         Self::new_internal(initials, features_only, Some(&mut visitor), opts)
@@ -284,7 +387,7 @@ impl<'g> CargoSet<'g> {
     fn new_internal(
         initials: FeatureSet<'g>,
         features_only: FeatureSet<'g>,
-        visitor: Option<&mut dyn PackageLinkVisitor<'g>>,
+        visitor: Option<&mut dyn CargoLinkVisitor<'g>>,
         opts: &CargoOptions<'_>,
     ) -> Result<Self, Error> {
         let build_state = CargoSetBuildState::new(initials.graph().package_graph, opts)?;

--- a/guppy/tests/graph-tests/cargo_set_tests.rs
+++ b/guppy/tests/graph-tests/cargo_set_tests.rs
@@ -3,34 +3,55 @@
 
 use fixtures::json::JsonFixture;
 use guppy::graph::{
-    DependencyDirection, PackageLink, PackageLinkContext, PackageLinkVisitor,
-    cargo::{CargoOptions, CargoSet},
+    DependencyDirection, PackageLink,
+    cargo::{BuildPlatform, CargoLinkContext, CargoLinkVisitor, CargoOptions, CargoSet},
     feature::StandardFeatures,
 };
 use std::collections::HashSet;
 
-struct PackageLinkVisitorForTesting<'a, 'g> {
+struct CargoLinkVisitorForTesting<'a, 'g> {
     /// Optional filter of `link`s.  If `None`, then all links are accepted.
     link_filter: Option<&'a dyn Fn(PackageLink<'g>) -> bool>,
+
+    /// The value of `CargoOptions::set_include_dev` the visitor expects to be
+    /// used with, for checking `CargoLinkContext::considers_dev_deps`.
+    include_dev: bool,
 
     /// The `trace` field stores `link`s that were passed to `fn visit_link`.
     /// The links are formatted as `"foo@1.2.3 => bar@4.5.6"`.
     /// The links are stored in the order of `fn visit_link` calls.
     trace: Vec<String>,
+
+    /// Like `trace`, but also records the `BuildPlatform` each link was
+    /// visited on.
+    platform_trace: Vec<(BuildPlatform, String)>,
 }
 
-impl<'a, 'g> PackageLinkVisitorForTesting<'a, 'g> {
+impl<'a, 'g> CargoLinkVisitorForTesting<'a, 'g> {
     fn new() -> Self {
         Self {
             link_filter: None,
+            include_dev: false,
             trace: vec![],
+            platform_trace: vec![],
         }
     }
 
     fn with_filter(f: &'a impl Fn(PackageLink<'g>) -> bool) -> Self {
         Self {
             link_filter: Some(f),
+            include_dev: false,
             trace: vec![],
+            platform_trace: vec![],
+        }
+    }
+
+    fn with_include_dev(include_dev: bool) -> Self {
+        Self {
+            link_filter: None,
+            include_dev,
+            trace: vec![],
+            platform_trace: vec![],
         }
     }
 }
@@ -54,9 +75,40 @@ fn links_to_strings<'g>(links: impl IntoIterator<Item = PackageLink<'g>>) -> Vec
     result
 }
 
-impl<'g> PackageLinkVisitor<'g> for PackageLinkVisitorForTesting<'_, 'g> {
-    fn visit_link(&mut self, _cx: &PackageLinkContext<'g>, link: PackageLink<'g>) -> bool {
-        self.trace.push(link_to_string(&link));
+impl<'g> CargoLinkVisitor<'g> for CargoLinkVisitorForTesting<'_, 'g> {
+    fn visit_link(&mut self, cx: &CargoLinkContext<'_, 'g>, link: PackageLink<'g>) -> bool {
+        let link_str = link_to_string(&link);
+
+        // The context must return values consistent with what can be computed
+        // from the link and options directly.
+        assert_eq!(
+            cx.considers_build_deps(&link),
+            link.from().has_build_script(),
+            "considers_build_deps for {link_str}",
+        );
+        assert_eq!(
+            cx.considers_dev_deps(&link),
+            self.include_dev && cx.package_context().starts_from_initial(&link),
+            "considers_dev_deps for {link_str}",
+        );
+        assert_eq!(
+            cx.package_context().direction(),
+            DependencyDirection::Forward,
+            "direction for {link_str}",
+        );
+        match cx.build_platform() {
+            BuildPlatform::Target => {}
+            BuildPlatform::Host => {
+                assert_eq!(
+                    format!("{:?}", cx.platform_spec()),
+                    format!("{:?}", cx.build_dep_platform_spec()),
+                    "host pass evaluates all deps against the host platform for {link_str}",
+                );
+            }
+        }
+
+        self.trace.push(link_str.clone());
+        self.platform_trace.push((cx.build_platform(), link_str));
         self.link_filter.map(|f| f(link)).unwrap_or(true)
     }
 }
@@ -64,7 +116,17 @@ impl<'g> PackageLinkVisitor<'g> for PackageLinkVisitorForTesting<'_, 'g> {
 fn cargo_set_with_visitor<'g>(
     test_fixture: &'g JsonFixture,
     root_package_name: &str,
-    visitor: &mut dyn PackageLinkVisitor<'g>,
+    visitor: &mut dyn CargoLinkVisitor<'g>,
+) -> CargoSet<'g> {
+    let cargo_options = CargoOptions::new();
+    cargo_set_with_visitor_and_options(test_fixture, root_package_name, visitor, &cargo_options)
+}
+
+fn cargo_set_with_visitor_and_options<'g>(
+    test_fixture: &'g JsonFixture,
+    root_package_name: &str,
+    visitor: &mut dyn CargoLinkVisitor<'g>,
+    cargo_options: &CargoOptions<'_>,
 ) -> CargoSet<'g> {
     let package_graph = test_fixture.graph();
 
@@ -75,8 +137,22 @@ fn cargo_set_with_visitor<'g>(
         .resolve_none()
         .to_feature_set(StandardFeatures::Default);
 
-    let cargo_options = CargoOptions::new();
-    CargoSet::with_cargo_link_visitor(initials, no_extra_features, visitor, &cargo_options).unwrap()
+    CargoSet::with_cargo_link_visitor(initials, no_extra_features, visitor, cargo_options).unwrap()
+}
+
+/// Returns the links from `platform_trace` visited on `build_platform`,
+/// sorted.
+fn platform_trace_links(
+    platform_trace: &[(BuildPlatform, String)],
+    build_platform: BuildPlatform,
+) -> Vec<String> {
+    let mut result = platform_trace
+        .iter()
+        .filter(|(platform, _)| *platform == build_platform)
+        .map(|(_, link)| link.clone())
+        .collect::<Vec<_>>();
+    result.sort();
+    result
 }
 
 fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {
@@ -92,7 +168,7 @@ fn cargo_set_package_names(cargo_set: &CargoSet) -> Vec<String> {
 
 #[test]
 fn test_package_link_visitor_visits() {
-    let mut visitor = PackageLinkVisitorForTesting::new();
+    let mut visitor = CargoLinkVisitorForTesting::new();
     let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
     assert_eq!(
         cargo_set_package_names(&cargo_set),
@@ -250,8 +326,57 @@ fn test_package_link_visitor_visits() {
 }
 
 #[test]
+fn test_cargo_link_visitor_build_platforms() {
+    let mut visitor = CargoLinkVisitorForTesting::new();
+    let cargo_set = cargo_set_with_visitor(JsonFixture::metadata1(), "testcrate", &mut visitor);
+
+    // testcrate has proc-macro and build deps, so both passes show up in the
+    // trace.
+    assert_eq!(visitor.platform_trace.len(), visitor.trace.len());
+
+    // For this fixture, the target pass == target + proc-macro + build-dep
+    // links, and host pass == host links.
+    let expected_target = links_to_strings(
+        cargo_set
+            .target_links()
+            .chain(cargo_set.proc_macro_links())
+            .chain(cargo_set.build_dep_links()),
+    );
+    assert_eq!(
+        platform_trace_links(&visitor.platform_trace, BuildPlatform::Target),
+        expected_target,
+    );
+    assert_eq!(
+        platform_trace_links(&visitor.platform_trace, BuildPlatform::Host),
+        links_to_strings(cargo_set.host_links()),
+    );
+}
+
+#[test]
+fn test_cargo_link_visitor_include_dev() {
+    let mut visitor = CargoLinkVisitorForTesting::with_include_dev(true);
+    let mut cargo_options = CargoOptions::new();
+    cargo_options.set_include_dev(true);
+    let cargo_set = cargo_set_with_visitor_and_options(
+        JsonFixture::metadata1(),
+        "testcrate",
+        &mut visitor,
+        &cargo_options,
+    );
+
+    let host_links = platform_trace_links(&visitor.platform_trace, BuildPlatform::Host);
+    let target_links = platform_trace_links(&visitor.platform_trace, BuildPlatform::Target);
+    assert!(!host_links.is_empty());
+    assert!(!target_links.is_empty());
+    assert_eq!(
+        platform_trace_links(&visitor.platform_trace, BuildPlatform::Host),
+        links_to_strings(cargo_set.host_links()),
+    );
+}
+
+#[test]
 fn test_package_link_visitor_filtering_normal_links_on_target() {
-    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
+    let mut visitor = CargoLinkVisitorForTesting::with_filter(&|link| {
         // Remove `winapi` and `winapu-util` links.  This should transitively remove `winapi =>
         // winapi-x86_64-pc-windows-gnu` and `winapi => winapi-i686-pc-windows-gnu`.
         //
@@ -291,7 +416,7 @@ fn test_package_link_visitor_filtering_normal_links_on_target() {
 
 #[test]
 fn test_package_link_visitor_filtering_build_links_on_target() {
-    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
+    let mut visitor = CargoLinkVisitorForTesting::with_filter(&|link| {
         // Remove `datatest` => `version_check` build dependency.
         //
         // This filter is meant to test whether `CargoSet` algotithm consults the `visitor`
@@ -324,7 +449,7 @@ fn test_package_link_visitor_filtering_build_links_on_target() {
 
 #[test]
 fn test_package_link_visitor_filtering_links_on_host() {
-    let mut visitor = PackageLinkVisitorForTesting::with_filter(&|link| {
+    let mut visitor = CargoLinkVisitorForTesting::with_filter(&|link| {
         // Remove dependencies of `ctor` and `datatest-derive` packages.  This should transitively
         // remove `proc-macro2`, `quote`, `syn`, and `unicode-xid` packages.
         //


### PR DESCRIPTION
`CargoSet::with_cargo_link_visitor` now takes a dedicated `CargoLinkVisitor` rather than a `PackageLinkVisitor`. Its `CargoLinkContext` tells the visitor which pass (target or host) the link is being evaluated for, which platform specs apply, and whether dev and build dependencies are under consideration for this link.

The Cargo resolution algorithm derives its own `consider_dev`/`consider_build` from the same context.

Part of #497.