### PR TITLE
[hakari] move to toml 1.1.4 and toml_edit 0.25.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2445,8 +2445,12 @@ dependencies = [
  "serde_json",
  "syn",
  "toml 1.1.4+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "windows-sys 0.59.0",
  "windows-sys 0.61.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2474,8 +2478,8 @@ dependencies = [
  "serde",
  "tabular",
  "target-spec",
- "toml 0.5.11",
- "toml_edit 0.22.26",
+ "toml 1.1.4+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
  "twox-hash",
 ]
 
@@ -4703,15 +4707,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
@@ -4789,6 +4784,19 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5333,6 +5341,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/tools/hakari/CHANGELOG.md
+++ b/tools/hakari/CHANGELOG.md
@@ -3,6 +3,14 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- Updated `toml` to 1.1.4 and `toml_edit` to 0.25.13.
+  - `HakariConfig::from_str`, `HakariBuilderSummary::to_string` and
+    `HakariBuilderSummary::write_to_string` now return error types from `toml`
+    1.x, and `TomlOutError::Toml` wraps `toml` 1.x's `ser::Error`.
+  - Configuration files are parsed according to the TOML 1.1 specification.
+
 ## [0.17.9] - 2025-12-26
 
 ### Changed

--- a/tools/hakari/Cargo.toml
+++ b/tools/hakari/Cargo.toml
@@ -52,8 +52,8 @@ rayon = "1.10.0"
 serde = { version = "1.0.228", features = ["derive"], optional = true }
 tabular = { version = "0.2.0", features = ["ansi-cell"], optional = true }
 target-spec = { version = "3.6.0", path = "../../target-spec" }
-toml = { version = "0.5.11", optional = true }
-toml_edit = "0.22.26"
+toml = { version = "1.1.4", optional = true }
+toml_edit = "0.25.13"
 twox-hash.workspace = true
 guppy-workspace-hack.workspace = true
 

--- a/tools/hakari/src/summaries.rs
+++ b/tools/hakari/src/summaries.rs
@@ -15,7 +15,6 @@ use guppy::{
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fmt, str::FromStr};
-use toml::Serializer;
 
 /// The location of the configuration used by `cargo hakari`, relative to the workspace root.
 pub static DEFAULT_CONFIG_PATH: &str = ".config/hakari.toml";
@@ -190,9 +189,8 @@ impl HakariBuilderSummary {
     ///
     /// Returns an error if writing out the TOML was unsuccessful.
     pub fn write_to_string(&self, dst: &mut String) -> Result<(), toml::ser::Error> {
-        let mut serializer = Serializer::pretty(dst);
-        serializer.pretty_array(false);
-        self.serialize(&mut serializer)
+        let table = toml::Table::try_from(self)?;
+        guppy::graph::summaries::toml_compat::write_table(&table, dst)
     }
 }
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -40,6 +40,10 @@ serde = { version = "1.0.228", features = ["alloc", "derive"] }
 serde_core = { version = "1.0.228", features = ["alloc"] }
 serde_json = { version = "1.0.150", features = ["unbounded_depth"] }
 toml = { version = "1.1.4", features = ["preserve_order"] }
+toml_datetime = { version = "1.1.1", features = ["serde"] }
+toml_parser = { version = "1.1.3" }
+toml_writer = { version = "1.1.2" }
+winnow = { version = "1.0.3" }
 
 [build-dependencies]
 proc-macro2 = { version = "1.0.101" }


### PR DESCRIPTION
Use `guppy_summaries::toml_compat` so that output remains the same.