### PR TITLE
[meta] update to cfg-expr 0.20.9 and cargo 0.99.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        rust-version: ["1.86", stable]
+        rust-version: ["1.91", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
-        rust-version: ["1.86", stable]
+        rust-version: ["1.91", stable]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings
@@ -142,7 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # This matches the cfg-expr version.
-      - uses: dtolnay/rust-toolchain@1.94.0
+      - uses: dtolnay/rust-toolchain@1.98.0
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # v2
       - name: Build and test
         run: cargo test --package cargo-compare --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.11"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4850548ff4a25a77ce3bda7241874e17fb702ea551f0cc62a2dbe052f1272"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -84,7 +84,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.6",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -94,9 +109,19 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-hyperlink"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a14cad0fa1d1fb02de486a95ea7fd8dd28567b82f65b4ca34bffa7da81823e4"
+dependencies = [
+ "libc",
+ "percent-encoding",
+]
 
 [[package]]
 name = "anstyle-lossy"
@@ -117,6 +142,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-progress"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082ebe8b7607a68881fbcccc7b3a3e784aa58593ed4261df0679a803fdb80853"
+
+[[package]]
 name = "anstyle-query"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,7 +171,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3607949e9f6de49ea4bafe12f5e4fd73613ebf24795e48587302a8cc0e4bb35"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "anstyle-lossy",
  "html-escape",
@@ -151,21 +191,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayvec"
@@ -178,6 +215,17 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "atomicwrites"
@@ -266,9 +314,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitmaps"
@@ -281,16 +335,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec 0.7.6",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -300,6 +353,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -336,9 +398,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
@@ -351,14 +413,15 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.95.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af45a75a5265a587a8d9e4098cd2b12a07b34bcbd9eb7952ae6a62ea6d65c4d"
+checksum = "0c30a0d29369c04a80056b22089ad95f28c3df596821f1f8672d44ef64b7e26a"
 dependencies = [
- "annotate-snippets",
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
+ "anstyle-progress",
  "anyhow",
+ "async-trait",
  "base64",
  "blake3",
  "cargo-credential",
@@ -368,6 +431,7 @@ dependencies = [
  "cargo-platform",
  "cargo-util",
  "cargo-util-schemas",
+ "cargo-util-terminal",
  "clap",
  "clap_complete",
  "color-print",
@@ -376,18 +440,22 @@ dependencies = [
  "curl-sys",
  "filetime",
  "flate2",
+ "futures",
+ "futures-timer",
  "git2",
  "git2-curl",
  "gix",
  "glob",
+ "heck",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "home",
+ "http",
  "http-auth",
  "ignore",
  "im-rc",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "jiff",
  "jobserver",
  "libc",
@@ -397,7 +465,8 @@ dependencies = [
  "os_info",
  "pasetors",
  "pathdiff",
- "rand",
+ "portable-atomic",
+ "rand 0.10.2",
  "regex",
  "rusqlite",
  "rustc-hash",
@@ -409,16 +478,16 @@ dependencies = [
  "serde-untagged",
  "serde_ignored",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "shell-escape",
- "supports-hyperlinks",
- "supports-unicode",
  "tar",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "time",
- "toml 0.9.11+spec-1.1.0",
- "toml_edit 0.24.1+spec-1.1.0",
+ "toml",
+ "toml_edit 0.25.13+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "tracing",
  "tracing-chrome",
  "tracing-subscriber",
@@ -428,7 +497,7 @@ dependencies = [
  "url",
  "walkdir",
  "windows-sys 0.61.2",
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -461,16 +530,16 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "time",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.5.6"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a795e7ae9d07fe3943afa57a752a476d01532d4119ed375ac5f002aa2297bf"
+checksum = "05e5f16a4f9f863e65e5c8b09a0b72d7ffe2b2c17eec4f7ea480360ddc4f61ca"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -479,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.4.21"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120b1181de67f8796928c41f56ee053b7983cfd0fa81ab59adf9e7c7110e674"
+checksum = "06f5b56bc59e9f3fe2a0450cd379057c8a327662c1d04ccecab61cd79818325e"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -489,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.4.21"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5356aa9bee1f33e94f9b39779a7ba9999a9068dcb37055ef2eded869a1f5e03d"
+checksum = "25c2de3e8263008f298c44371abc403c08742df04c88230a66e781a11d2110fc"
 dependencies = [
  "cargo-credential",
  "windows-sys 0.61.2",
@@ -539,18 +608,19 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8abf5d501fd757c2d2ee78d0cc40f606e92e3a63544420316565556ed28485e2"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo-util"
-version = "0.2.28"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4162900cab52029d1e29a44ba98277ec9936948b8cefbd7a2269c990ac7d58a"
+checksum = "218d28c233cdb23a98404ae6d6f8eea19db3c3ab28c34633c7d9facf72f2d2ff"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -560,8 +630,9 @@ dependencies = [
  "jobserver",
  "libc",
  "miow",
+ "portable-atomic",
  "same-file",
- "sha2",
+ "sha2 0.11.0",
  "shell-escape",
  "tempfile",
  "tracing",
@@ -571,19 +642,39 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.12.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b5c24ba23f6d05b6cb15946d08bb6dd61b96ae920f17b33b17d4e7b1e76555"
+checksum = "46262ca4393669799a8df4852e81672ddea46657e73294b1a846f0d5c71509ed"
 dependencies = [
  "jiff",
  "semver",
  "serde",
  "serde-untagged",
  "serde-value",
- "thiserror 2.0.17",
- "toml 0.9.11+spec-1.1.0",
+ "thiserror 2.0.20",
+ "toml",
  "unicode-ident",
  "url",
+]
+
+[[package]]
+name = "cargo-util-terminal"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1548e157f51e667fdf147e5c55ee09a713cab10345293b1009f8de9af4974b"
+dependencies = [
+ "annotate-snippets",
+ "anstream 1.0.0",
+ "anstyle",
+ "anstyle-hyperlink",
+ "anstyle-progress",
+ "anyhow",
+ "libc",
+ "serde",
+ "serde_json",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -597,7 +688,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -614,14 +705,14 @@ checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
- "shlex",
+ "shlex 1.3.0",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6b04e07d8080154ed4ac03546d9a2b303cc2fe1901ba0b35b301516e289368"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -638,6 +729,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "ciborium"
@@ -668,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.56"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ca66430e33a14957acc24c5077b503e7d374151b2b4b3a10c83b4ceb4be0e"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -678,11 +780,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.56"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -691,39 +793,45 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.65"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b4dc2b5e3861848de79627b2bedc9f3342c7da5173a14eaa5d0f8dc18ae5d"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
  "clap_lex",
  "is_executable",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color-eyre"
@@ -756,7 +864,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -783,6 +891,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "constant_time_eq"
@@ -816,16 +930,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "crates-io"
-version = "0.40.18"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ba15a8fb280fc0913c21098c1801c274da7852f0665684fbdf1fcc2dc97cb5"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "curl",
+ "libc",
+]
+
+[[package]]
+name = "crates-io"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61eac17e797075f82dc4f2ca6c2b807abcb7f2b101f1fd1f627c5f1cde27b0d5"
+dependencies = [
+ "http",
  "percent-encoding",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -937,10 +1060,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ct-codecs"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b916ba8ce9e4182696896f015e8a5ae6081b305f74690baa8465e35f5a142ea4"
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
 
 [[package]]
 name = "curl"
@@ -959,9 +1100,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",
@@ -970,7 +1111,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1007,12 +1148,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffe7ed1d93f4553003e20b629abe9085e1e81b1429520f897f8f8860bc6dfc21"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1042,7 +1214,7 @@ dependencies = [
  "petgraph",
  "rayon",
  "serde",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -1088,10 +1260,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1100,7 +1284,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
 ]
 
@@ -1112,7 +1296,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1140,7 +1324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1170,7 +1354,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1223,7 +1407,7 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "env_filter",
  "jiff",
@@ -1307,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -1329,13 +1513,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1376,11 +1559,10 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
- "crc32fast",
  "miniz_oxide 0.8.9",
  "zlib-rs",
 ]
@@ -1419,25 +1601,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
-name = "futures-task"
-version = "0.3.32"
+name = "futures-executor"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1473,11 +1725,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1488,11 +1750,11 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git2"
-version = "0.20.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2b37e2f62729cdada11f0e6b3b6fe383c69c29fc619e391223e12856af308c"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -1503,9 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "git2-curl"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8dcabbc09ece4d30a9aa983d5804203b7e2f8054a171f792deff59b56d31fa"
+checksum = "1f1f6fe01327a2f7a1d6ee519c14651f79530aa4d64e870f4cf672efe697bea5"
 dependencies = [
  "curl",
  "git2",
@@ -1515,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d8284d86a2f5c0987fbf7219a128815cc04af5a18f5fd7eec6a76d83c2b78cc"
+checksum = "fa8b2e38ebfc4484dfef8580ddcaf8abb7285e6f3eb6413ff6775d104ae96ca6"
 dependencies = [
  "gix-actor",
  "gix-attributes",
@@ -1529,6 +1791,7 @@ dependencies = [
  "gix-diff",
  "gix-dir",
  "gix-discover",
+ "gix-error",
  "gix-features",
  "gix-filter",
  "gix-fs",
@@ -1562,30 +1825,29 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "gix-worktree",
+ "gix-worktree-stream",
+ "nonempty",
  "prodash",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-actor"
-version = "0.37.1"
+version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c345528d405eab51d20f505f5fe1a4680973953694e0292c6bbe97827daa55c4"
+checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-utils",
- "itoa",
- "thiserror 2.0.17",
- "winnow 0.7.14",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-attributes"
-version = "0.29.0"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dabf8a50f1558c3a55d978440c7c4f22f87ac897bef03b4edbc96f6115966"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1594,33 +1856,33 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "unicode-bom",
 ]
 
 [[package]]
 name = "gix-bitmap"
-version = "0.2.15"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e150161b8a75b5860521cb876b506879a3376d3adc857ec7a9d35e7c6a5e531"
+checksum = "7cd1d118d0f5d88b96e6f6e13b566475fef4797ead4a02c26fed36c1375066f7"
 dependencies = [
- "thiserror 2.0.17",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-chunk"
-version = "0.4.12"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+checksum = "b2a871e5cab12ba568845714473505deefffb3c04eb47f4708ce344cd459c1cc"
 dependencies = [
- "thiserror 2.0.17",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-command"
-version = "0.6.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9c425730a654835351e6da8c3c69ba1804f8b8d4e96d027254151138d5c64"
+checksum = "cf4363accdf6ef7ba861871d2d521ab7418a04aaaed919fadb022af71d379b12"
 dependencies = [
  "bstr",
  "gix-path",
@@ -1631,22 +1893,23 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.31.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdcba8048045baf15225daf949d597c3e6183d130245e22a7fbd27084abe63a"
+checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
 dependencies = [
  "bstr",
  "gix-chunk",
+ "gix-error",
  "gix-hash",
  "memmap2",
- "thiserror 2.0.17",
+ "nonempty",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.50.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58e2ff8eef96b71f2c5e260f02ca0475caff374027c5cc5a29bda69fac67404"
+checksum = "a29bf266c4cdaf759e535c24ad4ce655b987aeb6911075643403cc7cc5ade583"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -1655,31 +1918,29 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "unicode-bom",
- "winnow 0.7.14",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2409cffa4fe8b303847d5b6ba8df9da9ba65d302fc5ee474ea0cac5afde79840"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-credentials"
-version = "0.34.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316a12842fb761a7a6e9ae963d7bae9f0f4c433f242282df91192ef084b1891c"
+checksum = "e8a0fcfcd73229d1a9c34e04edd05dbcb80364ec6f3788d24c546de2916671eb"
 dependencies = [
  "bstr",
  "gix-command",
@@ -1690,27 +1951,26 @@ dependencies = [
  "gix-sec",
  "gix-trace",
  "gix-url",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-date"
-version = "0.12.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4a31bab8159e233094fa70d2e5fd3ec6f19e593f67e6ae01281daa48f8d8e7"
+checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
 dependencies = [
  "bstr",
+ "gix-error",
  "itoa",
  "jiff",
- "smallvec",
- "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "gix-diff"
-version = "0.57.1"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3506936e63ce14cd54b5f28ed06c8e43b92ef9f41c2238cc0bc271a9259b4e90"
+checksum = "92c6d56c94edf92d78203a1cd416f770e35e10b6955ede6b9d7d0c22ff88a5f3"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -1718,6 +1978,7 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -1726,15 +1987,14 @@ dependencies = [
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "imara-diff",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.19.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9fad32d2eb8b0129850874246569e801b6d5877e0c41356c23e9e2501e06"
+checksum = "20098fba2b9c6e29361ccb4c0379d42dfb81fc7f86f7ab11f2dff4528c0bf01f"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -1747,30 +2007,38 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "gix-worktree",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-discover"
-version = "0.45.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ce096dc132533802a09d6fd5d4008858f2038341dfe2e69e0d0239edb359de"
+checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
 dependencies = [
  "bstr",
  "dunce",
  "gix-fs",
- "gix-hash",
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+dependencies = [
+ "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.45.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56aad357ae016449434705033df644ac6253dfcf1281aad3af3af9e907560d1"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1782,16 +2050,16 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "prodash",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
  "walkdir",
  "zlib-rs",
 ]
 
 [[package]]
 name = "gix-filter"
-version = "0.24.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c02464962482570c1f94ad451a608c4391514f803e8074662d02c5629a25dc"
+checksum = "6644fb2ef97928c278675b239f366b457103d7e436f811d27331a8daf212759c"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -1805,30 +2073,30 @@ dependencies = [
  "gix-trace",
  "gix-utils",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-fs"
-version = "0.18.2"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785b9c499e46bc78d7b81c148c21b3fca18655379ee729a856ed19ce50d359ec"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-glob"
-version = "0.23.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8546300aee4c65c5862c22a3e321124a69b654a61a8b60de546a9284812b7e2"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-features",
  "gix-path",
@@ -1836,32 +2104,32 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.21.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e153930f42ccdab8a3306b1027cd524879f6a8996cd0c474d18b0e56cae7714d"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
  "sha1-checked",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-hashtable"
-version = "0.11.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222f7428636020bef272a87ed833ea48bf5fb3193f99852ae16fbb5a602bd2f0"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-ignore"
-version = "0.18.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa727fdf54fd9fb53fa3fbb1a5c17172d3073e8e336bf155f3cac3e25b81b21"
+checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1871,12 +2139,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-index"
-version = "0.45.1"
+name = "gix-imara-diff"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea6d3e9e11647ba49f441dea0782494cc6d2875ff43fa4ad9094e6957f42051"
+checksum = "1c91d8cffac8849493a82233811bd02b2b183b8cf39bf704de0fa0841b737595"
 dependencies = [
- "bitflags",
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d45f82ec5a4d7542ea595e9ad16e03e26c8cb4f221e5bc9fcdcf469f63a681"
+dependencies = [
+ "bitflags 2.13.1",
  "bstr",
  "filetime",
  "fnv",
@@ -1889,47 +2167,45 @@ dependencies = [
  "gix-traverse",
  "gix-utils",
  "gix-validate",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "libc",
  "memmap2",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "20.0.1"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115268ae5e3b3b7bc7fc77260eecee05acca458e45318ca45d35467fa81a3ac5"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.25.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cee7e32e6198e356caef0e4b8321bc2f9b2afeb76f870c0bf9aa05fe53edb6"
+checksum = "63d6081882a5f575ace9f53924a7c85f69bbd0f96071b982df12f258ab338cc9"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "smallvec",
- "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "gix-object"
-version = "0.54.1"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "363d6a879c52e4890180e0ffa7d8c9a364fd0b7e807caa368e860b80e8d0bc81"
+checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -1937,23 +2213,20 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
- "thiserror 2.0.17",
- "winnow 0.7.14",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.74.0"
+version = "0.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165a907df369a12ed4330faf8baf7ae597aadb08cfacb4ed8649f93d90bcc0c5"
+checksum = "7fadc59f6fa0f9dd445eceee61060a2b59ca557f48da9fc677f567db535b782a"
 dependencies = [
  "arc-swap",
- "gix-date",
  "gix-features",
  "gix-fs",
  "gix-hash",
@@ -1962,19 +2235,21 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "memmap2",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-pack"
-version = "0.64.1"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04a73d5ab07ea0faae55e2c0ae6f24e36e365ac8ce140394dee3a2c89cd4366"
+checksum = "ca3e7f1726cd2c0cd1cf1fc20be8a8e623f0b163f1f8d6fc836cfb9bc8cd758b"
 dependencies = [
  "clru",
  "gix-chunk",
+ "gix-error",
  "gix-features",
  "gix-hash",
  "gix-hashtable",
@@ -1984,66 +2259,66 @@ dependencies = [
  "memmap2",
  "parking_lot",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-packetline"
-version = "0.20.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad0ffb982a289888087a165d3e849cbac724f2aa5431236b050dd2cb9c7de31"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
 dependencies = [
  "bstr",
  "faster-hex",
  "gix-trace",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.22"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+checksum = "2b075e730586bba7341304d6fc1b4efc1d10cf64532622521c0e07f30e661046"
 dependencies = [
  "bstr",
  "gix-trace",
  "gix-validate",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-pathspec"
-version = "0.14.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9e0c881933c37a7ef45288d6c5779c4a7b3ad240b4c37657e1d9829eb90085"
+checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "bstr",
  "gix-attributes",
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-prompt"
-version = "0.12.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974b142ea650fb0050a301958f49c8cc68929c36f686e9606a381ce39da34fd9"
+checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
 dependencies = [
  "gix-command",
  "gix-config-value",
  "parking_lot",
- "rustix 1.1.3",
- "thiserror 2.0.17",
+ "rustix 1.1.4",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-protocol"
-version = "0.55.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c5dfd068789442c5709e702ef42d851765f2c09a11bf0a13749d24363f4d07"
+checksum = "978468bae4ea2df20c72db3b20d0bdb548a0c1090b85a83643b553e6e0e041f2"
 dependencies = [
  "bstr",
  "gix-credentials",
@@ -2061,26 +2336,26 @@ dependencies = [
  "gix-transport",
  "gix-utils",
  "maybe-async",
- "thiserror 2.0.17",
- "winnow 0.7.14",
+ "nonempty",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-quote"
-version = "0.6.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e912ec04b7b1566a85ad486db0cab6b9955e3e32bcd3c3a734542ab3af084c5b"
+checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
 dependencies = [
  "bstr",
+ "gix-error",
  "gix-utils",
- "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "gix-ref"
-version = "0.57.0"
+version = "0.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb33aa97006e37e9e83fde233569a66b02ed16fd4b0406cdf35834b06cf8a63"
+checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2093,62 +2368,64 @@ dependencies = [
  "gix-utils",
  "gix-validate",
  "memmap2",
- "thiserror 2.0.17",
- "winnow 0.7.14",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.35.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbba6ae5389f4021f73a2d62a4195aace7db1e8bb684b25521d3d685f57da02"
+checksum = "7bc36a4fb1a1540b59cf2da498783080743fa274b02a3f19ca444fc4015a9d4f"
 dependencies = [
  "bstr",
+ "gix-error",
  "gix-glob",
  "gix-hash",
  "gix-revision",
  "gix-validate",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-revision"
-version = "0.39.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91898c83b18c635696f7355d171cfa74a52f38022ff89581f567768935ebc4c8"
+checksum = "885075c3c21eb9c06e0be3b3728ba5932c04e1c1011dcee7c81801980e3e986f"
 dependencies = [
  "bstr",
  "gix-commitgraph",
  "gix-date",
+ "gix-error",
  "gix-hash",
  "gix-object",
  "gix-revwalk",
- "thiserror 2.0.17",
+ "nonempty",
 ]
 
 [[package]]
 name = "gix-revwalk"
-version = "0.25.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d063699278485016863d0d2bb0db7609fd2e8ba9a89379717bf06fd96949eb2"
+checksum = "8f11fe7ca2585193d3d70bbe0be175a2008d883a704cc7a55e454e113e689455"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
+ "gix-error",
  "gix-hash",
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.12.2"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
+checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -2156,21 +2433,22 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.7.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1c467fb9f7ec1d33613c2ea5482de514bcb84b8222a793cdc4c71955832356"
+checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
 dependencies = [
  "bstr",
  "gix-hash",
  "gix-lock",
- "thiserror 2.0.17",
+ "nonempty",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-status"
-version = "0.24.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0d94c685a831c679ca5454c22f350e8c233f50dcf377ca00d858bcba9696d2"
+checksum = "aec3293f75db1212f99217832cbc70c30faeb95cefc97c7f1a17fd3bcf13a72e"
 dependencies = [
  "bstr",
  "filetime",
@@ -2186,14 +2464,14 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-submodule"
-version = "0.24.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efee2a61198413d80de10028aa507344537827d776ade781760130721bec2419"
+checksum = "a7f9f594f7cbda0b38ba6b633b3e9a7b7901acdc5d27bc186a16633800cd1ac8"
 dependencies = [
  "bstr",
  "gix-config",
@@ -2201,14 +2479,14 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-tempfile"
-version = "20.0.1"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad89218e74850f42d364ed3877c7291f0474c8533502df91bb877ecc5cb0dd40"
+checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -2219,15 +2497,15 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.17"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e42a4c2583357721ba2d887916e78df504980f22f1182df06997ce197b89504"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-transport"
-version = "0.52.1"
+version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d4ed02a2ebe771a26111896ecda0b98b58ed35e1d9c0ccf07251c1abb4918d"
+checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
 dependencies = [
  "base64",
  "bstr",
@@ -2239,16 +2517,16 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-traverse"
-version = "0.51.1"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d052b83d1d1744be95ac6448ac02f95f370a8f6720e466be9ce57146e39f5280"
+checksum = "5062cca8f2977565bbaf666ec31dbdb9bc9d9293beb65f9bec52e6c1121b62a1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -2256,52 +2534,50 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-url"
-version = "0.34.0"
+version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff1996dfb9430b3699d89224c674169c1ae355eacc52bf30a03c0b8bffe73d9"
+checksum = "57d68e70e96da0e5f9c871f1566349e0fd0e1a20bb483c7f54af1dd0b85b4b29"
 dependencies = [
  "bstr",
- "gix-features",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
 dependencies = [
  "bstr",
  "fastrand",
+ "getrandom 0.4.3",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.10.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
 dependencies = [
  "bstr",
- "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "gix-worktree"
-version = "0.46.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfb7ce8cdbfe06117d335d1ad329351468d20331e0aafd108ceb647c1326aca"
+checksum = "92399ed66f259592050c6ed9dc80105e095a2f8e87e6b83d98aa2e21d8e27036"
 dependencies = [
  "bstr",
  "gix-attributes",
- "gix-features",
  "gix-fs",
  "gix-glob",
  "gix-hash",
@@ -2310,6 +2586,24 @@ dependencies = [
  "gix-object",
  "gix-path",
  "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f3a878c89a05470ad98c644b0015777c530da24854dd29e41fe4f41176840f"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2371,7 +2665,7 @@ dependencies = [
  "smallvec",
  "static_assertions",
  "target-spec",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -2410,7 +2704,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -2418,6 +2712,7 @@ name = "guppy-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "aho-corasick",
+ "anstream 0.6.21",
  "bit-set",
  "bit-vec",
  "camino",
@@ -2439,12 +2734,13 @@ dependencies = [
  "regex",
  "regex-automata",
  "regex-syntax",
- "rustix 0.38.44",
+ "rustix 1.1.4",
  "serde",
  "serde_core",
  "serde_json",
- "syn",
- "toml 1.1.4+spec-1.1.0",
+ "syn 2.0.106",
+ "syn 3.0.3",
+ "toml",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -2478,7 +2774,7 @@ dependencies = [
  "serde",
  "tabular",
  "target-spec",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "toml_edit 0.25.13+spec-1.1.0",
  "twox-hash",
 ]
@@ -2524,17 +2820,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2580,7 +2886,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2589,7 +2895,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2611,12 +2926,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-auth"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2734,7 +3068,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2802,15 +3136,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.4",
-]
-
-[[package]]
 name = "include_dir"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2874,11 +3199,11 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_executable"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+checksum = "82cb6a9f675da968c63b6208c641b9dca58fc0133ae53375736b1767b0cab8bd"
 dependencies = [
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2892,15 +3217,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -2922,28 +3238,40 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3000,15 +3328,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.8+1.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "7f7c568b25d7489bc3fb2988ed69ab111d2944d2f5fec3d5c987fe545ea97b50"
 dependencies = [
  "cc",
  "libc",
@@ -3039,21 +3367,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
-dependencies = [
- "bitflags",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libsqlite3-sys"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3080,7 +3397,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap",
  "escape8259",
@@ -3106,9 +3423,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -3143,26 +3460,26 @@ dependencies = [
 
 [[package]]
 name = "maybe-async"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3194,7 +3511,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3243,7 +3560,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3258,6 +3575,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "normalize-line-endings"
@@ -3313,7 +3636,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -3334,7 +3657,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
 ]
@@ -3345,7 +3668,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3378,7 +3701,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3396,7 +3719,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "block2",
  "libc",
  "objc2",
@@ -3409,7 +3732,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3420,7 +3743,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3432,7 +3755,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3576,7 +3899,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3604,13 +3927,13 @@ dependencies = [
 
 [[package]]
 name = "pasetors"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e1ed71dcdf863d9f66d9de86de714db38aedc2fcabc1a60207d1fde603e2d5"
+checksum = "e838401fb2873bad417e6a03179014c748746f67311cb7317ab14fc0881fa9f0"
 dependencies = [
  "ct-codecs",
  "ed25519-compact",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "orion",
  "p384",
  "rand_core 0.6.4",
@@ -3618,7 +3941,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "time",
  "zeroize",
@@ -3711,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -3760,18 +4083,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prodash"
-version = "30.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
@@ -3784,10 +4107,10 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.1",
  "lazy_static",
  "num-traits",
- "rand",
+ "rand 0.9.2",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3804,7 +4127,7 @@ checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3824,9 +4147,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3838,6 +4161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3845,6 +4174,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3874,6 +4214,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3919,14 +4265,14 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3936,9 +4282,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3947,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rfc6979"
@@ -3957,7 +4303,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3968,16 +4314,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "rusqlite"
-version = "0.38.0"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3994,9 +4340,9 @@ checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-stable-hash"
@@ -4006,14 +4352,13 @@ checksum = "781442f29170c5c93b7185ad559492601acdc71d5bb0706f5868094f45cfcd08"
 
 [[package]]
 name = "rustfix"
-version = "0.9.4"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864792a841a1d785ba91b8d2a75e1936b40bc517020c3c2958ac403b92e4f00a"
+checksum = "4ab550bf03e3428c98b8e0354800a18f366f1f5f25544b908463b4634374f34f"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror 2.0.17",
- "tracing",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4022,7 +4367,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4031,14 +4376,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4100,11 +4445,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4113,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4180,7 +4525,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4222,8 +4567,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4232,8 +4588,8 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
 dependencies = [
- "digest",
- "sha1",
+ "digest 0.10.7",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4243,8 +4599,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4285,12 +4652,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4334,7 +4707,7 @@ version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "anstyle-svg",
  "normalize-line-endings",
@@ -4349,7 +4722,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16569f53ca23a41bb6f62e0a5084aa1661f4814a67fa33696a79073e03a664af"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
 ]
 
 [[package]]
@@ -4460,6 +4833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4467,7 +4851,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4482,9 +4866,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -4492,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-spec"
@@ -4508,7 +4892,7 @@ dependencies = [
  "serde_json",
  "target-lexicon",
  "test-case",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -4525,25 +4909,25 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.59.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4564,7 +4948,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4575,7 +4959,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "test-case-core",
 ]
 
@@ -4600,11 +4984,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4615,18 +4999,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4707,21 +5091,6 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -4740,15 +5109,6 @@ name = "toml_datetime"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "toml_datetime"
@@ -4773,26 +5133,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.24.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
-dependencies = [
- "indexmap",
- "serde_core",
- "serde_spanned",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
+ "serde_core",
+ "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -4839,7 +5186,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4876,9 +5223,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4906,9 +5253,9 @@ checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -4918,9 +5265,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bom"
@@ -4930,9 +5277,9 @@ checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -5102,7 +5449,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -5351,7 +5698,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5392,7 +5739,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -5413,7 +5760,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5433,7 +5780,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -5462,14 +5809,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 [workspace.dependencies]
 ahash = "0.8.12"
 cargo_metadata = "0.23.1"
-cfg-expr = "0.20.7"
+cfg-expr = "0.20.9"
 datatest-stable = { version = "0.3.3", features = ["include-dir"] }
 guppy-workspace-hack = "0.1.0"
 iddqd = "0.3.17"
@@ -34,7 +34,7 @@ itertools = "0.15"
 [workspace.package]
 # Note: we commit to supporting the last 6 months of Rust releases. This
 # typically means N-4 to 5, unless a dependency requires a newer version.
-rust-version = "1.86"
+rust-version = "1.91"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ metadata`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html) format.
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) is **Rust 1.86**.
+The minimum supported Rust version (MSRV) is **Rust 1.91**.
 
 While a crate is pre-release status (0.x.x) it may have its MSRV bumped in a patch release. Once a crate has reached
 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/cargo-guppy/src/lib.rs
+++ b/cargo-guppy/src/lib.rs
@@ -465,10 +465,10 @@ pub fn cmd_subtree_size(options: &SubtreeSizeOptions) -> Result<()> {
 
                 if !subtree_package_set.contains(from_id) || nonunique_deps_set.contains(from_id) {
                     // if the from is from outside the subtree rooted at root_id, we ignore it
-                    if let Some(root_id) = root_id {
-                        if !dep_cache.depends_on(root_id, from_id)? {
-                            continue;
-                        }
+                    if let Some(root_id) = root_id
+                        && !dep_cache.depends_on(root_id, from_id)?
+                    {
+                        continue;
                     }
 
                     unique = false;

--- a/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_44b62fa-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['riscv32-wrs-vxworks', 'aarch64-unknown-uefi', 'powerpc64le-unknown-linux-musl']
+# platforms = ['riscv32gc-unknown-linux-gnu', 'aarch64-unknown-uefi', 'riscv32emc-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'fixture-manager'
 # version = '0.1.0'

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-unknown-hurd-gnu']
+# platforms = ['x86_64-unknown-illumos']
 # [[traversal-excludes.ids]]
 # name = 'cast'
 # version = '0.2.3'
@@ -229,7 +229,7 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.x86_64-unknown-hurd-gnu.dependencies]
+[target.x86_64-unknown-illumos.dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }
@@ -237,7 +237,7 @@ openssl-probe = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", default-features = false }
 termios = { version = "0.3", default-features = false }
 
-[target.x86_64-unknown-hurd-gnu.build-dependencies]
+[target.x86_64-unknown-illumos.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_78cb7e8-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['riscv64gc-unknown-hermit']
+# platforms = ['riscv64gc-unknown-netbsd']
 # [[traversal-excludes.ids]]
 # name = 'fnv'
 # version = '1.0.7'
@@ -61,7 +61,10 @@ proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
 
-[target.riscv64gc-unknown-hermit.dependencies]
+[target.riscv64gc-unknown-netbsd.dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.riscv64gc-unknown-netbsd.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-unknown-openbsd', 'riscv64imac-unknown-none-elf']
+# platforms = ['x86_64-unknown-none', 's390x-unknown-none-softfloat']
 # [[traversal-excludes.ids]]
 # name = 'commoncrypto-sys'
 # version = '0.2.0'
@@ -54,12 +54,6 @@ serde_json = { version = "1", features = ["raw_value"] }
 proc-macro2 = { version = "1" }
 quote = { version = "1" }
 syn = { version = "1", features = ["full", "visit"] }
-
-[target.x86_64-unknown-openbsd.dependencies]
-libc = { version = "0.2" }
-
-[target.x86_64-unknown-openbsd.build-dependencies]
-libc = { version = "0.2" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_869476c-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['mips-mti-none-elf', 'i686-unknown-uefi']
+# platforms = ['mips-unknown-linux-gnu', 'i686-uwp-windows-gnu']
 # [[traversal-excludes.ids]]
 # name = 'cc'
 # version = '1.0.61'
@@ -52,6 +52,12 @@ serde_json = { version = "1", features = ["raw_value", "std"] }
 proc-macro2 = { version = "1", features = ["proc-macro"] }
 quote = { version = "1", features = ["proc-macro"] }
 syn = { version = "1", features = ["clone-impls", "derive", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
+
+[target.mips-unknown-linux-gnu.dependencies]
+libc = { version = "0.2", features = ["std"] }
+
+[target.i686-uwp-windows-gnu.dependencies]
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['thumbv7a-nuttx-eabihf', 'aarch64-unknown-illumos']
+# platforms = ['thumbv7a-pc-windows-msvc', 'aarch64-unknown-illumos']
 # [[traversal-excludes.ids]]
 # name = 'diffus'
 # version = '0.9.1'
@@ -223,13 +223,17 @@ unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 version_check = { version = "0.9", default-features = false }
 
-[target.thumbv7a-nuttx-eabihf.dependencies]
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-openssl = { version = "0.10", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false }
-termios = { version = "0.3", default-features = false }
+[target.thumbv7a-pc-windows-msvc.dependencies]
+encode_unicode = { version = "0.3", features = ["std"] }
+fwdansi = { version = "1", default-features = false }
+miow = { version = "0.3", default-features = false }
+schannel = { version = "0.1", default-features = false }
+winapi = { version = "0.3", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "libloaderapi", "lmcons", "memoryapi", "minschannel", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntstatus", "processenv", "processthreadsapi", "profileapi", "psapi", "schannel", "securitybaseapi", "shellapi", "shlobj", "sspi", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "wincrypt", "winerror", "winnt", "winsock2", "winuser", "ws2def", "ws2ipdef", "ws2tcpip"] }
+winapi-util = { version = "0.1", default-features = false }
+
+[target.thumbv7a-pc-windows-msvc.build-dependencies]
+ctor = { version = "0.1", default-features = false }
+vcpkg = { version = "0.2", default-features = false }
 
 [target.aarch64-unknown-illumos.dependencies]
 foreign-types = { version = "0.3", default-features = false }

--- a/fixtures/guppy/hakari/metadata_guppy_c9b4f76-1.toml
+++ b/fixtures/guppy/hakari/metadata_guppy_c9b4f76-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['mipsel-unknown-linux-uclibc']
+# platforms = ['mipsisa32r6-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'crossbeam-epoch'
 # version = '0.8.2'
@@ -227,7 +227,7 @@ unicode-segmentation = { version = "1", default-features = false }
 unicode-xid-c65f7effa3be6d31 = { package = "unicode-xid", version = "0.1" }
 unicode-xid-6f8ce4dd05d13bba = { package = "unicode-xid", version = "0.2" }
 
-[target.mipsel-unknown-linux-uclibc.dependencies]
+[target.mipsisa32r6-unknown-linux-gnu.dependencies]
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 openssl = { version = "0.10", default-features = false }
@@ -237,7 +237,7 @@ ppv-lite86 = { version = "0.2", default-features = false, features = ["std"] }
 rand_chacha = { version = "0.2", default-features = false, features = ["std"] }
 termios = { version = "0.3", default-features = false }
 
-[target.mipsel-unknown-linux-uclibc.build-dependencies]
+[target.mipsisa32r6-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 
 ### END HAKARI SECTION

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-haiku'
+triple = 'x86_64-unknown-helenos'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'sparc64-unknown-linux-gnu'
+triple = 'thumbv4t-none-eabi'
 target-features = ['avx2', 'sse2', 'ssse3', 'xsaves']
 flags = ['flag-test']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-openbsd'
+triple = 'aarch64-unknown-redox'
 target-features = 'all'
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-4.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32-wrs-vxworks'
+triple = 'riscv32gc-unknown-linux-gnu'
 target-features = ['aes', 'avx', 'avx2', 'bmi2', 'xsaves']
 flags = ['test-flag']
 

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-6.toml
@@ -12,7 +12,7 @@ target-features = 'unknown'
 flags = ['cargo_web', 'foo']
 
 [metadata.target-platform]
-triple = 'x86_64-win7-windows-msvc'
+triple = 'x86_64-win7-windows-gnu'
 target-features = 'unknown'
 flags = ['abc', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_44b62fa-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_44b62fa-7.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv32em-unknown-none-elf'
+triple = 'riscv32i-unknown-none-elf'
 target-features = 'unknown'
 flags = ['foo']
 
 [metadata.target-platform]
-triple = 'mips64-openwrt-linux-musl'
+triple = 'mips64-unknown-linux-muslabi64'
 target-features = 'unknown'
 flags = ['abc', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv32imac-unknown-none-elf'
+triple = 'riscv32imafc-unknown-nuttx-elf'
 target-features = 'all'
 flags = ['bar']
 

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'riscv32imac-unknown-nuttx-elf'
+triple = 'riscv32imafc-unknown-nuttx-elf'
 target-features = 'all'
 
 [[metadata.features-only]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-musleabi'
+triple = 'armv7-unknown-linux-gnueabi'
 target-features = 'unknown'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'thumbv7a-pc-windows-msvc'
+triple = 'thumbv7em-none-eabi'
 target-features = ['avx2', 'fma', 'sse4.1', 'ssse3']
 flags = ['foo']
 

--- a/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_78cb7e8-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-none'
+triple = 'mipsisa64r6-unknown-linux-gnuabi64'
 target-features = 'unknown'
 flags = ['cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-0.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'arm64ec-pc-windows-msvc'
+triple = 'armeb-unknown-linux-gnueabi'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-redox'
+triple = 'x86_64-unknown-openbsd'
 target-features = ['rdrand', 'sse', 'ssse3', 'xsavec']
 flags = ['bar', 'flag-test']
 [[metadata.omitted-packages.ids]]
@@ -761,13 +761,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'redox_syscall'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'regex'
 version = '1.3.9'
 crates-io = true
@@ -1058,6 +1051,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[host-package]]
 name = 'pkg-config'
 version = '0.3.18'
 crates-io = true
@@ -1157,13 +1157,6 @@ version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = ['default']
-
-[[host-package]]
-name = 'vcpkg'
-version = '0.2.10'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[host-package]]
 name = 'version_check'

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 's390x-unknown-linux-gnu'
+triple = 'sparc64-unknown-helenos'
 target-features = ['xsaveopt']
 flags = ['test-flag']
 

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv6-unknown-netbsd-eabihf'
+triple = 'armv6-unknown-freebsd'
 target-features = 'unknown'
 flags = ['bar', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-4.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'sparcv9-sun-solaris'
+triple = 'thumbv6m-none-eabi'
 target-features = ['aes', 'bmi1', 'sse4.2', 'xsavec']
 flags = ['foo']
 [[metadata.omitted-packages.ids]]
@@ -402,7 +402,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
+optional-deps = ['getrandom_package']
 
 [[target-package]]
 name = 'rand_chacha'
@@ -493,13 +493,6 @@ features = []
 [[target-package]]
 name = 'terminal_size'
 version = '0.1.13'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'termios'
-version = '0.3.2'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/guppy/summaries/metadata_guppy_869476c-6.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_869476c-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'm68k-unknown-none-elf'
+triple = 'mips-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['flag-test']
 
@@ -327,6 +327,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'libc'
+version = '0.2.79'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
 name = 'num-traits'
 version = '0.2.12'
 crates-io = true
@@ -353,7 +360,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package']
+optional-deps = ['getrandom_package', 'libc']
 
 [[target-package]]
 name = 'rand_chacha'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-managarm-mlibc'
+triple = 'x86_64-unknown-linux-ohos'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'assert_matches'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-3.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-3.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'thumbv7em-nuttx-eabi'
+triple = 'thumbv7m-none-eabi'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'riscv32imc-unknown-nuttx-elf'
+triple = 'riscv64a23-unknown-linux-gnu'
 target-features = 'all'
 flags = ['abc']
 [[metadata.omitted-packages.ids]]
@@ -1218,13 +1218,6 @@ version = '0.1.21'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[host-package]]
-name = 'libc'
-version = '0.2.79'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[host-package]]
 name = 'pkg-config'

--- a/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
+++ b/fixtures/guppy/summaries/metadata_guppy_c9b4f76-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-l4re-uclibc'
+triple = 'x86_64-unknown-linux-gnu'
 target-features = ['sse4.1', 'sse4.2', 'xsavec']
 
 [metadata.target-platform]

--- a/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armv7-linux-androideabi']
+# platforms = ['armv6k-nintendo-3ds']
 # [[traversal-excludes.ids]]
 # name = 'slab'
 # version = '0.4.9'
@@ -135,11 +135,11 @@ tracing-core = { version = "0.1", default-features = false, features = ["once_ce
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 want = { version = "0.3", default-features = false }
 
-[target.armv7-linux-androideabi.dependencies]
+[target.armv6k-nintendo-3ds.dependencies]
 libc = { version = "0.2", features = ["std"] }
 signal-hook-registry = { version = "1", default-features = false }
 
-[target.armv7-linux-androideabi.build-dependencies]
+[target.armv6k-nintendo-3ds.build-dependencies]
 libc = { version = "0.2", features = ["std"] }
 signal-hook-registry = { version = "1", default-features = false }
 

--- a/fixtures/large/hakari/hyper_util_7afb1ed-1.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['loongarch64-unknown-linux-musl', 'aarch64-apple-tvos']
+# platforms = ['loongarch64-unknown-linux-ohos', 'aarch64-apple-tvos-sim']
 # [[traversal-excludes.ids]]
 # name = 'async-stream'
 # version = '0.3.5'

--- a/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/hakari/hyper_util_7afb1ed-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64-unknown-linux-ohos']
+# platforms = ['aarch64-unknown-linux-pauthtest']
 # [[traversal-excludes.ids]]
 # name = 'http-body-util'
 # version = '0.1.2'
@@ -119,7 +119,7 @@ try-lock = { version = "0.2", default-features = false }
 unicode-ident = { version = "1", default-features = false }
 want = { version = "0.3", default-features = false }
 
-[target.aarch64-unknown-linux-ohos.dependencies]
+[target.aarch64-unknown-linux-pauthtest.dependencies]
 ipnetwork = { version = "0.20" }
 libc = { version = "0.2" }
 no-std-net = { version = "0.6", default-features = false, features = ["std"] }
@@ -129,7 +129,7 @@ pnet_sys = { version = "0.35", default-features = false }
 serde = { version = "1" }
 signal-hook-registry = { version = "1", default-features = false }
 
-[target.aarch64-unknown-linux-ohos.build-dependencies]
+[target.aarch64-unknown-linux-pauthtest.build-dependencies]
 ipnetwork = { version = "0.20" }
 libc = { version = "0.2" }
 no-std-net = { version = "0.6", default-features = false, features = ["std"] }

--- a/fixtures/large/hakari/metadata_libra-1.toml
+++ b/fixtures/large/hakari/metadata_libra-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64_be-unknown-linux-gnu_ilp32', 'armv7a-nuttx-eabihf', 'armv7r-none-eabi']
+# platforms = ['aarch64_be-unknown-linux-musl', 'armv7a-nuttx-eabi', 'armv7k-apple-watchos']
 # [[traversal-excludes.ids]]
 # name = 'benchmark'
 # version = '0.1.0'
@@ -481,7 +481,7 @@ version_check = { version = "0.1", default-features = false }
 walkdir = { version = "2", default-features = false }
 which = { version = "2", default-features = false }
 
-[target.aarch64_be-unknown-linux-gnu_ilp32.dependencies]
+[target.aarch64_be-unknown-linux-musl.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -493,13 +493,13 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.aarch64_be-unknown-linux-gnu_ilp32.build-dependencies]
+[target.aarch64_be-unknown-linux-musl.build-dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
 
-[target.armv7a-nuttx-eabihf.dependencies]
+[target.armv7a-nuttx-eabi.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
@@ -511,20 +511,25 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.armv7a-nuttx-eabihf.build-dependencies]
+[target.armv7a-nuttx-eabi.build-dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
 
-[target.armv7r-none-eabi.dependencies]
+[target.armv7k-apple-watchos.dependencies]
 ansi_term = { version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
+nix = { version = "0.14", default-features = false }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", features = ["simd", "std"] }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
-[target.armv7r-none-eabi.build-dependencies]
+[target.armv7k-apple-watchos.build-dependencies]
 c2-chacha = { version = "0.2", default-features = false, features = ["lazy_static", "simd", "std"] }
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 ppv-lite86 = { version = "0.2", features = ["simd", "std"] }

--- a/fixtures/large/hakari/metadata_libra-3.toml
+++ b/fixtures/large/hakari/metadata_libra-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['riscv32imafc-esp-espidf', 'i686-pc-windows-gnullvm']
+# platforms = ['riscv32imc-unknown-nuttx-elf', 'i686-pc-windows-gnullvm']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -111,10 +111,10 @@ tokio-sync = { version = "0.2.0-alpha.6", default-features = false, features = [
 toml = { version = "0.5" }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 
-[target.riscv32imafc-esp-espidf.dependencies]
+[target.riscv32imc-unknown-nuttx-elf.dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 
-[target.riscv32imafc-esp-espidf.build-dependencies]
+[target.riscv32imc-unknown-nuttx-elf.build-dependencies]
 lazy_static = { version = "1", default-features = false, features = ["spin", "spin_no_std"] }
 
 [target.i686-pc-windows-gnullvm.dependencies]

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['thumbv7m-none-eabi', 'powerpc64le-unknown-linux-musl', 'powerpc-unknown-openbsd']
+# platforms = ['thumbv7neon-linux-androideabi', 'riscv32emc-unknown-none-elf', 'powerpc64-ibm-aix']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -518,7 +518,41 @@ version_check-c65f7effa3be6d31 = { package = "version_check", version = "0.1", d
 which = { version = "3", default-features = false }
 zeroize_derive = { version = "1", default-features = false }
 
-[target.thumbv7m-none-eabi.dependencies]
+[target.thumbv7neon-linux-androideabi.dependencies]
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+async-compression = { version = "0.3", default-features = false, features = ["gzip", "stream"] }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
+crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6" }
+encoding_rs = { version = "0.8", default-features = false }
+get_if_addrs-sys = { version = "0.1", default-features = false }
+hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20" }
+hyper-tls = { version = "0.4", default-features = false }
+mio-uds = { version = "0.6", default-features = false }
+native-tls = { version = "0.2", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration"] }
+rustls-native-certs = { version = "0.3", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
+tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-tls = { version = "0.3", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1" }
+
+[target.thumbv7neon-linux-androideabi.build-dependencies]
+ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
+c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+gcc = { version = "0.3", default-features = false }
+ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+
+[target.riscv32emc-unknown-none-elf.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
@@ -534,13 +568,13 @@ rustls-native-certs = { version = "0.3", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
 
-[target.thumbv7m-none-eabi.build-dependencies]
+[target.riscv32emc-unknown-none-elf.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 
-[target.powerpc64le-unknown-linux-musl.dependencies]
+[target.powerpc64-ibm-aix.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
@@ -566,39 +600,7 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1" }
 
-[target.powerpc64le-unknown-linux-musl.build-dependencies]
-ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
-c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-
-[target.powerpc-unknown-openbsd.dependencies]
-ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
-async-compression = { version = "0.3", default-features = false, features = ["gzip", "stream"] }
-c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
-crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6" }
-encoding_rs = { version = "0.8", default-features = false }
-hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20" }
-hyper-tls = { version = "0.4", default-features = false }
-mio-uds = { version = "0.6", default-features = false }
-native-tls = { version = "0.2", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration"] }
-rustls-native-certs = { version = "0.3", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
-tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-tls = { version = "0.3", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1" }
-
-[target.powerpc-unknown-openbsd.build-dependencies]
+[target.powerpc64-ibm-aix.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['powerpc64-unknown-linux-gnu', 'powerpc64le-unknown-freebsd']
+# platforms = ['powerpc64-wrs-vxworks', 'riscv32e-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'backtrace'
 # version = '0.3.45'
@@ -144,16 +144,16 @@ toml = { version = "0.5" }
 ureq = { version = "0.11", features = ["cookie", "cookies", "json", "rustls", "serde_json", "tls", "webpki", "webpki-roots"] }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 
-[target.powerpc64-unknown-linux-gnu.dependencies]
+[target.powerpc64-wrs-vxworks.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.powerpc64-unknown-linux-gnu.build-dependencies]
+[target.powerpc64-wrs-vxworks.build-dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.powerpc64le-unknown-freebsd.dependencies]
+[target.riscv32e-unknown-none-elf.dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
-[target.powerpc64le-unknown-freebsd.build-dependencies]
+[target.riscv32e-unknown-none-elf.build-dependencies]
 hyper = { version = "0.13", features = ["net2", "runtime", "stream", "tcp"] }
 
 ### END HAKARI SECTION

--- a/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
+++ b/fixtures/large/hakari/metadata_libra_9ffd93b-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['mipsel-unknown-linux-gnu', 'aarch64-unknown-trusty', 'riscv32gc-unknown-linux-gnu']
+# platforms = ['mipsel-unknown-netbsd', 'aarch64-unknown-uefi', 'riscv32ima-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'libra-crypto-derive'
 # version = '0.1.0'
@@ -536,7 +536,7 @@ version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", d
 which = { version = "3", default-features = false }
 zeroize_derive = { version = "1", default-features = false }
 
-[target.mipsel-unknown-linux-gnu.dependencies]
+[target.mipsel-unknown-netbsd.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
@@ -562,13 +562,13 @@ tokio-uds = { version = "0.2", default-features = false }
 utf8parse = { version = "0.1", default-features = false }
 void = { version = "1", features = ["std"] }
 
-[target.mipsel-unknown-linux-gnu.build-dependencies]
+[target.mipsel-unknown-netbsd.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 
-[target.aarch64-unknown-trusty.dependencies]
+[target.aarch64-unknown-uefi.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
@@ -584,39 +584,29 @@ rustls-native-certs = { version = "0.3", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
 
-[target.aarch64-unknown-trusty.build-dependencies]
+[target.aarch64-unknown-uefi.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 
-[target.riscv32gc-unknown-linux-gnu.dependencies]
+[target.riscv32ima-unknown-none-elf.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 async-compression = { version = "0.3", default-features = false, features = ["bytes", "flate2", "gzip", "stream"] }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
-crossbeam-utils = { version = "0.6", features = ["lazy_static", "std"] }
 encoding_rs = { version = "0.8", default-features = false }
 hyper-rustls-56bd22fc3884b12 = { package = "hyper-rustls", version = "0.20", features = ["ct-logs", "native-tokio", "rustls-native-certs", "tokio-runtime"] }
 hyper-tls = { version = "0.4", default-features = false }
-mio-uds = { version = "0.6", default-features = false }
 native-tls = { version = "0.2", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
 openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-9067fe90e8c1f593 = { package = "rustls", version = "0.17", features = ["dangerous_configuration", "log", "logging"] }
 rustls-native-certs = { version = "0.3", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-594e8ee84c453af0 = { package = "tokio-rustls", version = "0.13", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
 tokio-tls = { version = "0.3", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1", features = ["std"] }
 
-[target.riscv32gc-unknown-linux-gnu.build-dependencies]
+[target.riscv32ima-unknown-none-elf.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }

--- a/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv5te-unknown-linux-uclibceabi']
+# platforms = ['armv6-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'arc-swap'
 # version = '0.4.4'
@@ -75,7 +75,7 @@ crossbeam-channel-468e82937335b1c9 = { package = "crossbeam-channel", version = 
 crossbeam-channel-9fbad63c4bcf4a8f = { package = "crossbeam-channel", version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8" }
-crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2" }
+crossbeam-queue = { version = "0.2" }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6" }
 crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7" }
 crunchy = { version = "0.2" }
@@ -433,7 +433,7 @@ crossbeam-channel-468e82937335b1c9 = { package = "crossbeam-channel", version = 
 crossbeam-channel-9fbad63c4bcf4a8f = { package = "crossbeam-channel", version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8" }
-crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2" }
+crossbeam-queue = { version = "0.2" }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6" }
 crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7" }
 crunchy = { version = "0.2" }
@@ -774,58 +774,36 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git" }
 
-[target.armv5te-unknown-linux-uclibceabi.dependencies]
+[target.armv6-none-eabi.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 encoding_rs = { version = "0.8", default-features = false }
 futures-util = { version = "0.3" }
 hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2" }
-mio-uds = { version = "0.6", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls = { version = "0.16", default-features = false, features = ["dangerous_configuration"] }
 rustls-native-certs = { version = "0.1", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
 unicase = { version = "2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
-void = { version = "1" }
 
-[target.armv5te-unknown-linux-uclibceabi.build-dependencies]
+[target.armv6-none-eabi.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
-crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 encoding_rs = { version = "0.8", default-features = false }
 futures-util = { version = "0.3" }
 hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2" }
-mio-uds = { version = "0.6", default-features = false }
-nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
-nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls = { version = "0.16", default-features = false, features = ["dangerous_configuration"] }
 rustls-native-certs = { version = "0.1", default-features = false }
-signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
-tokio-signal = { version = "0.2", default-features = false }
-tokio-uds = { version = "0.2", default-features = false }
 unicase = { version = "2", default-features = false }
-utf8parse = { version = "0.1", default-features = false }
 version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
-void = { version = "1" }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['mipsel-unknown-none']
+# platforms = ['mipsisa64r6-unknown-linux-gnuabi64']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]
@@ -91,7 +91,7 @@ crossbeam-channel-468e82937335b1c9 = { package = "crossbeam-channel", version = 
 crossbeam-channel-9fbad63c4bcf4a8f = { package = "crossbeam-channel", version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.2", features = ["std"] }
+crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
@@ -449,7 +449,7 @@ crossbeam-channel-468e82937335b1c9 = { package = "crossbeam-channel", version = 
 crossbeam-channel-9fbad63c4bcf4a8f = { package = "crossbeam-channel", version = "0.4", default-features = false }
 crossbeam-deque = { version = "0.7", default-features = false }
 crossbeam-epoch = { version = "0.8", features = ["lazy_static", "std"] }
-crossbeam-queue = { version = "0.2", features = ["std"] }
+crossbeam-queue-6f8ce4dd05d13bba = { package = "crossbeam-queue", version = "0.2", features = ["std"] }
 crossbeam-utils-3b31131e45eafb45 = { package = "crossbeam-utils", version = "0.6", features = ["lazy_static", "std"] }
 crossbeam-utils-ca01ad9e24f5d932 = { package = "crossbeam-utils", version = "0.7", features = ["lazy_static", "std"] }
 crunchy = { version = "0.2", features = ["limit_128"] }
@@ -786,32 +786,52 @@ zeroize = { version = "1", default-features = false, features = ["alloc", "zeroi
 zeroize_derive = { version = "1", default-features = false }
 zstd-sys = { git = "https://github.com/gyscos/zstd-rs.git", features = ["legacy"] }
 
-[target.mipsel-unknown-none.dependencies]
+[target.mipsisa64r6-unknown-linux-gnuabi64.dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 encoding_rs = { version = "0.8", default-features = false }
 hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19", features = ["ct-logs", "rustls-native-certs", "tokio-runtime"] }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", features = ["rev-mappings"] }
+mio-uds = { version = "0.6", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.1", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
 unicase = { version = "2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
+void = { version = "1", features = ["std"] }
 
-[target.mipsel-unknown-none.build-dependencies]
+[target.mipsisa64r6-unknown-linux-gnuabi64.build-dependencies]
 ansi_term-a6292c17cd707f01 = { package = "ansi_term", version = "0.11", default-features = false }
 c2-chacha = { version = "0.2", default-features = false, features = ["simd", "std"] }
+crossbeam-queue-c65f7effa3be6d31 = { package = "crossbeam-queue", version = "0.1", default-features = false }
 encoding_rs = { version = "0.8", default-features = false }
 hyper-rustls-cdcf2f9584511fe6 = { package = "hyper-rustls", version = "0.19", features = ["ct-logs", "rustls-native-certs", "tokio-runtime"] }
 mime = { version = "0.3", default-features = false }
 mime_guess = { version = "2", features = ["rev-mappings"] }
+mio-uds = { version = "0.6", default-features = false }
+nix-582f2526e08bb6a0 = { package = "nix", version = "0.14", default-features = false }
+nix-9067fe90e8c1f593 = { package = "nix", version = "0.17", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
 ppv-lite86 = { version = "0.2", default-features = false, features = ["simd", "std"] }
 rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.1", default-features = false }
+signal-hook-registry = { version = "1", default-features = false }
 tokio-rustls-5ef9efb8ec2df382 = { package = "tokio-rustls", version = "0.12", default-features = false }
+tokio-signal = { version = "0.2", default-features = false }
+tokio-uds = { version = "0.2", default-features = false }
 unicase = { version = "2", default-features = false }
+utf8parse = { version = "0.1", default-features = false }
 version_check-274715c4dabd11b0 = { package = "version_check", version = "0.9", default-features = false }
+void = { version = "1", features = ["std"] }
 
 ### END HAKARI SECTION
 

--- a/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/hakari/metadata_libra_f0091a4-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['loongarch64-unknown-linux-ohos']
+# platforms = ['loongarch64-unknown-none']
 # [[traversal-excludes.ids]]
 # name = 'rand_hc'
 # version = '0.1.0'
@@ -127,16 +127,14 @@ ureq = { version = "0.11", features = ["json"] }
 x25519-dalek = { git = "https://github.com/calibra/x25519-dalek.git", branch = "fiat", default-features = false, features = ["fiat_u64_backend", "std", "u64_backend"] }
 zeroize = { version = "1", default-features = false, features = ["alloc", "zeroize_derive"] }
 
-[target.loongarch64-unknown-linux-ohos.dependencies]
+[target.loongarch64-unknown-none.dependencies]
 futures-util = { version = "0.3" }
 hyper = { version = "0.13" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 
-[target.loongarch64-unknown-linux-ohos.build-dependencies]
+[target.loongarch64-unknown-none.build-dependencies]
 futures-util = { version = "0.3" }
 hyper = { version = "0.13" }
-libc = { version = "0.2", default-features = false, features = ["extra_traits"] }
 rustls = { version = "0.16", features = ["dangerous_configuration"] }
 
 ### END HAKARI SECTION

--- a/fixtures/large/hakari/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['aarch64-unknown-freebsd', 'loongarch64-unknown-none-softfloat', 'arm64e-apple-darwin']
+# platforms = ['aarch64-unknown-freebsd', 'm68k-unknown-none-elf', 'arm64e-apple-darwin']
 # [[traversal-excludes.ids]]
 # name = 'trust-dns-proto'
 # version = '0.22.0'
@@ -1131,7 +1131,7 @@ unicode-bom = { version = "2", default-features = false }
 webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
 xattr = { version = "1" }
 
-[target.loongarch64-unknown-none-softfloat.dependencies]
+[target.m68k-unknown-none-elf.dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
@@ -1151,7 +1151,7 @@ polling = { version = "2" }
 rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
 waker-fn = { version = "1", default-features = false }
 
-[target.loongarch64-unknown-none-softfloat.build-dependencies]
+[target.m68k-unknown-none-elf.build-dependencies]
 async-executor = { version = "1", default-features = false }
 async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }

--- a/fixtures/large/hakari/mnemos_b3b4da9-3.toml
+++ b/fixtures/large/hakari/mnemos_b3b4da9-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['x86_64-unikraft-linux-musl', 'riscv64imac-unknown-nuttx-elf']
+# platforms = ['x86_64-unknown-dragonfly', 'sparc-unknown-linux-gnu']
 # [[traversal-excludes.ids]]
 # name = 'csv-core'
 # version = '0.1.10'
@@ -970,19 +970,20 @@ zstd-safe-cdf1610d3e1514e9 = { package = "zstd-safe", version = "5", default-fea
 zstd-safe-a490c3000a992113 = { package = "zstd-safe", version = "6", default-features = false, features = ["arrays", "legacy", "std", "zdict_builder", "zstdmt"] }
 zstd-sys = { version = "2", default-features = false, features = ["legacy", "std", "zdict_builder", "zstdmt"] }
 
-[target.x86_64-unikraft-linux-musl.dependencies]
+[target.x86_64-unknown-dragonfly.dependencies]
 async-global-executor = { version = "2" }
 async-io = { version = "1", default-features = false }
 async-process = { version = "1", default-features = false }
 async-task = { version = "4" }
 atomic-waker = { version = "1", default-features = false }
 blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+errno-dragonfly = { version = "0.1", default-features = false }
 foreign-types = { version = "0.3", default-features = false }
 foreign-types-shared = { version = "0.1", default-features = false }
 futures-lite = { version = "1" }
 iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
 libc = { version = "0.2", default-features = false, features = ["use_std"] }
-linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 lock_api = { version = "0.4" }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
@@ -999,7 +1000,7 @@ spin-274715c4dabd11b0 = { package = "spin", version = "0.9" }
 static_assertions = { version = "1", default-features = false }
 waker-fn = { version = "1", default-features = false }
 
-[target.x86_64-unikraft-linux-musl.build-dependencies]
+[target.x86_64-unknown-dragonfly.build-dependencies]
 ahash = { version = "0.8" }
 arc-swap = { version = "1", default-features = false }
 async-global-executor = { version = "2" }
@@ -1027,6 +1028,190 @@ ed25519-compact = { version = "2", default-features = false, features = ["random
 elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
 encoding_rs = { version = "0.8" }
 enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
+errno-dragonfly = { version = "0.1", default-features = false }
+faster-hex = { version = "0.8" }
+fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
+ff = { version = "0.13", default-features = false, features = ["alloc"] }
+fiat-crypto = { version = "0.1", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+git2 = { version = "0.17" }
+git2-curl = { version = "0.18", default-features = false }
+gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-actor = { version = "0.20", default-features = false }
+gix-attributes = { version = "0.12", default-features = false }
+gix-bitmap = { version = "0.2", default-features = false }
+gix-chunk = { version = "0.4", default-features = false }
+gix-command = { version = "0.2", default-features = false }
+gix-config = { version = "0.22", default-features = false }
+gix-config-value = { version = "0.12", default-features = false }
+gix-credentials = { version = "0.14", default-features = false }
+gix-date = { version = "0.5", default-features = false }
+gix-diff = { version = "0.29", default-features = false }
+gix-discover = { version = "0.18", default-features = false }
+gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
+gix-fs = { version = "0.1", default-features = false }
+gix-glob = { version = "0.7", default-features = false }
+gix-hash = { version = "0.11", default-features = false }
+gix-hashtable = { version = "0.2", default-features = false }
+gix-ignore = { version = "0.2", default-features = false }
+gix-index = { version = "0.16", default-features = false }
+gix-lock = { version = "5", default-features = false }
+gix-mailmap = { version = "0.12", default-features = false }
+gix-object = { version = "0.29", default-features = false }
+gix-odb = { version = "0.45", default-features = false }
+gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
+gix-packetline = { version = "0.16", features = ["blocking-io"] }
+gix-path = { version = "0.8", default-features = false }
+gix-prompt = { version = "0.5", default-features = false }
+gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
+gix-quote = { version = "0.4", default-features = false }
+gix-ref = { version = "0.29", default-features = false }
+gix-refspec = { version = "0.10", default-features = false }
+gix-revision = { version = "0.13", default-features = false }
+gix-sec = { version = "0.8", default-features = false }
+gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
+gix-trace = { version = "0.1" }
+gix-transport = { version = "0.31", features = ["http-client-curl"] }
+gix-traverse = { version = "0.25", default-features = false }
+gix-url = { version = "0.18", default-features = false }
+gix-utils = { version = "0.1", default-features = false }
+gix-validate = { version = "0.7", default-features = false }
+gix-worktree = { version = "0.17", default-features = false }
+glob = { version = "0.3", default-features = false }
+globset = { version = "0.4" }
+group = { version = "0.13", default-features = false, features = ["alloc"] }
+hkdf = { version = "0.12", default-features = false }
+hostname = { version = "0.3" }
+http-auth = { version = "0.1", default-features = false }
+hyper-rustls = { version = "0.24", default-features = false }
+hyper-tls = { version = "0.5", default-features = false }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
+ignore = { version = "0.4", default-features = false }
+im-rc = { version = "15", default-features = false }
+imara-diff = { version = "0.1" }
+io-close = { version = "0.3", default-features = false }
+ipnet = { version = "2" }
+is-docker = { version = "0.2", default-features = false }
+is-wsl = { version = "0.4", default-features = false }
+itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
+kstring = { version = "2" }
+lazycell = { version = "1", default-features = false }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
+libnghttp2-sys = { version = "0.1", default-features = false }
+libssh2-sys = { version = "0.3", default-features = false }
+linked-hash-map = { version = "0.5", default-features = false }
+lru-cache = { version = "0.1", default-features = false }
+match_cfg = { version = "0.1" }
+maybe-async = { version = "0.2", features = ["is_sync"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+num_threads = { version = "0.1", default-features = false }
+opener = { version = "0.5", default-features = false }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-macros = { version = "0.1", default-features = false }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-src = { version = "111" }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+ordered-float = { version = "2" }
+orion = { version = "0.17", default-features = false }
+os_info = { version = "3" }
+p384 = { version = "0.13" }
+pasetors = { version = "0.6", features = ["serde", "v3"] }
+pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
+pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
+polling = { version = "2" }
+primeorder = { version = "0.13", default-features = false }
+prodash = { version = "23", default-features = false, features = ["progress-tree"] }
+rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
+resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
+rfc6979 = { version = "0.4", default-features = false }
+rustfix = { version = "0.6", default-features = false }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
+rustls-pemfile = { version = "1", default-features = false }
+sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
+serde-value = { version = "0.7", default-features = false }
+sha1_smol = { version = "1", default-features = false }
+shell-escape = { version = "0.1", default-features = false }
+signal-hook = { version = "0.3" }
+signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
+signal-hook-registry = { version = "1", default-features = false }
+signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
+sized-chunks = { version = "0.6" }
+spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
+spin-274715c4dabd11b0 = { package = "spin", version = "0.9" }
+spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
+tokio-rustls = { version = "0.24" }
+trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.22" }
+unicode-bom = { version = "2", default-features = false }
+webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
+xattr = { version = "1" }
+
+[target.sparc-unknown-linux-gnu.dependencies]
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-process = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+blocking = { version = "1", default-features = false }
+errno = { version = "0.3", default-features = false }
+foreign-types = { version = "0.3", default-features = false }
+foreign-types-shared = { version = "0.1", default-features = false }
+futures-lite = { version = "1" }
+iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
+libc = { version = "0.2", default-features = false, features = ["use_std"] }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
+linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
+memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
+nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
+nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
+openssl = { version = "0.10", features = ["vendored"] }
+openssl-probe = { version = "0.1", default-features = false }
+openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
+parking = { version = "2", default-features = false }
+polling = { version = "2" }
+rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
+signal-hook = { version = "0.3" }
+signal-hook-registry = { version = "1", default-features = false }
+static_assertions = { version = "1", default-features = false }
+waker-fn = { version = "1", default-features = false }
+
+[target.sparc-unknown-linux-gnu.build-dependencies]
+ahash = { version = "0.8" }
+arc-swap = { version = "1", default-features = false }
+async-global-executor = { version = "2" }
+async-io = { version = "1", default-features = false }
+async-task = { version = "4" }
+atomic-waker = { version = "1", default-features = false }
+base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
+bitmaps = { version = "2" }
+blocking = { version = "1", default-features = false }
+bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
+btoi = { version = "0.4" }
+bytesize = { version = "1" }
+cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
+cargo-util = { version = "0.2", default-features = false }
+clru = { version = "0.6", default-features = false }
+crates-io = { version = "0.37", default-features = false }
+crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
+ct-codecs = { version = "1", default-features = false }
+curl = { version = "0.4", features = ["http2"] }
+curl-sys = { version = "0.4", features = ["http2"] }
+der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
+ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
+ed25519-compact = { version = "2", default-features = false, features = ["random"] }
+elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
+encoding_rs = { version = "0.8" }
+enum-as-inner = { version = "0.5", default-features = false }
+errno = { version = "0.3", default-features = false }
 faster-hex = { version = "0.8" }
 fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
 ff = { version = "0.13", default-features = false, features = ["alloc"] }
@@ -1102,6 +1287,9 @@ libc = { version = "0.2", default-features = false, features = ["use_std"] }
 libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
 libnghttp2-sys = { version = "0.1", default-features = false }
 libssh2-sys = { version = "0.3", default-features = false }
+libudev-6f8ce4dd05d13bba = { package = "libudev", version = "0.2", default-features = false }
+libudev-468e82937335b1c9 = { package = "libudev", version = "0.3", default-features = false }
+libudev-sys = { version = "0.1", default-features = false }
 linked-hash-map = { version = "0.5", default-features = false }
 linux-raw-sys-468e82937335b1c9 = { package = "linux-raw-sys", version = "0.3", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
 linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["errno", "general", "ioctl", "no_std"] }
@@ -1111,182 +1299,6 @@ maybe-async = { version = "0.2", features = ["is_sync"] }
 memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 neli = { version = "0.6" }
 neli-proc-macros = { version = "0.1", default-features = false }
-nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
-num_threads = { version = "0.1", default-features = false }
-opener = { version = "0.5", default-features = false }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-macros = { version = "0.1", default-features = false }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-src = { version = "111" }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-ordered-float = { version = "2" }
-orion = { version = "0.17", default-features = false }
-os_info = { version = "3" }
-p384 = { version = "0.13" }
-pasetors = { version = "0.6", features = ["serde", "v3"] }
-pem-rfc7468 = { version = "0.7", default-features = false, features = ["alloc"] }
-pkcs8 = { version = "0.10", default-features = false, features = ["pem", "std"] }
-polling = { version = "2" }
-primeorder = { version = "0.13", default-features = false }
-prodash = { version = "23", default-features = false, features = ["progress-tree"] }
-rand_chacha-6f8ce4dd05d13bba = { package = "rand_chacha", version = "0.2", default-features = false, features = ["std"] }
-resolv-conf = { version = "0.7", default-features = false, features = ["system"] }
-rfc6979 = { version = "0.4", default-features = false }
-rustfix = { version = "0.6", default-features = false }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["termios"] }
-rustls-pemfile = { version = "1", default-features = false }
-sec1 = { version = "0.7", features = ["pem", "std", "subtle"] }
-serde-value = { version = "0.7", default-features = false }
-sha1_smol = { version = "1", default-features = false }
-shell-escape = { version = "0.1", default-features = false }
-signal-hook = { version = "0.3" }
-signal-hook-mio = { version = "0.2", default-features = false, features = ["support-v0_8"] }
-signal-hook-registry = { version = "1", default-features = false }
-signature = { version = "2", default-features = false, features = ["digest", "rand_core", "std"] }
-sized-chunks = { version = "0.6" }
-spin-d8f496e17d97b5cb = { package = "spin", version = "0.5", default-features = false }
-spin-274715c4dabd11b0 = { package = "spin", version = "0.9" }
-spki = { version = "0.7", default-features = false, features = ["pem", "std"] }
-tokio-rustls = { version = "0.24" }
-trust-dns-proto = { version = "0.22", default-features = false, features = ["tokio-runtime"] }
-trust-dns-resolver = { version = "0.22" }
-unicode-bom = { version = "2", default-features = false }
-webpki-roots-2ffb4c3fe830441c = { package = "webpki-roots", version = "0.25", default-features = false }
-xattr = { version = "1" }
-
-[target.riscv64imac-unknown-nuttx-elf.dependencies]
-async-global-executor = { version = "2" }
-async-io = { version = "1", default-features = false }
-async-process = { version = "1", default-features = false }
-async-task = { version = "4" }
-atomic-waker = { version = "1", default-features = false }
-blocking = { version = "1", default-features = false }
-errno = { version = "0.3", default-features = false }
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-futures-lite = { version = "1" }
-iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
-libc = { version = "0.2", default-features = false, features = ["use_std"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
-nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
-nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
-openssl = { version = "0.10", features = ["vendored"] }
-openssl-probe = { version = "0.1", default-features = false }
-openssl-sys = { version = "0.9", default-features = false, features = ["vendored"] }
-parking = { version = "2", default-features = false }
-polling = { version = "2" }
-rustix-d736d0ac4424f0f1 = { package = "rustix", version = "0.37", features = ["fs", "termios"] }
-signal-hook = { version = "0.3" }
-signal-hook-registry = { version = "1", default-features = false }
-static_assertions = { version = "1", default-features = false }
-waker-fn = { version = "1", default-features = false }
-
-[target.riscv64imac-unknown-nuttx-elf.build-dependencies]
-ahash = { version = "0.8" }
-arc-swap = { version = "1", default-features = false }
-async-global-executor = { version = "2" }
-async-io = { version = "1", default-features = false }
-async-task = { version = "4" }
-atomic-waker = { version = "1", default-features = false }
-base16ct = { version = "0.2", default-features = false, features = ["alloc"] }
-bitmaps = { version = "2" }
-blocking = { version = "1", default-features = false }
-bstr-dff4ba8e3ae991db = { package = "bstr", version = "1" }
-btoi = { version = "0.4" }
-bytesize = { version = "1" }
-cargo = { version = "0.72", default-features = false, features = ["vendored-openssl"] }
-cargo-util = { version = "0.2", default-features = false }
-clru = { version = "0.6", default-features = false }
-crates-io = { version = "0.37", default-features = false }
-crypto-bigint = { version = "0.5", default-features = false, features = ["generic-array", "rand_core", "zeroize"] }
-ct-codecs = { version = "1", default-features = false }
-curl = { version = "0.4", features = ["http2"] }
-curl-sys = { version = "0.4", features = ["http2"] }
-der = { version = "0.7", default-features = false, features = ["oid", "pem", "std"] }
-ecdsa = { version = "0.16", default-features = false, features = ["pem", "signing", "std", "verifying"] }
-ed25519-compact = { version = "2", default-features = false, features = ["random"] }
-elliptic-curve = { version = "0.13", default-features = false, features = ["ecdh", "hazmat", "pem", "std"] }
-encoding_rs = { version = "0.8" }
-enum-as-inner = { version = "0.5", default-features = false }
-errno = { version = "0.3", default-features = false }
-faster-hex = { version = "0.8" }
-fastrand-f595c2ba2a3f28df = { package = "fastrand", version = "2" }
-ff = { version = "0.13", default-features = false, features = ["alloc"] }
-fiat-crypto = { version = "0.1", default-features = false }
-foreign-types = { version = "0.3", default-features = false }
-foreign-types-shared = { version = "0.1", default-features = false }
-git2 = { version = "0.17" }
-git2-curl = { version = "0.18", default-features = false }
-gix = { version = "0.44", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
-gix-actor = { version = "0.20", default-features = false }
-gix-attributes = { version = "0.12", default-features = false }
-gix-bitmap = { version = "0.2", default-features = false }
-gix-chunk = { version = "0.4", default-features = false }
-gix-command = { version = "0.2", default-features = false }
-gix-config = { version = "0.22", default-features = false }
-gix-config-value = { version = "0.12", default-features = false }
-gix-credentials = { version = "0.14", default-features = false }
-gix-date = { version = "0.5", default-features = false }
-gix-diff = { version = "0.29", default-features = false }
-gix-discover = { version = "0.18", default-features = false }
-gix-features = { version = "0.29", features = ["crc32", "io-pipe", "once_cell", "parallel", "progress", "rustsha1", "walkdir", "zlib"] }
-gix-fs = { version = "0.1", default-features = false }
-gix-glob = { version = "0.7", default-features = false }
-gix-hash = { version = "0.11", default-features = false }
-gix-hashtable = { version = "0.2", default-features = false }
-gix-ignore = { version = "0.2", default-features = false }
-gix-index = { version = "0.16", default-features = false }
-gix-lock = { version = "5", default-features = false }
-gix-mailmap = { version = "0.12", default-features = false }
-gix-object = { version = "0.29", default-features = false }
-gix-odb = { version = "0.45", default-features = false }
-gix-pack = { version = "0.35", default-features = false, features = ["object-cache-dynamic"] }
-gix-packetline = { version = "0.16", features = ["blocking-io"] }
-gix-path = { version = "0.8", default-features = false }
-gix-prompt = { version = "0.5", default-features = false }
-gix-protocol = { version = "0.32", default-features = false, features = ["blocking-client"] }
-gix-quote = { version = "0.4", default-features = false }
-gix-ref = { version = "0.29", default-features = false }
-gix-refspec = { version = "0.10", default-features = false }
-gix-revision = { version = "0.13", default-features = false }
-gix-sec = { version = "0.8", default-features = false }
-gix-tempfile = { version = "5", default-features = false, features = ["signals"] }
-gix-trace = { version = "0.1" }
-gix-transport = { version = "0.31", features = ["http-client-curl"] }
-gix-traverse = { version = "0.25", default-features = false }
-gix-url = { version = "0.18", default-features = false }
-gix-utils = { version = "0.1", default-features = false }
-gix-validate = { version = "0.7", default-features = false }
-gix-worktree = { version = "0.17", default-features = false }
-glob = { version = "0.3", default-features = false }
-globset = { version = "0.4" }
-group = { version = "0.13", default-features = false, features = ["alloc"] }
-hkdf = { version = "0.12", default-features = false }
-hostname = { version = "0.3" }
-http-auth = { version = "0.1", default-features = false }
-hyper-rustls = { version = "0.24", default-features = false }
-hyper-tls = { version = "0.5", default-features = false }
-iana-time-zone = { version = "0.1", default-features = false, features = ["fallback"] }
-idna-6f8ce4dd05d13bba = { package = "idna", version = "0.2", default-features = false }
-ignore = { version = "0.4", default-features = false }
-im-rc = { version = "15", default-features = false }
-imara-diff = { version = "0.1" }
-io-close = { version = "0.3", default-features = false }
-ipnet = { version = "2" }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10" }
-kstring = { version = "2" }
-lazycell = { version = "1", default-features = false }
-libc = { version = "0.2", default-features = false, features = ["use_std"] }
-libgit2-sys = { version = "0.15", default-features = false, features = ["https", "ssh", "ssh_key_from_memory"] }
-libnghttp2-sys = { version = "0.1", default-features = false }
-libssh2-sys = { version = "0.3", default-features = false }
-linked-hash-map = { version = "0.5", default-features = false }
-lru-cache = { version = "0.1", default-features = false }
-match_cfg = { version = "0.1" }
-maybe-async = { version = "0.2", features = ["is_sync"] }
-memoffset-3b31131e45eafb45 = { package = "memoffset", version = "0.6" }
 nix-2b5c6dc72f624058 = { package = "nix", version = "0.23", default-features = false }
 nix-2f80eeee3b1b6c7e = { package = "nix", version = "0.26", default-features = false, features = ["dir", "ioctl", "poll", "signal", "term"] }
 num_threads = { version = "0.1", default-features = false }

--- a/fixtures/large/summaries/hyper_util_7afb1ed-1.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32im-risc0-zkvm-elf'
+triple = 'riscv32imac-unknown-nuttx-elf'
 target-features = 'all'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]
@@ -226,6 +226,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'libc'
+version = '0.2.155'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
+
+[[target-package]]
 name = 'log'
 version = '0.4.22'
 crates-io = true
@@ -282,6 +289,13 @@ version = '0.8.4'
 crates-io = true
 status = 'transitive'
 features = ['std']
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.4.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'slab'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-2.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv6k-nintendo-3ds'
+triple = 'armv6-unknown-netbsd-eabihf'
 target-features = 'unknown'
 flags = ['bar', 'foo']
 
 [metadata.target-platform]
-triple = 'armv7-unknown-linux-musleabi'
+triple = 'armv7-unknown-linux-gnueabi'
 target-features = 'unknown'
 
 [[metadata.features-only]]

--- a/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-5.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'thumbv7a-pc-windows-msvc'
+triple = 'thumbv7a-uwp-windows-msvc'
 target-features = 'unknown'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'loongarch64-unknown-none-softfloat'
+triple = 'm68k-unknown-none-elf'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'httpdate'

--- a/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-freebsd'
+triple = 'x86_64-unknown-fuchsia'
 target-features = 'all'
 
 [[host-package]]

--- a/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
+++ b/fixtures/large/summaries/hyper_util_7afb1ed-7.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32e-unknown-none-elf'
+triple = 'riscv32gc-unknown-linux-musl'
 target-features = 'all'
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'riscv32e-unknown-none-elf'
+triple = 'riscv32gc-unknown-linux-musl'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'no-std-net'

--- a/fixtures/large/summaries/metadata_libra-2.toml
+++ b/fixtures/large/summaries/metadata_libra-2.toml
@@ -12,7 +12,7 @@ target-features = []
 flags = ['foo', 'test-flag']
 
 [metadata.target-platform]
-triple = 'aarch64_be-unknown-netbsd'
+triple = 'aarch64v8r-unknown-none'
 target-features = []
 [[metadata.omitted-packages.ids]]
 name = 'ed25519-dalek'
@@ -2058,7 +2058,7 @@ version = '0.5.6'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc']
+optional-deps = ['getrandom']
 
 [[target-package]]
 name = 'mime'
@@ -2089,13 +2089,6 @@ status = 'transitive'
 features = ['default', 'with-deprecated']
 
 [[target-package]]
-name = 'mio-uds'
-version = '0.6.7'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'net2'
 version = '0.2.33'
 crates-io = true
@@ -2105,13 +2098,6 @@ features = ['default', 'duration']
 [[target-package]]
 name = 'nibble_vec'
 version = '0.0.4'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'nix'
-version = '0.14.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2349,7 +2335,6 @@ version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'libc', 'std']
-optional-deps = ['libc']
 
 [[target-package]]
 name = 'rand'
@@ -2357,7 +2342,6 @@ version = '0.5.6'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'cloudabi', 'default', 'fuchsia-cprng', 'libc', 'std', 'winapi']
-optional-deps = ['libc']
 
 [[target-package]]
 name = 'rand'
@@ -2493,7 +2477,6 @@ version = '0.16.9'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
-optional-deps = ['lazy_static']
 
 [[target-package]]
 name = 'rmp'
@@ -2699,7 +2682,7 @@ version = '0.1.22'
 crates-io = true
 status = 'transitive'
 features = ['bytes', 'codec', 'default', 'fs', 'io', 'mio', 'num_cpus', 'reactor', 'rt-full', 'sync', 'tcp', 'timer', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp', 'tokio-uds', 'udp', 'uds']
-optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp', 'tokio-uds']
+optional-deps = ['bytes', 'mio', 'num_cpus', 'tokio-codec', 'tokio-current-thread', 'tokio-executor', 'tokio-fs', 'tokio-io', 'tokio-reactor', 'tokio-sync', 'tokio-tcp', 'tokio-threadpool', 'tokio-timer', 'tokio-udp']
 
 [[target-package]]
 name = 'tokio-buf'
@@ -2780,7 +2763,7 @@ version = '0.2.0-alpha.6'
 crates-io = true
 status = 'transitive'
 features = ['async-traits', 'bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds', 'tcp', 'udp', 'uds']
-optional-deps = ['bytes', 'futures-sink-preview', 'iovec', 'libc', 'mio-uds']
+optional-deps = ['bytes', 'futures-sink-preview', 'iovec']
 
 [[target-package]]
 name = 'tokio-process'
@@ -2799,13 +2782,6 @@ features = []
 [[target-package]]
 name = 'tokio-rustls'
 version = '0.10.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-signal'
-version = '0.2.7'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2848,13 +2824,6 @@ features = ['async-traits']
 [[target-package]]
 name = 'tokio-udp'
 version = '0.1.5'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'tokio-uds'
-version = '0.2.5'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2958,13 +2927,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'utf8parse'
-version = '0.1.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'uuid'
 version = '0.7.4'
 crates-io = true
@@ -2978,13 +2940,6 @@ version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
-
-[[target-package]]
-name = 'void'
-version = '1.0.2'
-crates-io = true
-status = 'transitive'
-features = ['default', 'std']
 
 [[target-package]]
 name = 'wait-timeout'

--- a/fixtures/large/summaries/metadata_libra-3.toml
+++ b/fixtures/large/summaries/metadata_libra-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'powerpc-unknown-freebsd'
+triple = 'powerpc-unknown-linux-musl'
 target-features = ['bmi2', 'fma', 'sse2', 'sse4.2', 'xsaves']
 flags = ['cargo_web', 'flag-test']
 

--- a/fixtures/large/summaries/metadata_libra-4.toml
+++ b/fixtures/large/summaries/metadata_libra-4.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv7a-kmc-solid_asp3-eabi'
+triple = 'armv7-wrs-vxworks-eabihf'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/large/summaries/metadata_libra-5.toml
+++ b/fixtures/large/summaries/metadata_libra-5.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-nto-qnx800'
+triple = 'aarch64-unknown-openbsd'
 target-features = ['avx2', 'sse4.1', 'ssse3', 'xsaves']
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'sparc-unknown-none-elf'
+triple = 'sparc64-unknown-openbsd'
 target-features = ['sha', 'sse4.1', 'ssse3']
 flags = ['abc']
 [[metadata.omitted-packages.ids]]
@@ -1858,6 +1858,7 @@ version = '0.16.9'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'dev_urandom_fallback', 'lazy_static', 'std']
+optional-deps = ['lazy_static']
 
 [[host-package]]
 name = 'rmp'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-1.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'thumbv7neon-linux-androideabi'
+triple = 'thumbv7neon-unknown-linux-musleabihf'
 target-features = ['avx2', 'bmi1', 'sha', 'sse3', 'xsave', 'xsaves']
 
 [metadata.target-platform]
-triple = 'thumbv5te-none-eabi'
+triple = 'thumbv7a-none-eabi'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'libra-node'

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-6.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabihf'
+triple = 'arm-unknown-linux-gnueabi'
 target-features = 'all'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
+++ b/fixtures/large/summaries/metadata_libra_9ffd93b-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7a-nuttx-eabi'
+triple = 'armv7a-none-eabihf'
 target-features = 'all'
 flags = ['test-flag']
 [[metadata.omitted-packages.ids]]
@@ -487,7 +487,7 @@ version = '0.2.13'
 crates-io = true
 status = 'direct'
 features = ['blocking', 'default', 'dns', 'fnv', 'fs', 'full', 'futures-core', 'io-driver', 'io-std', 'io-util', 'iovec', 'lazy_static', 'libc', 'macros', 'memchr', 'mio', 'mio-named-pipes', 'mio-uds', 'net', 'num_cpus', 'process', 'rt-core', 'rt-threaded', 'rt-util', 'signal', 'signal-hook-registry', 'slab', 'stream', 'sync', 'tcp', 'time', 'tokio-macros', 'udp', 'uds']
-optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'libc', 'memchr', 'mio', 'mio-uds', 'num_cpus', 'signal-hook-registry', 'slab', 'tokio-macros']
+optional-deps = ['fnv', 'futures-core', 'iovec', 'lazy_static', 'memchr', 'mio', 'num_cpus', 'slab', 'tokio-macros']
 
 [[target-package]]
 name = 'toml'
@@ -535,13 +535,6 @@ features = ['default', 'std']
 [[target-package]]
 name = 'ansi_term'
 version = '0.11.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'arc-swap'
-version = '0.4.4'
 crates-io = true
 status = 'transitive'
 features = []
@@ -972,7 +965,7 @@ version = '0.5.7'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc']
+optional-deps = ['getrandom']
 
 [[target-package]]
 name = 'mio'
@@ -980,13 +973,6 @@ version = '0.6.21'
 crates-io = true
 status = 'transitive'
 features = ['default', 'with-deprecated']
-
-[[target-package]]
-name = 'mio-uds'
-version = '0.6.7'
-crates-io = true
-status = 'transitive'
-features = []
 
 [[target-package]]
 name = 'net2'
@@ -1099,7 +1085,6 @@ version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'libc', 'std']
-optional-deps = ['libc']
 
 [[target-package]]
 name = 'rand'
@@ -1107,7 +1092,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'rand_pcg', 'small_rng', 'std']
-optional-deps = ['getrandom_package', 'libc', 'rand_pcg']
+optional-deps = ['getrandom_package', 'rand_pcg']
 
 [[target-package]]
 name = 'rand04'
@@ -1275,13 +1260,6 @@ features = []
 [[target-package]]
 name = 'sha3'
 version = '0.8.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'signal-hook-registry'
-version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-0.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unikraft-linux-musl'
+triple = 'x86_64-unknown-dragonfly'
 target-features = 'unknown'
 flags = ['foo']
 
@@ -967,6 +967,13 @@ status = 'transitive'
 features = []
 
 [[host-package]]
+name = 'errno-dragonfly'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[host-package]]
 name = 'failure'
 version = '0.1.6'
 crates-io = true
@@ -1066,6 +1073,13 @@ crates-io = true
 status = 'transitive'
 features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'compat', 'futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'futures_01', 'io', 'io-compat', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'sink', 'slab', 'std', 'tokio-io']
 optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'futures_01', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab', 'tokio-io']
+
+[[host-package]]
+name = 'gcc'
+version = '0.3.55'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[host-package]]
 name = 'generic-array'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-1.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-linux-ohos'
+triple = 'x86_64-unknown-linux-none'
 target-features = ['sha', 'sse2', 'sse4.2', 'ssse3', 'xsave', 'xsaves']
 flags = ['flag-test']
 

--- a/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mipsisa32r6-unknown-linux-gnu'
+triple = 'mipsisa64r6el-unknown-linux-gnuabi64'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-3.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'thumbv5te-none-eabi'
+triple = 'thumbv7a-none-eabi'
 target-features = 'all'
 flags = ['test-flag']
 
 [metadata.target-platform]
-triple = 'xtensa-esp32s2-espidf'
+triple = 'xtensa-esp32-none-elf'
 target-features = 'unknown'
 
 [[target-package]]
@@ -547,7 +547,7 @@ version = '0.5.7'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'mach_o_sys', 'use_os', 'winapi']
-optional-deps = ['getrandom', 'libc']
+optional-deps = ['getrandom']
 
 [[target-package]]
 name = 'nibble_vec'
@@ -611,7 +611,6 @@ version = '0.4.6'
 crates-io = true
 status = 'transitive'
 features = ['default', 'libc', 'std']
-optional-deps = ['libc']
 
 [[target-package]]
 name = 'rand'
@@ -619,7 +618,7 @@ version = '0.7.3'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'getrandom_package', 'libc', 'std']
-optional-deps = ['getrandom_package', 'libc']
+optional-deps = ['getrandom_package']
 
 [[target-package]]
 name = 'rand04'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-4.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-netbsd'
+triple = 'x86_64-unknown-managarm-mlibc'
 target-features = 'unknown'
 flags = ['bar', 'test-flag']
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-none'
+triple = 'x86_64-unknown-netbsd'
 target-features = ['rdrand', 'sse']
 [[metadata.omitted-packages.ids]]
 name = 'rental-impl'
@@ -1760,6 +1760,13 @@ status = 'transitive'
 features = ['default', 'with-deprecated']
 
 [[target-package]]
+name = 'mio-uds'
+version = '0.6.7'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'net2'
 version = '0.2.33'
 crates-io = true
@@ -1769,6 +1776,20 @@ features = ['default', 'duration']
 [[target-package]]
 name = 'nibble_vec'
 version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nix'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nix'
+version = '0.17.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2154,6 +2175,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'signal-hook-registry'
+version = '1.2.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'slab'
 version = '0.4.2'
 crates-io = true
@@ -2502,11 +2530,25 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'vec_map'
 version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'wait-timeout'

--- a/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-6.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7-linux-androideabi'
+triple = 'armv6k-nintendo-3ds'
 target-features = 'unknown'
 
 [metadata.target-platform]
@@ -1039,22 +1039,8 @@ features = ['alloc', 'async-await', 'async-await-macro', 'channel', 'futures-cha
 optional-deps = ['futures-channel', 'futures-io', 'futures-macro', 'futures-sink', 'memchr', 'proc-macro-hack', 'proc-macro-nested', 'slab']
 
 [[host-package]]
-name = 'gcc'
-version = '0.3.55'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'generic-array'
 version = '0.12.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'get_if_addrs-sys'
-version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
+++ b/fixtures/large/summaries/metadata_libra_f0091a4-7.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv64imac-unknown-nuttx-elf'
+triple = 'sparc-unknown-none-elf'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'i686-win7-windows-msvc'
+triple = 'i686-wrs-vxworks'
 target-features = []
 [[metadata.omitted-packages.ids]]
 name = 'endian-type'
@@ -1438,6 +1438,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'ansi_term'
+version = '0.11.0'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'arbitrary'
 version = '0.4.0'
 crates-io = true
@@ -1692,6 +1699,13 @@ crates-io = true
 status = 'transitive'
 features = ['default', 'lazy_static', 'std']
 optional-deps = ['lazy_static']
+
+[[target-package]]
+name = 'crossbeam-queue'
+version = '0.1.2'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'crossbeam-queue'
@@ -2031,13 +2045,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'kernel32-sys'
-version = '0.2.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'lazy_static'
 version = '1.4.0'
 crates-io = true
@@ -2159,22 +2166,8 @@ status = 'transitive'
 features = ['default', 'with-deprecated']
 
 [[target-package]]
-name = 'mio-named-pipes'
-version = '0.1.6'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'miow'
-version = '0.2.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'miow'
-version = '0.3.3'
+name = 'mio-uds'
+version = '0.6.7'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2189,6 +2182,20 @@ features = ['default', 'duration']
 [[target-package]]
 name = 'nibble_vec'
 version = '0.0.4'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nix'
+version = '0.14.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'nix'
+version = '0.17.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2594,13 +2601,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'schannel'
-version = '0.1.17'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
 name = 'scopeguard'
 version = '1.0.0'
 crates-io = true
@@ -2624,6 +2624,13 @@ features = []
 [[target-package]]
 name = 'shlex'
 version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'signal-hook-registry'
+version = '1.2.0'
 crates-io = true
 status = 'transitive'
 features = []
@@ -2660,13 +2667,6 @@ features = []
 name = 'snappy-sys'
 version = '0.1.0'
 source = 'git+https://github.com/busyjay/rust-snappy.git?branch=static-link#8c12738bad811397600455d6982aff754ea2ac44'
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'socket2'
-version = '0.3.11'
-crates-io = true
 status = 'transitive'
 features = []
 
@@ -2849,6 +2849,13 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'tokio-signal'
+version = '0.2.9'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'tokio-sync'
 version = '0.1.8'
 crates-io = true
@@ -2879,6 +2886,13 @@ features = []
 [[target-package]]
 name = 'tokio-udp'
 version = '0.1.6'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
+name = 'tokio-uds'
+version = '0.2.6'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3085,11 +3099,25 @@ status = 'transitive'
 features = []
 
 [[target-package]]
+name = 'utf8parse'
+version = '0.1.1'
+crates-io = true
+status = 'transitive'
+features = []
+
+[[target-package]]
 name = 'vec_map'
 version = '0.8.1'
 crates-io = true
 status = 'transitive'
 features = []
+
+[[target-package]]
+name = 'void'
+version = '1.0.2'
+crates-io = true
+status = 'transitive'
+features = ['default', 'std']
 
 [[target-package]]
 name = 'wait-timeout'
@@ -3129,41 +3157,6 @@ features = []
 [[target-package]]
 name = 'webpki-roots'
 version = '0.18.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.2.8'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winapi'
-version = '0.3.8'
-crates-io = true
-status = 'transitive'
-features = ['consoleapi', 'errhandlingapi', 'fileapi', 'handleapi', 'impl-debug', 'impl-default', 'ioapiset', 'knownfolders', 'libloaderapi', 'lmcons', 'memoryapi', 'minschannel', 'minwinbase', 'minwindef', 'namedpipeapi', 'ntdef', 'ntsecapi', 'ntstatus', 'objbase', 'processenv', 'processthreadsapi', 'profileapi', 'schannel', 'securitybaseapi', 'shlobj', 'sspi', 'std', 'synchapi', 'sysinfoapi', 'threadpoollegacyapiset', 'timezoneapi', 'winbase', 'wincon', 'wincrypt', 'winerror', 'winnt', 'winreg', 'winsock2', 'winuser', 'ws2def', 'ws2ipdef', 'ws2tcpip', 'wtypesbase']
-
-[[target-package]]
-name = 'winapi-util'
-version = '0.1.3'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'winreg'
-version = '0.6.2'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[target-package]]
-name = 'ws2_32-sys'
-version = '0.2.1'
 crates-io = true
 status = 'transitive'
 features = []
@@ -3997,13 +3990,6 @@ features = []
 [[host-package]]
 name = 'which'
 version = '3.1.0'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
-name = 'winapi-build'
-version = '0.1.1'
 crates-io = true
 status = 'transitive'
 features = []

--- a/fixtures/large/summaries/mnemos_b3b4da9-0.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'powerpc64-unknown-openbsd'
+triple = 'powerpc64le-unknown-linux-musl'
 target-features = 'unknown'
 
 [metadata.target-platform]
@@ -2667,13 +2667,6 @@ status = 'transitive'
 features = []
 
 [[host-package]]
-name = 'errno'
-version = '0.3.1'
-crates-io = true
-status = 'transitive'
-features = []
-
-[[host-package]]
 name = 'float-cmp'
 version = '0.8.0'
 crates-io = true
@@ -2823,6 +2816,13 @@ version = '0.2.147'
 crates-io = true
 status = 'transitive'
 features = ['default', 'extra_traits', 'std']
+
+[[host-package]]
+name = 'linux-raw-sys'
+version = '0.3.8'
+crates-io = true
+status = 'transitive'
+features = ['errno', 'general', 'ioctl', 'no_std']
 
 [[host-package]]
 name = 'log'

--- a/fixtures/large/summaries/mnemos_b3b4da9-1.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32imac-unknown-xous-elf'
+triple = 'riscv32imc-unknown-none-elf'
 target-features = 'unknown'
 flags = ['abc', 'foo']
 [[metadata.omitted-packages.ids]]
@@ -173,7 +173,7 @@ version = '0.7.16'
 crates-io = true
 status = 'direct'
 features = ['atomic-polyfill', 'cas', 'default', 'defmt', 'defmt-impl', 'serde']
-optional-deps = ['defmt', 'serde']
+optional-deps = ['atomic-polyfill', 'defmt', 'serde']
 
 [[target-package]]
 name = 'input-mgr'
@@ -284,6 +284,13 @@ crates-io = true
 status = 'direct'
 features = ['serde']
 optional-deps = ['serde']
+
+[[target-package]]
+name = 'atomic-polyfill'
+version = '0.1.11'
+crates-io = true
+status = 'transitive'
+features = []
 
 [[target-package]]
 name = 'az'

--- a/fixtures/large/summaries/mnemos_b3b4da9-2.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64im-unknown-none-elf'
+triple = 's390x-unknown-none-softfloat'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/large/summaries/mnemos_b3b4da9-4.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-4.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'armv7a-kmc-solid_asp3-eabihf'
+triple = 'armv7a-kmc-solid_asp3-eabi'
 target-features = ['aes', 'rdrand']
 flags = ['cargo_web']
 
 [metadata.target-platform]
-triple = 'powerpc64le-unknown-linux-gnu'
+triple = 'riscv32e-unknown-none-elf'
 target-features = 'all'
 flags = ['cargo_web']
 
@@ -127,7 +127,7 @@ version = '0.4.26'
 crates-io = true
 status = 'direct'
 features = ['clock', 'default', 'iana-time-zone', 'js-sys', 'oldtime', 'std', 'time', 'wasm-bindgen', 'wasmbind', 'winapi']
-optional-deps = ['iana-time-zone', 'time']
+optional-deps = ['time']
 
 [[target-package]]
 name = 'clap'
@@ -303,7 +303,7 @@ version = '1.29.1'
 crates-io = true
 status = 'direct'
 features = ['bytes', 'default', 'io-std', 'io-util', 'libc', 'macros', 'mio', 'net', 'rt', 'socket2', 'sync', 'time', 'tokio-macros', 'tracing']
-optional-deps = ['bytes', 'libc', 'mio', 'socket2', 'tokio-macros']
+optional-deps = ['bytes', 'mio', 'socket2', 'tokio-macros']
 
 [[target-package]]
 name = 'tracing'
@@ -701,13 +701,6 @@ status = 'transitive'
 features = []
 
 [[target-package]]
-name = 'iana-time-zone'
-version = '0.1.57'
-crates-io = true
-status = 'transitive'
-features = ['fallback']
-
-[[target-package]]
 name = 'idna'
 version = '0.4.0'
 crates-io = true
@@ -1034,7 +1027,7 @@ version = '0.8.5'
 crates-io = true
 status = 'transitive'
 features = ['alloc', 'default', 'getrandom', 'libc', 'rand_chacha', 'small_rng', 'std', 'std_rng']
-optional-deps = ['libc', 'rand_chacha']
+optional-deps = ['rand_chacha']
 
 [[target-package]]
 name = 'rand_chacha'

--- a/fixtures/large/summaries/mnemos_b3b4da9-5.toml
+++ b/fixtures/large/summaries/mnemos_b3b4da9-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32imafc-unknown-none-elf'
+triple = 'riscv32imfc-unknown-none-elf'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/hakari/metadata1-0.toml
+++ b/fixtures/small/hakari/metadata1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['thumbv7neon-linux-androideabi', 'i686-wrs-vxworks', 'i686-unknown-openbsd']
+# platforms = ['thumbv7neon-unknown-linux-musleabihf', 'loongarch32-unknown-none', 'i686-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'regex'
 # version = '1.3.1'

--- a/fixtures/small/hakari/metadata1-1.toml
+++ b/fixtures/small/hakari/metadata1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['powerpc64-unknown-openbsd', 'riscv32imac-unknown-nuttx-elf']
+# platforms = ['powerpc64le-unknown-linux-musl', 'riscv32imafc-unknown-nuttx-elf']
 # [[traversal-excludes.ids]]
 # name = 'dtoa'
 # version = '0.4.4'

--- a/fixtures/small/hakari/metadata1-2.toml
+++ b/fixtures/small/hakari/metadata1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv7a-kmc-solid_asp3-eabi', 'aarch64-unknown-nuttx', 'loongarch64-unknown-none']
+# platforms = ['armv7-wrs-vxworks-eabihf', 'aarch64-unknown-openbsd', 'loongarch64-unknown-none-softfloat']
 # [[traversal-excludes.ids]]
 # name = 'mach'
 # version = '0.2.3'

--- a/fixtures/small/hakari/metadata1-3.toml
+++ b/fixtures/small/hakari/metadata1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['powerpc64le-unknown-freebsd']
+# platforms = ['riscv32e-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'same-file'
 # version = '1.0.5'

--- a/fixtures/small/hakari/metadata2-0.toml
+++ b/fixtures/small/hakari/metadata2-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['wasm32v1-none', 'mipsisa32r6el-unknown-linux-gnu', 'aarch64-unknown-nuttx']
+# platforms = ['wasm32v1-none', 'msp430-none-elf', 'aarch64-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'ctor'
 # version = '0.1.10'

--- a/fixtures/small/hakari/metadata2-1.toml
+++ b/fixtures/small/hakari/metadata2-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['x86_64-unknown-linux-ohos', 'aarch64-nintendo-switch-freestanding', 'aarch64-unknown-helenos']
+# platforms = ['x86_64-unknown-linux-musl', 'aarch64-oe-linux-gnu', 'aarch64-unknown-helenos']
 # [[traversal-excludes.ids]]
 # name = 'serde_yaml'
 # version = '0.8.9'

--- a/fixtures/small/hakari/metadata2-2.toml
+++ b/fixtures/small/hakari/metadata2-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['riscv64gc-unknown-hermit', 'aarch64-unknown-none', 'riscv32imac-esp-espidf']
+# platforms = ['riscv64gc-unknown-netbsd', 'aarch64-unknown-none', 'riscv32imafc-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'dtoa'
 # version = '0.4.4'

--- a/fixtures/small/hakari/metadata2-3.toml
+++ b/fixtures/small/hakari/metadata2-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['i586-unknown-linux-gnu', 'sparc64-unknown-linux-gnu']
+# platforms = ['i586-unknown-linux-musl', 'thumbv4t-none-eabi']
 # [[traversal-excludes.ids]]
 # name = 'aho-corasick'
 # version = '0.7.6'

--- a/fixtures/small/hakari/metadata_alternate_registries-1.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armv6-unknown-netbsd-eabihf']
+# platforms = ['armv6-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'unicode-xid'
 # version = '0.2.2'

--- a/fixtures/small/hakari/metadata_alternate_registries-3.toml
+++ b/fixtures/small/hakari/metadata_alternate_registries-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armeb-unknown-linux-gnueabi', 'riscv32e-unknown-none-elf', 'aarch64-wrs-vxworks']
+# platforms = ['armeb-unknown-linux-gnueabi', 'riscv32gc-unknown-linux-musl', 'aarch64-wrs-vxworks']
 # [[traversal-excludes.ids]]
 # name = 'debug-ignore'
 # version = '1.0.1'

--- a/fixtures/small/hakari/metadata_build_targets1-0.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['riscv32imac-esp-espidf', 'aarch64_be-unknown-linux-gnu', 'i686-unknown-openbsd']
+# platforms = ['riscv32imafc-unknown-none-elf', 'aarch64_be-unknown-linux-gnu_ilp32', 'i686-unknown-uefi']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_build_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64-apple-visionos', 'wasm32-wasip2', 'aarch64-unknown-linux-gnu_ilp32']
+# platforms = ['aarch64-apple-visionos', 'wasm32-wasip2', 'aarch64-unknown-linux-musl']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_build_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['wasm32-wasip3', 'armv7-unknown-linux-uclibceabihf']
+# platforms = ['wasm32-wasip3', 'armv7-unknown-linux-uclibceabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_build_targets1-3.toml
+++ b/fixtures/small/hakari/metadata_build_targets1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64-unknown-openbsd', 'loongarch64-unknown-none']
+# platforms = ['aarch64-unknown-redox', 'loongarch64-unknown-none-softfloat']
 # [[traversal-excludes.ids]]
 # name = 'testcrate'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-0.toml
+++ b/fixtures/small/hakari/metadata_builddep-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['mipsisa32r6el-unknown-linux-gnu', 'aarch64-unknown-teeos']
+# platforms = ['msp430-none-elf', 'aarch64-unknown-teeos']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-1.toml
+++ b/fixtures/small/hakari/metadata_builddep-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'full'
-# platforms = ['powerpc64le-unknown-linux-musl']
+# platforms = ['riscv32em-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-2.toml
+++ b/fixtures/small/hakari/metadata_builddep-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['mips64-unknown-linux-muslabi64', 'thumbv6m-nuttx-eabi', 'riscv64gc-unknown-none-elf']
+# platforms = ['mips64el-unknown-linux-muslabi64', 'thumbv7a-nuttx-eabi', 'riscv64im-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_builddep-3.toml
+++ b/fixtures/small/hakari/metadata_builddep-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['loongarch64-unknown-linux-gnu', 'thumbv6m-none-eabi']
+# platforms = ['loongarch64-unknown-linux-musl', 'thumbv7a-none-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'builddep'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle1-0.toml
+++ b/fixtures/small/hakari/metadata_cycle1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['x86_64-unknown-fuchsia']
+# platforms = ['x86_64-unknown-haiku']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-0.toml
+++ b/fixtures/small/hakari/metadata_cycle2-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['mips64-unknown-linux-muslabi64']
+# platforms = ['mips64el-unknown-linux-muslabi64']
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-1.toml
+++ b/fixtures/small/hakari/metadata_cycle2-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['armv7-unknown-freebsd']
+# platforms = ['armv7-rtems-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'lower-b'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle2-2.toml
+++ b/fixtures/small/hakari/metadata_cycle2-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['aarch64-unknown-nuttx', 'i686-unknown-linux-musl', 'thumbv7m-none-eabi']
+# platforms = ['aarch64-unknown-qnx', 'i686-unknown-linux-musl', 'thumbv7neon-linux-androideabi']
 # [[traversal-excludes.ids]]
 # name = 'lower-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-0.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['loongarch32-unknown-none', 'riscv32ima-unknown-none-elf', 'aarch64-unknown-openbsd']
+# platforms = ['loongarch32-unknown-none-softfloat', 'riscv32imafc-esp-espidf', 'aarch64-unknown-qnx']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-1.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64-unknown-motor']
+# platforms = ['x86_64-unknown-managarm-mlibc']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-2.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['riscv32imc-unknown-none-elf']
+# platforms = ['riscv64-wrs-vxworks']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_cycle_features-3.toml
+++ b/fixtures/small/hakari/metadata_cycle_features-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['aarch64_be-unknown-netbsd']
+# platforms = ['aarch64v8r-unknown-none']
 # [[traversal-excludes.ids]]
 # name = 'testcycles-base'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_dups-2.toml
+++ b/fixtures/small/hakari/metadata_dups-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64-unknown-linux-gnu', 'arm-unknown-linux-musleabi']
+# platforms = ['x86_64-unknown-linux-gnumsan', 'arm-unknown-linux-musleabi']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_dups-3.toml
+++ b/fixtures/small/hakari/metadata_dups-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['xtensa-esp32-espidf', 'riscv32imafc-esp-espidf']
+# platforms = ['x86_64h-apple-darwin', 'riscv32imc-unknown-nuttx-elf']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.5.4'

--- a/fixtures/small/hakari/metadata_proc_macro1-0.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['mipsisa64r6el-unknown-linux-gnuabi64']
+# platforms = ['powerpc-unknown-freebsd']
 # [[traversal-excludes.ids]]
 # name = 'dev-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-1.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['thumbv7a-nuttx-eabi']
+# platforms = ['thumbv7a-nuttx-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-2.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '3'
 # workspace-hack-line-style = 'version-only'
-# platforms = ['armv7a-nuttx-eabi', 'powerpc64-ibm-aix']
+# platforms = ['armv7a-none-eabihf', 'powerpc64-unknown-openbsd']
 # [[traversal-excludes.ids]]
 # name = 'build-user'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_proc_macro1-3.toml
+++ b/fixtures/small/hakari/metadata_proc_macro1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv7k-apple-watchos', 'aarch64-unknown-helenos']
+# platforms = ['armv7a-vex-v5', 'aarch64-unknown-helenos']
 #
 # [traversal-excludes]
 # [[final-excludes.ids]]

--- a/fixtures/small/hakari/metadata_self_dev_cycle-2.toml
+++ b/fixtures/small/hakari/metadata_self_dev_cycle-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '3'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['riscv64gc-unknown-none-elf', 'i586-unknown-netbsd', 'riscv64a23-unknown-linux-gnu']
+# platforms = ['riscv64im-unknown-none-elf', 'i586-unknown-netbsd', 'riscv64gc-unknown-hermit']
 # [[traversal-excludes.ids]]
 # name = 'self-dev-cycle-cycle-a'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_targets1-1.toml
+++ b/fixtures/small/hakari/metadata_targets1-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['riscv32e-unknown-none-elf', 'wasm32-unknown-emscripten', 'i686-unknown-helenos']
+# platforms = ['riscv32gc-unknown-linux-musl', 'wasm32-unknown-emscripten', 'i686-unknown-helenos']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.5.3'

--- a/fixtures/small/hakari/metadata_targets1-2.toml
+++ b/fixtures/small/hakari/metadata_targets1-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '1'
 # workspace-hack-line-style = 'full'
-# platforms = ['i686-unknown-linux-musl', 'x86_64-unknown-haiku']
+# platforms = ['i686-unknown-netbsd', 'x86_64-unknown-haiku']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.5.3'
@@ -21,7 +21,7 @@
 dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false }
 lazy_static-dff4ba8e3ae991db = { package = "lazy_static", version = "1", default-features = false }
 
-[target.i686-unknown-linux-musl.dependencies]
+[target.i686-unknown-netbsd.dependencies]
 dep-a = { path = "/Users/fakeuser/local/testcrates/testcrate-targets/../dep-a", default-features = false, features = ["bar", "baz", "foo", "quux"] }
 lazy_static-6f8ce4dd05d13bba = { package = "lazy_static", version = "0.2", default-features = false }
 

--- a/fixtures/small/hakari/metadata_targets1-3.toml
+++ b/fixtures/small/hakari/metadata_targets1-3.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '2'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['riscv32ima-unknown-none-elf', 'riscv32im-risc0-zkvm-elf']
+# platforms = ['riscv32imac-unknown-xous-elf', 'riscv32imac-unknown-none-elf']
 # [[traversal-excludes.ids]]
 # name = 'bytes'
 # version = '0.5.3'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-0.toml
@@ -7,7 +7,7 @@
 # output-single-feature = true
 # dep-format-version = '4'
 # workspace-hack-line-style = 'workspace-dotted'
-# platforms = ['x86_64-unknown-hurd-gnu']
+# platforms = ['x86_64-unknown-illumos']
 # [[traversal-excludes.ids]]
 # name = 'pathdiff'
 # version = '0.2.1'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-1.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '2'
 # workspace-hack-line-style = 'full'
-# platforms = ['armv7a-kmc-solid_asp3-eabi']
+# platforms = ['armv7-wrs-vxworks-eabihf']
 # [[traversal-excludes.ids]]
 # name = 'namespaced-weak'
 # version = '0.1.0'

--- a/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
+++ b/fixtures/small/hakari/metadata_weak_namespaced_features-2.toml
@@ -7,7 +7,7 @@
 # output-single-feature = false
 # dep-format-version = '4'
 # workspace-hack-line-style = 'full'
-# platforms = ['x86_64-unknown-redox', 'x86_64-uwp-windows-gnu', 'riscv32im-unknown-none-elf']
+# platforms = ['x86_64-unknown-openbsd', 'x86_64-unknown-uefi', 'riscv32imac-unknown-nuttx-elf']
 # [[traversal-excludes.ids]]
 # name = 'arrayvec'
 # version = '0.7.2'

--- a/fixtures/small/summaries/metadata1-1.toml
+++ b/fixtures/small/summaries/metadata1-1.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'armv7-unknown-netbsd-eabihf'
+triple = 'armv7-unknown-linux-uclibceabi'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata1-2.toml
+++ b/fixtures/small/summaries/metadata1-2.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'sparc64-unknown-helenos'
 target-features = 'all'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata1-5.toml
+++ b/fixtures/small/summaries/metadata1-5.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'loongarch64-unknown-linux-gnu'
+triple = 'loongarch64-unknown-linux-musl'
 target-features = 'unknown'
 flags = ['cargo_web', 'flag-test']
 

--- a/fixtures/small/summaries/metadata1-7.toml
+++ b/fixtures/small/summaries/metadata1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'aarch64-kmc-solid_asp3'
+triple = 'aarch64-linux-android'
 target-features = ['aes', 'avx']
 flags = ['bar', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'i686-unknown-linux-musl'
+triple = 'i686-unknown-netbsd'
 target-features = ['sha', 'sse2']
 [[metadata.omitted-packages.ids]]
 name = 'winapi-i686-pc-windows-gnu'

--- a/fixtures/small/summaries/metadata2-0.toml
+++ b/fixtures/small/summaries/metadata2-0.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i586-unknown-netbsd'
+triple = 'i586-unknown-redox'
 target-features = 'all'
 flags = ['bar', 'test-flag']
 

--- a/fixtures/small/summaries/metadata2-1.toml
+++ b/fixtures/small/summaries/metadata2-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-pc-windows-gnu'
+triple = 'x86_64-pc-windows-gnullvm'
 target-features = 'unknown'
 flags = ['abc', 'foo']
 

--- a/fixtures/small/summaries/metadata2-3.toml
+++ b/fixtures/small/summaries/metadata2-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-netbsd'
+triple = 'riscv64gc-unknown-redox'
 target-features = 'all'
 flags = ['flag-test', 'foo']
 

--- a/fixtures/small/summaries/metadata2-5.toml
+++ b/fixtures/small/summaries/metadata2-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'riscv32i-unknown-none-elf'
+triple = 'riscv32imac-unknown-none-elf'
 target-features = 'all'
 flags = ['cargo_web', 'foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-0.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-helenos'
+triple = 'x86_64-unknown-hermit'
 target-features = 'unknown'
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'arm-unknown-linux-gnueabi'
+triple = 'arm-linux-androideabi'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'serde'

--- a/fixtures/small/summaries/metadata_alternate_registries-1.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-1.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-lynx-lynxos178'
+triple = 'x86_64-oe-linux-gnu'
 target-features = []
 flags = ['bar']
 

--- a/fixtures/small/summaries/metadata_alternate_registries-2.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'x86_64-unknown-haiku'
+triple = 'x86_64-unknown-helenos'
 target-features = ['avx', 'sse2', 'ssse3']
 flags = ['foo', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-3.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32imc-unknown-nuttx-elf'
+triple = 'riscv64a23-unknown-linux-gnu'
 target-features = 'all'
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_alternate_registries-6.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'i586-unknown-redox'
+triple = 'i686-apple-darwin'
 target-features = 'unknown'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_alternate_registries-7.toml
+++ b/fixtures/small/summaries/metadata_alternate_registries-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mips-unknown-linux-uclibc'
+triple = 'mips64-unknown-linux-gnuabi64'
 target-features = 'all'
 flags = ['abc', 'flag-test']
 

--- a/fixtures/small/summaries/metadata_build_targets1-3.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'thumbv7a-uwp-windows-msvc'
+triple = 'thumbv7em-none-eabihf'
 target-features = ['rdrand', 'sse', 'xsavec', 'xsaveopt']
 flags = ['bar', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_build_targets1-5.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'riscv32gc-unknown-linux-musl'
+triple = 'riscv32ima-unknown-none-elf'
 target-features = 'all'
 flags = ['bar', 'foo']
 

--- a/fixtures/small/summaries/metadata_build_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv32ima-unknown-none-elf'
+triple = 'riscv32imac-unknown-xous-elf'
 target-features = 'all'
 flags = ['abc']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_build_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_build_targets1-7.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'sparcv9-sun-solaris'
+triple = 'thumbv6m-none-eabi'
 target-features = 'all'
 flags = ['flag-test']
 

--- a/fixtures/small/summaries/metadata_builddep-1.toml
+++ b/fixtures/small/summaries/metadata_builddep-1.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7k-apple-watchos'
+triple = 'armv7a-vex-v5'
 target-features = 'all'
 flags = ['bar']
 
 [metadata.target-platform]
-triple = 'riscv32imafc-unknown-none-elf'
+triple = 'riscv32imfc-unknown-none-elf'
 target-features = ['avx', 'avx2', 'fma', 'rdrand', 'sse3', 'ssse3', 'xsaves']
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_builddep-3.toml
+++ b/fixtures/small/summaries/metadata_builddep-3.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv6-unknown-freebsd'
+triple = 'armv6-none-eabihf'
 target-features = 'unknown'
 flags = ['abc', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_builddep-6.toml
+++ b/fixtures/small/summaries/metadata_builddep-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'x86_64h-apple-darwin'
+triple = 'x86_64-wrs-vxworks'
 target-features = ['aes', 'avx', 'rdrand', 'sse']
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_cycle1-0.toml
+++ b/fixtures/small/summaries/metadata_cycle1-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'armv7-rtems-eabihf'
+triple = 'armv7-linux-androideabi'
 target-features = 'unknown'
 flags = ['foo']
 

--- a/fixtures/small/summaries/metadata_cycle1-3.toml
+++ b/fixtures/small/summaries/metadata_cycle1-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-netbsd'
+triple = 'aarch64-unknown-managarm-mlibc'
 target-features = 'unknown'
 flags = ['flag-test', 'test-flag']
 

--- a/fixtures/small/summaries/metadata_cycle1-5.toml
+++ b/fixtures/small/summaries/metadata_cycle1-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'i686-unknown-linux-musl'
+triple = 'i686-unknown-netbsd'
 target-features = 'all'
 flags = ['foo']
 

--- a/fixtures/small/summaries/metadata_cycle1-6.toml
+++ b/fixtures/small/summaries/metadata_cycle1-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'thumbv5te-none-eabi'
+triple = 'thumbv7a-none-eabi'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle1-7.toml
+++ b/fixtures/small/summaries/metadata_cycle1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32imc-esp-espidf'
+triple = 'riscv64-oe-linux-gnu'
 target-features = ['ssse3']
 flags = ['abc']
 
 [metadata.target-platform]
-triple = 'mipsel-unknown-linux-uclibc'
+triple = 'mipsisa32r6-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-0.toml
+++ b/fixtures/small/summaries/metadata_cycle2-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'aarch64_be-unknown-none-softfloat'
+triple = 'aarch64v8r-unknown-none'
 target-features = ['avx', 'bmi2', 'sse4.1', 'ssse3']
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle2-2.toml
+++ b/fixtures/small/summaries/metadata_cycle2-2.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-hermit'
+triple = 'riscv64gc-unknown-netbsd'
 target-features = 'unknown'
 flags = ['bar', 'foo']
 
 [metadata.target-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'sparc64-unknown-linux-gnu'
 target-features = 'all'
 flags = ['abc']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-3.toml
+++ b/fixtures/small/summaries/metadata_cycle2-3.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'powerpc64-unknown-openbsd'
+triple = 'powerpc64le-unknown-linux-gnu'
 target-features = ['sse4.2', 'xsave']
 flags = ['abc', 'flag-test']
 

--- a/fixtures/small/summaries/metadata_cycle2-4.toml
+++ b/fixtures/small/summaries/metadata_cycle2-4.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-netbsd'
+triple = 'x86_64-unknown-managarm-mlibc'
 target-features = 'all'
 flags = ['cargo_web', 'flag-test']
 
 [metadata.target-platform]
-triple = 'mips-unknown-linux-gnu'
+triple = 'mips-unknown-linux-uclibc'
 target-features = 'unknown'
 flags = ['cargo_web', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle2-5.toml
+++ b/fixtures/small/summaries/metadata_cycle2-5.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'riscv32emc-unknown-none-elf'
+triple = 'riscv32im-risc0-zkvm-elf'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_cycle_features-1.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-1.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mips64el-unknown-linux-gnuabi64'
+triple = 'mipsel-mti-none-elf'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'testcycles-base'

--- a/fixtures/small/summaries/metadata_cycle_features-4.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-netbsd'
+triple = 'riscv64gc-unknown-redox'
 target-features = 'all'
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_cycle_features-5.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-5.toml
@@ -11,7 +11,7 @@ triple = 'bpfel-unknown-none'
 target-features = ['xsave', 'xsaveopt']
 
 [metadata.target-platform]
-triple = 'riscv32imc-unknown-nuttx-elf'
+triple = 'riscv64gc-unknown-freebsd'
 target-features = 'all'
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_cycle_features-6.toml
+++ b/fixtures/small/summaries/metadata_cycle_features-6.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'mips64-openwrt-linux-musl'
+triple = 'mips64-unknown-linux-muslabi64'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'powerpc64-unknown-linux-gnu'
+triple = 'powerpc64le-unknown-freebsd'
 target-features = 'all'
 flags = ['bar', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_dups-0.toml
+++ b/fixtures/small/summaries/metadata_dups-0.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'x86_64-fortanix-unknown-sgx'
+triple = 'x86_64-linux-android'
 target-features = 'all'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_dups-4.toml
+++ b/fixtures/small/summaries/metadata_dups-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'm68k-unknown-none-elf'
+triple = 'mips-unknown-linux-gnu'
 target-features = 'unknown'
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_dups-5.toml
+++ b/fixtures/small/summaries/metadata_dups-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc64-unknown-freebsd'
+triple = 'powerpc64-unknown-openbsd'
 target-features = 'all'
 flags = ['foo']
 

--- a/fixtures/small/summaries/metadata_dups-7.toml
+++ b/fixtures/small/summaries/metadata_dups-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-fuchsia'
+triple = 'riscv64gc-unknown-managarm-mlibc'
 target-features = 'all'
 flags = ['bar', 'cargo_web']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_proc_macro1-0.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-0.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64-linux-android'
+triple = 'riscv64gc-unknown-fuchsia'
 target-features = ['bmi2', 'rdrand', 'sse2', 'xsave', 'xsaves']
 flags = ['test-flag']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-2.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-2.toml
@@ -7,7 +7,7 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 's390x-unknown-linux-musl'
+triple = 'sparc64-unknown-linux-gnu'
 target-features = ['aes', 'avx2', 'sha', 'sse4.2', 'ssse3']
 flags = ['abc', 'foo']
 

--- a/fixtures/small/summaries/metadata_proc_macro1-6.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-6.toml
@@ -11,7 +11,7 @@ triple = 'xtensa-esp32s2-none-elf'
 target-features = 'all'
 
 [metadata.target-platform]
-triple = 'hexagon-unknown-none-elf'
+triple = 'hexagon-unknown-qurt'
 target-features = ['avx2', 'sha', 'sse4.1', 'xsaves']
 flags = ['abc']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_proc_macro1-7.toml
+++ b/fixtures/small/summaries/metadata_proc_macro1-7.toml
@@ -10,7 +10,7 @@ initials-platform = 'proc-macros-on-target'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-nto-qnx800'
+triple = 'aarch64-unknown-nuttx'
 target-features = 'all'
 flags = ['foo', 'test-flag']
 

--- a/fixtures/small/summaries/metadata_self_dev_cycle-1.toml
+++ b/fixtures/small/summaries/metadata_self_dev_cycle-1.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'armv7-unknown-netbsd-eabihf'
+triple = 'armv7-unknown-linux-uclibceabihf'
 target-features = 'unknown'
 flags = ['abc', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'aarch64-unknown-nuttx'
+triple = 'aarch64-unknown-openbsd'
 target-features = 'unknown'
 flags = ['foo']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_self_dev_cycle-2.toml
+++ b/fixtures/small/summaries/metadata_self_dev_cycle-2.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'any'
 
 [metadata.target-platform]
-triple = 'powerpc64-unknown-linux-musl'
+triple = 'powerpc64le-unknown-freebsd'
 target-features = ['avx', 'bmi2', 'fma', 'sha', 'sse2', 'xsave', 'xsaves']
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_self_dev_cycle-3.toml
+++ b/fixtures/small/summaries/metadata_self_dev_cycle-3.toml
@@ -7,11 +7,11 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-unknown-linux-musl'
+triple = 'aarch64-unknown-linux-ohos'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-freebsd'
+triple = 'armv7-sony-vita-newlibeabihf'
 target-features = 'unknown'
 [[metadata.omitted-packages.ids]]
 name = 'self-dev-cycle-helper'

--- a/fixtures/small/summaries/metadata_self_dev_cycle-5.toml
+++ b/fixtures/small/summaries/metadata_self_dev_cycle-5.toml
@@ -12,7 +12,7 @@ target-features = 'all'
 flags = ['flag-test']
 
 [metadata.target-platform]
-triple = 'xtensa-esp32-espidf'
+triple = 'x86_64h-apple-darwin'
 target-features = 'all'
 flags = ['abc']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_self_dev_cycle-6.toml
+++ b/fixtures/small/summaries/metadata_self_dev_cycle-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'powerpc-wrs-vxworks-spe'
+triple = 'powerpc64-unknown-linux-gnuelfv2'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'self-dev-cycle-cycle-a'

--- a/fixtures/small/summaries/metadata_targets1-0.toml
+++ b/fixtures/small/summaries/metadata_targets1-0.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'aarch64-kmc-solid_asp3'
+triple = 'aarch64-linux-android'
 target-features = ['bmi1']
 flags = ['flag-test', 'test-flag']
 
 [metadata.target-platform]
-triple = 'armv7-wrs-vxworks-eabihf'
+triple = 'armv7-unknown-netbsd-eabihf'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'bytes'

--- a/fixtures/small/summaries/metadata_targets1-1.toml
+++ b/fixtures/small/summaries/metadata_targets1-1.toml
@@ -7,11 +7,11 @@ include-dev = false
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'armv7k-apple-watchos'
+triple = 'armv7a-vex-v5'
 target-features = 'unknown'
 
 [metadata.target-platform]
-triple = 'powerpc-wrs-vxworks'
+triple = 'powerpc64-unknown-linux-gnu'
 target-features = ['sha']
 
 [[metadata.features-only]]

--- a/fixtures/small/summaries/metadata_targets1-2.toml
+++ b/fixtures/small/summaries/metadata_targets1-2.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'host'
 
 [metadata.host-platform]
-triple = 'mipsel-unknown-netbsd'
+triple = 'mipsisa32r6el-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['bar', 'foo']
 
 [metadata.target-platform]
-triple = 'riscv64gc-unknown-freebsd'
+triple = 'riscv64gc-unknown-linux-gnu'
 target-features = 'unknown'
 flags = ['abc', 'test-flag']
 

--- a/fixtures/small/summaries/metadata_targets1-4.toml
+++ b/fixtures/small/summaries/metadata_targets1-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'x86_64-unknown-helenos'
+triple = 'x86_64-unknown-hermit'
 target-features = ['sse2']
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_targets1-6.toml
+++ b/fixtures/small/summaries/metadata_targets1-6.toml
@@ -7,12 +7,12 @@ include-dev = false
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'riscv64gc-unknown-managarm-mlibc'
+triple = 'riscv64gc-unknown-openbsd'
 target-features = ['aes', 'bmi1', 'sha', 'sse4.1', 'xsavec']
 flags = ['abc', 'cargo_web']
 
 [metadata.target-platform]
-triple = 'mipsel-mti-none-elf'
+triple = 'mipsel-unknown-linux-gnu'
 target-features = []
 flags = ['bar']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_targets1-7.toml
+++ b/fixtures/small/summaries/metadata_targets1-7.toml
@@ -7,12 +7,12 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'sparc-unknown-none-elf'
+triple = 'sparc64-unknown-openbsd'
 target-features = 'unknown'
 flags = ['flag-test']
 
 [metadata.target-platform]
-triple = 'loongarch64-unknown-linux-gnu'
+triple = 'loongarch64-unknown-linux-musl'
 target-features = 'all'
 flags = ['abc', 'flag-test']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-0.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-0.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv7-unknown-freebsd'
+triple = 'armv7-sony-vita-newlibeabihf'
 target-features = 'unknown'
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-1.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'standard'
 
 [metadata.host-platform]
-triple = 'i686-pc-windows-gnullvm'
+triple = 'i686-pc-windows-msvc'
 target-features = 'unknown'
 flags = ['cargo_web']
 

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-3.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-3.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'mipsisa64r6-unknown-linux-gnuabi64'
+triple = 'nvptx64-nvidia-cuda'
 target-features = ['sse4.2', 'xsavec', 'xsaves']
 
 [metadata.target-platform]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-4.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-4.toml
@@ -7,7 +7,7 @@ include-dev = true
 initials-platform = 'proc-macros-on-target'
 
 [metadata.host-platform]
-triple = 'i686-win7-windows-gnu'
+triple = 'i686-win7-windows-msvc'
 target-features = ['avx', 'bmi2', 'rdrand', 'sse2', 'xsaves']
 flags = ['abc']
 

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-5.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-5.toml
@@ -10,7 +10,7 @@ initials-platform = 'host'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'armv6-unknown-freebsd'
+triple = 'armv6-none-eabi'
 target-features = 'unknown'
 flags = ['flag-test', 'test-flag']
 [[metadata.omitted-packages.ids]]

--- a/fixtures/small/summaries/metadata_weak_namespaced_features-6.toml
+++ b/fixtures/small/summaries/metadata_weak_namespaced_features-6.toml
@@ -10,7 +10,7 @@ initials-platform = 'standard'
 spec = 'always'
 
 [metadata.target-platform]
-triple = 'mipsisa64r6el-unknown-linux-gnuabi64'
+triple = 'powerpc-unknown-helenos'
 target-features = 'all'
 [[metadata.omitted-packages.ids]]
 name = 'arrayvec'

--- a/guppy-summaries/CHANGELOG.md
+++ b/guppy-summaries/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- MSRV updated to Rust 1.91, as required by dependencies.
 - Updated `toml` to 1.1.4. The on-disk format written by `Summary::write_to_string` is unchanged: summaries are now written by the new `toml_compat` module, which reproduces the output of `toml` 0.5's pretty serializer, including its ordering of nested metadata tables.
   - `Summary::metadata` is now `toml` 1.x's `Table`.
   - `Summary::parse`, `Summary::with_metadata`, `Summary::to_string` and `Summary::write_to_string` return `toml` 1.x's error types.

--- a/guppy-summaries/src/toml_compat.rs
+++ b/guppy-summaries/src/toml_compat.rs
@@ -280,10 +280,10 @@ fn emit_key_inner(out: &mut String, state: &State<'_>) -> Result<(), Error> {
 }
 
 fn array_type(state: &State<'_>, type_: ArrayState) {
-    if let State::Array { type_: prev, .. } = state {
-        if prev.get().is_none() {
-            prev.set(Some(type_));
-        }
+    if let State::Array { type_: prev, .. } = state
+        && prev.get().is_none()
+    {
+        prev.set(Some(type_));
     }
 }
 
@@ -425,10 +425,10 @@ fn emit_table_header(out: &mut String, state: &State<'_>) {
     // `[a.b]` headers can omit their `[a]` ancestor, but `[[a]]` ancestors
     // cannot be omitted, so emit those first.
     let mut p = state;
-    if let State::Array { first, parent, .. } = *state {
-        if first.get() {
-            p = parent;
-        }
+    if let State::Array { first, parent, .. } = *state
+        && first.get()
+    {
+        p = parent;
     }
     while let State::Table { first, parent, .. } = *p {
         p = parent;
@@ -454,10 +454,10 @@ fn emit_table_header(out: &mut String, state: &State<'_>) {
         State::Array { parent, first, .. } => {
             if !first.get() {
                 out.push('\n');
-            } else if let State::Table { first, .. } = *parent {
-                if !first.get() {
-                    out.push('\n');
-                }
+            } else if let State::Table { first, .. } = *parent
+                && !first.get()
+            {
+                out.push('\n');
             }
         }
         State::End => {}

--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- MSRV updated to Rust 1.91, as required by dependencies.
 - The package and feature "resolver" traits are renamed and now receive an
   opaque context ([#497]):
   - `PackageResolver` is now `PackageLinkVisitor`, and `FeatureResolver` is now

--- a/guppy/src/graph/build.rs
+++ b/guppy/src/graph/build.rs
@@ -541,10 +541,10 @@ impl<'g> ReqResolvedName<'g> {
     }
 
     fn matches(&self, name: &str) -> bool {
-        if let Some(rename) = &self.renamed {
-            if rename == name {
-                return true;
-            }
+        if let Some(rename) = &self.renamed
+            && rename == name
+        {
+            return true;
         }
 
         match self.resolved_name {

--- a/guppy/src/graph/feature/build.rs
+++ b/guppy/src/graph/feature/build.rs
@@ -169,20 +169,21 @@ impl FeatureGraphBuildState {
                     //
                     // should not insert a self-edge from `tokio` to `tokio`. The second condition
                     // checks this.
-                    if !*weak && &**dep_name != from_named_feature {
-                        if let Some(same_named_feature_node) = self.make_named_feature_node(
+                    if !*weak
+                        && &**dep_name != from_named_feature
+                        && let Some(same_named_feature_node) = self.make_named_feature_node(
                             &metadata,
                             from_label,
                             &metadata,
                             FeatureLabel::Named(dep_name),
                             // Don't warn if this dep isn't optional.
                             false,
-                        ) {
-                            nodes_edges.push((
-                                same_named_feature_node,
-                                Self::make_named_feature_cross_edge(link, None),
-                            ));
-                        }
+                        )
+                    {
+                        nodes_edges.push((
+                            same_named_feature_node,
+                            Self::make_named_feature_cross_edge(link, None),
+                        ));
                     }
                 }
             }
@@ -204,15 +205,14 @@ impl FeatureGraphBuildState {
                     &metadata,
                     FeatureLabel::OptionalDependency(dep_name.as_ref()),
                     true,
-                ) {
-                    if let Some(link) = dep_name_to_link.get(dep_name.as_ref()) {
-                        nodes_edges.push((
-                            same_node,
-                            FeatureEdge::NamedFeatureDepColon(
-                                Self::make_full_conditional_link_impl(link),
-                            ),
-                        ));
-                    }
+                ) && let Some(link) = dep_name_to_link.get(dep_name.as_ref())
+                {
+                    nodes_edges.push((
+                        same_node,
+                        FeatureEdge::NamedFeatureDepColon(Self::make_full_conditional_link_impl(
+                            link,
+                        )),
+                    ));
                 }
             }
         };

--- a/guppy/src/graph/summaries/package_set.rs
+++ b/guppy/src/graph/summaries/package_set.rs
@@ -587,19 +587,19 @@ impl<'a> PackageMatcher<'a> {
         let mut third_party: AHashMap<_, SmallVec<[_; 2]>> = AHashMap::new();
         let mut registry_names_to_urls = AHashMap::new();
         for tp_summary in &summary.third_party {
-            if let ThirdPartySource::Registry(Some(name)) = &tp_summary.source {
-                if !registry_names_to_urls.contains_key(name.as_str()) {
-                    match registry_name_to_url(name) {
-                        Some(url) => {
-                            registry_names_to_urls.insert(name.as_str(), url);
-                        }
-                        None => {
-                            return Err(Error::UnknownRegistryName {
-                                message: error_message.to_owned(),
-                                summary: Box::new(tp_summary.clone()),
-                                registry_name: name.clone(),
-                            });
-                        }
+            if let ThirdPartySource::Registry(Some(name)) = &tp_summary.source
+                && !registry_names_to_urls.contains_key(name.as_str())
+            {
+                match registry_name_to_url(name) {
+                    Some(url) => {
+                        registry_names_to_urls.insert(name.as_str(), url);
+                    }
+                    None => {
+                        return Err(Error::UnknownRegistryName {
+                            message: error_message.to_owned(),
+                            summary: Box::new(tp_summary.clone()),
+                            registry_name: name.clone(),
+                        });
                     }
                 }
             }

--- a/internal-tools/cargo-compare/Cargo.toml
+++ b/internal-tools/cargo-compare/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.100"
-cargo = { version = "0.95.0", features = ["vendored-libgit2"] }
+cargo = { version = "0.99.0", features = ["vendored-libgit2"] }
 clap = { version = "4.5.49", features = ["derive"] }
 color-eyre = { version = "0.6.5", default-features = false }
 diffus = "0.10.0"

--- a/internal-tools/cargo-compare/src/common.rs
+++ b/internal-tools/cargo-compare/src/common.rs
@@ -67,7 +67,10 @@ impl GuppyCargoCommon {
         }
 
         let compile_kind = match &self.target_platform {
-            Some(platform) => CompileKind::Target(CompileTarget::new(platform)?),
+            // unstable_json (the second parameter to CompileTarget::new) =
+            // false matches stable cargo. (cargo-compare only accepts builtin
+            // target triples here.)
+            Some(platform) => CompileKind::Target(CompileTarget::new(platform, false)?),
             None => CompileKind::Host,
         };
         let mut target_data = RustcTargetData::new(&workspace, &[compile_kind])?;

--- a/target-spec-miette/CHANGELOG.md
+++ b/target-spec-miette/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- MSRV updated to Rust 1.91, as required by dependencies.
+
 ## [0.4.8] - 2026-05-21
 
 ### Added

--- a/target-spec-miette/README.md
+++ b/target-spec-miette/README.md
@@ -19,7 +19,7 @@ produces. This can be used to pretty-print errors returned by target-spec.
 
 ### Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) is **Rust 1.86**.
+The minimum supported Rust version (MSRV) is **Rust 1.91**.
 
 While this crate is in pre-release status (0.x), the MSRV may be bumped in
 patch releases.

--- a/target-spec-miette/src/lib.rs
+++ b/target-spec-miette/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Minimum supported Rust version
 //!
-//! The minimum supported Rust version (MSRV) is **Rust 1.86**.
+//! The minimum supported Rust version (MSRV) is **Rust 1.91**.
 //!
 //! While this crate is in pre-release status (0.x), the MSRV may be bumped in
 //! patch releases.

--- a/target-spec/CHANGELOG.md
+++ b/target-spec/CHANGELOG.md
@@ -3,6 +3,11 @@
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- Updated `cfg-expr` to version 0.20.9, updating builtin targets to Rust 1.98.
+- MSRV updated to Rust 1.91, as required by dependencies.
+
 ## [3.6.0] - 2026-03-31
 
 ### Added

--- a/target-spec/README.md
+++ b/target-spec/README.md
@@ -58,13 +58,13 @@ For more advanced usage, see `Platform` and `TargetSpec`.
 
 ### Minimum supported Rust version
 
-The minimum supported Rust version (MSRV) is **Rust 1.82**. The MSRV history is:
+The minimum supported Rust version (MSRV) is **Rust 1.91**. The MSRV history is:
 
 * For target-spec 3.0.x: **Rust 1.66**.
 * For target-spec 3.1.x: **Rust 1.73**.
 * For target-spec 3.2.x: **Rust 1.75**.
 * For target-spec 3.3.x and 3.4.x: **Rust 1.82**.
-* For target-spec 3.5.x: **Rust 1.86**.
+* For target-spec 3.5.x and 3.6.x: **Rust 1.86**.
 
 Within the 3.x series, MSRV bumps will be accompanied by a minor version
 update. The last 6 months of stable Rust releases will be supported.

--- a/target-spec/src/lib.rs
+++ b/target-spec/src/lib.rs
@@ -52,13 +52,13 @@
 //!
 //! ## Minimum supported Rust version
 //!
-//! The minimum supported Rust version (MSRV) is **Rust 1.82**. The MSRV history is:
+//! The minimum supported Rust version (MSRV) is **Rust 1.91**. The MSRV history is:
 //!
 //! * For target-spec 3.0.x: **Rust 1.66**.
 //! * For target-spec 3.1.x: **Rust 1.73**.
 //! * For target-spec 3.2.x: **Rust 1.75**.
 //! * For target-spec 3.3.x and 3.4.x: **Rust 1.82**.
-//! * For target-spec 3.5.x: **Rust 1.86**.
+//! * For target-spec 3.5.x and 3.6.x: **Rust 1.86**.
 //!
 //! Within the 3.x series, MSRV bumps will be accompanied by a minor version
 //! update. The last 6 months of stable Rust releases will be supported.

--- a/tools/cargo-hakari/CHANGELOG.md
+++ b/tools/cargo-hakari/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+### Changed
+
+- Builtin targets updated to Rust 1.98.
+- MSRV updated to Rust 1.91, as required by dependencies.
+
 ## [0.9.38] - 2026-05-21
 
 ### Fixed

--- a/tools/determinator/CHANGELOG.md
+++ b/tools/determinator/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- MSRV updated to Rust 1.91, as required by dependencies.
 - Updated `toml` to 1.1.4. `DeterminatorRules::parse` now returns `toml` 1.x's
   `de::Error`, a breaking change for code that names that type. Rules files are
   parsed strictly according to the TOML 1.1 specification.

--- a/tools/hakari/CHANGELOG.md
+++ b/tools/hakari/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 
+- MSRV updated to Rust 1.91, as required by dependencies.
 - Updated `toml` to 1.1.4 and `toml_edit` to 0.25.13.
   - `HakariConfig::from_str`, `HakariBuilderSummary::to_string` and
     `HakariBuilderSummary::write_to_string` now return error types from `toml`

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -18,11 +18,12 @@ edition = "2024"
 ### BEGIN HAKARI SECTION
 [dependencies]
 aho-corasick = { version = "1.1.3" }
+anstream = { version = "0.6.21" }
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
 camino = { version = "1.2.1", default-features = false, features = ["serde1"] }
-clap = { version = "4.5.56", features = ["derive"] }
-clap_builder = { version = "4.5.56", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
+clap = { version = "4.6.6", features = ["derive"] }
+clap_builder = { version = "4.6.6", default-features = false, features = ["color", "help", "std", "suggestions", "usage"] }
 getrandom = { version = "0.3.3", default-features = false, features = ["std"] }
 hashbrown = { version = "0.16.1", default-features = false, features = ["allocator-api2", "inline-more"] }
 include_dir = { version = "0.7.4", features = ["glob"] }
@@ -33,9 +34,9 @@ num-traits = { version = "0.2.19" }
 once_cell = { version = "1.21.3" }
 owo-colors = { version = "3.5.0", default-features = false, features = ["supports-colors"] }
 petgraph = { version = "0.8.3", default-features = false, features = ["graphmap", "std"] }
-regex = { version = "1.12.2", default-features = false, features = ["perf", "std"] }
-regex-automata = { version = "0.4.13", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
-regex-syntax = { version = "0.8.5" }
+regex = { version = "1.13.1", default-features = false, features = ["perf", "std"] }
+regex-automata = { version = "0.4.18", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "std", "unicode"] }
+regex-syntax = { version = "0.8.11" }
 serde = { version = "1.0.228", features = ["alloc", "derive"] }
 serde_core = { version = "1.0.228", features = ["alloc"] }
 serde_json = { version = "1.0.150", features = ["unbounded_depth"] }
@@ -46,21 +47,22 @@ toml_writer = { version = "1.1.2" }
 winnow = { version = "1.0.3" }
 
 [build-dependencies]
-proc-macro2 = { version = "1.0.101" }
-quote = { version = "1.0.41" }
-syn = { version = "2.0.106", features = ["extra-traits", "full", "visit"] }
+proc-macro2 = { version = "1.0.107" }
+quote = { version = "1.0.47" }
+syn-7b89eefb6aaa9bf3 = { package = "syn", version = "3.0.3", features = ["full"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.106", features = ["extra-traits", "full", "visit"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-libc = { version = "0.2.180" }
-rustix = { version = "0.38.44", features = ["fs", "termios"] }
+libc = { version = "0.2.189" }
+rustix = { version = "1.1.4", features = ["fs", "termios"] }
 
 [target.x86_64-apple-darwin.dependencies]
-libc = { version = "0.2.180", features = ["extra_traits"] }
-rustix = { version = "0.38.44", features = ["fs", "termios"] }
+libc = { version = "0.2.189", features = ["extra_traits"] }
+rustix = { version = "1.1.4", features = ["fs", "termios"] }
 
 [target.aarch64-apple-darwin.dependencies]
-libc = { version = "0.2.180", features = ["extra_traits"] }
-rustix = { version = "0.38.44", features = ["fs", "termios"] }
+libc = { version = "0.2.189", features = ["extra_traits"] }
+rustix = { version = "1.1.4", features = ["fs", "termios"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_Input_KeyboardAndMouse"] }


### PR DESCRIPTION
cfg-expr 0.20.9 updates the builtin target list to Rust 1.98.

Also bump the MSRV to 1.91 as required by dependencies.