### PR TITLE
[guppy] introduce IxSet and port ResolveCore onto it

### DIFF
--- a/guppy/src/graph/feature/resolve.rs
+++ b/guppy/src/graph/feature/resolve.rs
@@ -41,7 +41,7 @@ impl<'g> FeatureGraph<'g> {
     pub fn resolve_none(&self) -> FeatureSet<'g> {
         FeatureSet {
             graph: DebugIgnore(*self),
-            core: ResolveCore::empty(),
+            core: ResolveCore::empty(self.dep_graph()),
         }
     }
 
@@ -52,12 +52,9 @@ impl<'g> FeatureGraph<'g> {
         &self,
         feature_ids: impl IntoIterator<Item = impl Into<FeatureId<'a>>>,
     ) -> Result<FeatureSet<'g>, Error> {
-        Ok(FeatureSet {
-            graph: DebugIgnore(*self),
-            core: ResolveCore::from_included::<IxBitSet>(
-                self.feature_ixs(feature_ids.into_iter().map(|feature| feature.into()))?,
-            ),
-        })
+        let included: IxBitSet =
+            self.feature_ixs(feature_ids.into_iter().map(|feature| feature.into()))?;
+        Ok(FeatureSet::from_included(*self, included))
     }
 }
 
@@ -129,14 +126,13 @@ impl<'g> FeatureSet<'g> {
         Self { graph, core }
     }
 
-    #[allow(dead_code)]
     pub(in crate::graph) fn from_included(
         graph: FeatureGraph<'g>,
         included: impl Into<FixedBitSet>,
     ) -> Self {
         Self {
             graph: DebugIgnore(graph),
-            core: ResolveCore::from_included(included.into()),
+            core: ResolveCore::from_included(included.into(), graph.dep_graph()),
         }
     }
 
@@ -179,13 +175,7 @@ impl<'g> FeatureSet<'g> {
     ///
     /// This is equivalent to constructing a query from all the feature IDs in this set.
     pub fn to_feature_query(&self, direction: DependencyDirection) -> FeatureQuery<'g> {
-        let feature_ixs = SortedSet::new(
-            self.core
-                .included
-                .ones()
-                .map(NodeIndex::new)
-                .collect::<Vec<_>>(),
-        );
+        let feature_ixs = SortedSet::new(self.core.included.ones().collect::<Vec<_>>());
         self.graph.query_from_parts(feature_ixs, direction)
     }
 
@@ -301,7 +291,7 @@ impl<'g> FeatureSet<'g> {
         mut callback: impl FnMut(FeatureMetadata<'g>) -> bool,
     ) -> (Self, Self) {
         let graph = self.graph;
-        let mut left = IxBitSet::with_capacity(self.core.included.len());
+        let mut left = IxBitSet::with_capacity(graph.dep_graph().node_count());
         let mut right = left.clone();
 
         self.features(direction).for_each(|feature| {
@@ -334,7 +324,7 @@ impl<'g> FeatureSet<'g> {
         mut callback: impl FnMut(FeatureMetadata<'g>) -> Option<bool>,
     ) -> (Self, Self) {
         let graph = self.graph;
-        let mut left = IxBitSet::with_capacity(self.core.included.len());
+        let mut left = IxBitSet::with_capacity(graph.dep_graph().node_count());
         let mut right = left.clone();
 
         self.features(direction).for_each(|feature| {
@@ -371,10 +361,7 @@ impl<'g> FeatureSet<'g> {
             .core
             .included
             .ones()
-            .map(|feature_ix| {
-                self.graph
-                    .package_ix_for_feature_ix(NodeIndex::new(feature_ix))
-            })
+            .map(|feature_ix| self.graph.package_ix_for_feature_ix(feature_ix))
             .collect();
         PackageSet::from_included(self.graph.package_graph, included.0)
     }
@@ -570,7 +557,7 @@ impl<'g> FeatureSet<'g> {
     pub(in crate::graph) fn ixs_unordered(
         &self,
     ) -> impl Iterator<Item = NodeIndex<FeatureIx>> + '_ {
-        self.core.included.ones().map(NodeIndex::new)
+        self.core.included.ones()
     }
 
     /// Returns true if this feature set contains the given package ix.

--- a/guppy/src/graph/ix_set.rs
+++ b/guppy/src/graph/ix_set.rs
@@ -1,0 +1,124 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::graph::GraphSpec;
+use fixedbitset::FixedBitSet;
+use petgraph::{graph::NodeIndex, visit::FilterNode};
+use std::marker::PhantomData;
+
+/// A dense bitset of node indexes.
+///
+/// The capacity is always the same as the node count, and `len` is a cache of
+/// `bits.count_ones(..)`.
+#[derive(Debug)]
+pub(super) struct IxSet<G> {
+    bits: FixedBitSet,
+    len: usize,
+    _phantom: PhantomData<G>,
+}
+
+// This manual impl avoids a G: Clone bound.
+impl<G> Clone for IxSet<G> {
+    fn clone(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            len: self.len,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<G: GraphSpec> IxSet<G> {
+    pub(super) fn empty(node_count: usize) -> Self {
+        Self {
+            bits: FixedBitSet::with_capacity(node_count),
+            len: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(super) fn from_visit_map(bits: FixedBitSet, len: usize, node_count: usize) -> Self {
+        debug_assert_eq!(
+            bits.len(),
+            node_count,
+            "visit map capacity matches the graph's node count"
+        );
+        debug_assert_eq!(bits.count_ones(..), len, "visit map popcount matches len");
+        Self {
+            bits,
+            len,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(super) fn from_bits(mut bits: FixedBitSet, node_count: usize) -> Self {
+        debug_assert!(
+            bits.len() <= node_count,
+            "bits capacity is at most the graph's node count"
+        );
+        bits.grow(node_count);
+        let len = bits.count_ones(..);
+        Self {
+            bits,
+            len,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub(super) fn contains(&self, ix: NodeIndex<G::Ix>) -> bool {
+        self.bits.contains(ix.index())
+    }
+
+    pub(super) fn ones(&self) -> impl Iterator<Item = NodeIndex<G::Ix>> + '_ {
+        self.bits.ones().map(NodeIndex::new)
+    }
+
+    pub(super) fn union_with(&mut self, other: &Self) {
+        self.bits.union_with(&other.bits);
+        self.recount();
+    }
+
+    pub(super) fn intersect_with(&mut self, other: &Self) {
+        self.bits.intersect_with(&other.bits);
+        self.recount();
+    }
+
+    pub(super) fn difference(&self, other: &Self) -> Self {
+        let mut res = self.clone();
+        res.bits.difference_with(&other.bits);
+        res.recount();
+        res
+    }
+
+    pub(super) fn symmetric_difference_with(&mut self, other: &Self) {
+        self.bits.symmetric_difference_with(&other.bits);
+        self.recount();
+    }
+
+    fn recount(&mut self) {
+        self.len = self.bits.count_ones(..);
+    }
+}
+
+// This manual impl avoids a G: PartialEq bound.
+impl<G: GraphSpec> PartialEq for IxSet<G> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len == other.len && self.bits == other.bits
+    }
+}
+
+impl<G: GraphSpec> Eq for IxSet<G> {}
+
+impl<G: GraphSpec> FilterNode<NodeIndex<G::Ix>> for &IxSet<G> {
+    fn include_node(&self, node: NodeIndex<G::Ix>) -> bool {
+        self.contains(node)
+    }
+}

--- a/guppy/src/graph/mod.rs
+++ b/guppy/src/graph/mod.rs
@@ -16,6 +16,7 @@ pub mod cargo;
 mod cycles;
 pub mod feature;
 mod graph_impl;
+mod ix_set;
 #[cfg(feature = "proptest1")]
 mod proptest_helpers;
 mod query;

--- a/guppy/src/graph/resolve.rs
+++ b/guppy/src/graph/resolve.rs
@@ -44,7 +44,7 @@ impl PackageGraph {
     pub fn resolve_none(&self) -> PackageSet<'_> {
         PackageSet {
             graph: DebugIgnore(self),
-            core: ResolveCore::empty(),
+            core: ResolveCore::empty(&self.dep_graph),
         }
     }
 
@@ -57,10 +57,8 @@ impl PackageGraph {
         &self,
         package_ids: impl IntoIterator<Item = &'a PackageId>,
     ) -> Result<PackageSet<'_>, Error> {
-        Ok(PackageSet {
-            graph: DebugIgnore(self),
-            core: ResolveCore::from_included::<IxBitSet>(self.package_ixs(package_ids)?),
-        })
+        let included: IxBitSet = self.package_ixs(package_ids)?;
+        Ok(PackageSet::from_included(self, included))
     }
 
     /// Creates a new `PackageSet` consisting of all packages in this workspace.
@@ -72,10 +70,7 @@ impl PackageGraph {
             .iter_by_path()
             .map(|(_, package)| package.package_ix())
             .collect();
-        PackageSet {
-            graph: DebugIgnore(self),
-            core: ResolveCore::from_included(included),
-        }
+        PackageSet::from_included(self, included)
     }
 
     /// Creates a new `PackageSet` consisting of the specified workspace packages by path.
@@ -96,10 +91,7 @@ impl PackageGraph {
                     .map(|package| package.package_ix())
             })
             .collect::<Result<_, Error>>()?;
-        Ok(PackageSet {
-            graph: DebugIgnore(self),
-            core: ResolveCore::from_included(included),
-        })
+        Ok(PackageSet::from_included(self, included))
     }
 
     /// Creates a new `PackageSet` consisting of the specified workspace packages by name.
@@ -120,10 +112,7 @@ impl PackageGraph {
                     .map(|package| package.package_ix())
             })
             .collect::<Result<_, _>>()?;
-        Ok(PackageSet {
-            graph: DebugIgnore(self),
-            core: ResolveCore::from_included(included),
-        })
+        Ok(PackageSet::from_included(self, included))
     }
 
     /// Creates a new `PackageSet` consisting of packages with the given name.
@@ -173,7 +162,7 @@ impl<'g> PackageSet<'g> {
     pub(super) fn from_included(graph: &'g PackageGraph, included: impl Into<FixedBitSet>) -> Self {
         Self {
             graph: DebugIgnore(graph),
-            core: ResolveCore::from_included(included),
+            core: ResolveCore::from_included(included, graph.dep_graph()),
         }
     }
 
@@ -214,13 +203,7 @@ impl<'g> PackageSet<'g> {
     ///
     /// This is equivalent to constructing a query from all the `package_ids`.
     pub fn to_package_query(&self, direction: DependencyDirection) -> PackageQuery<'g> {
-        let package_ixs = SortedSet::new(
-            self.core
-                .included
-                .ones()
-                .map(NodeIndex::new)
-                .collect::<Vec<_>>(),
-        );
+        let package_ixs = SortedSet::new(self.core.included.ones().collect::<Vec<_>>());
         self.graph.query_from_parts(package_ixs, direction)
     }
 
@@ -336,7 +319,7 @@ impl<'g> PackageSet<'g> {
         mut callback: impl FnMut(PackageMetadata<'g>) -> bool,
     ) -> (Self, Self) {
         let graph = *self.graph;
-        let mut left = IxBitSet::with_capacity(self.core.included.len());
+        let mut left = IxBitSet::with_capacity(graph.dep_graph().node_count());
         let mut right = left.clone();
 
         self.packages(direction).for_each(|package| {
@@ -369,7 +352,7 @@ impl<'g> PackageSet<'g> {
         mut callback: impl FnMut(PackageMetadata<'g>) -> Option<bool>,
     ) -> (Self, Self) {
         let graph = *self.graph;
-        let mut left = IxBitSet::with_capacity(self.core.included.len());
+        let mut left = IxBitSet::with_capacity(graph.dep_graph().node_count());
         let mut right = left.clone();
 
         self.packages(direction).for_each(|package| {
@@ -536,7 +519,7 @@ impl<'g> PackageSet<'g> {
     /// Returns all the package ixs without topologically sorting them.
     #[allow(dead_code)]
     pub(super) fn ixs_unordered(&self) -> impl Iterator<Item = NodeIndex<PackageIx>> + '_ {
-        self.core.included.ones().map(NodeIndex::new)
+        self.core.included.ones()
     }
 
     pub(super) fn contains_ix(&self, package_ix: NodeIndex<PackageIx>) -> bool {

--- a/guppy/src/graph/resolve_core.rs
+++ b/guppy/src/graph/resolve_core.rs
@@ -5,6 +5,7 @@ use crate::{
     debug_ignore::DebugIgnore,
     graph::{
         DependencyDirection, GraphSpec,
+        ix_set::IxSet,
         query_core::{QueryParams, all_visit_map, reachable_map, reachable_map_buffered_filter},
     },
     petgraph_support::{
@@ -17,18 +18,15 @@ use fixedbitset::FixedBitSet;
 use petgraph::{
     graph::EdgeReference,
     prelude::*,
-    visit::{NodeFiltered, Reversed, VisitMap},
+    visit::{NodeFiltered, Reversed},
 };
-use std::marker::PhantomData;
 
 /// Core logic for queries that have been resolved into a known set of packages.
 ///
 /// The `G` param ensures that package and feature resolutions aren't mixed up accidentally.
 #[derive(Clone, Debug)]
 pub(super) struct ResolveCore<G> {
-    pub(super) included: FixedBitSet,
-    pub(super) len: usize,
-    _phantom: PhantomData<G>,
+    pub(super) included: IxSet<G>,
 }
 
 impl<G: GraphSpec> ResolveCore<G> {
@@ -41,26 +39,20 @@ impl<G: GraphSpec> ResolveCore<G> {
             QueryParams::Reverse(initials) => reachable_map(Reversed(graph), initials.into_inner()),
         };
         Self {
-            included,
-            len,
-            _phantom: PhantomData,
+            included: IxSet::from_visit_map(included, len, graph.node_count()),
         }
     }
 
     pub(super) fn all_nodes(graph: &Graph<G::Node, G::Edge, Directed, G::Ix>) -> Self {
         let (included, len) = all_visit_map(graph);
         Self {
-            included,
-            len,
-            _phantom: PhantomData,
+            included: IxSet::from_visit_map(included, len, graph.node_count()),
         }
     }
 
-    pub(super) fn empty() -> Self {
+    pub(super) fn empty(graph: &Graph<G::Node, G::Edge, Directed, G::Ix>) -> Self {
         Self {
-            included: FixedBitSet::with_capacity(0),
-            len: 0,
-            _phantom: PhantomData,
+            included: IxSet::empty(graph.node_count()),
         }
     }
 
@@ -83,9 +75,7 @@ impl<G: GraphSpec> ResolveCore<G> {
             ),
         };
         Self {
-            included,
-            len,
-            _phantom: PhantomData,
+            included: IxSet::from_visit_map(included, len, graph.node_count()),
         }
     }
 
@@ -106,32 +96,29 @@ impl<G: GraphSpec> ResolveCore<G> {
             ),
         };
         Self {
-            included,
-            len,
-            _phantom: PhantomData,
+            included: IxSet::from_visit_map(included, len, graph.node_count()),
         }
     }
 
-    pub(super) fn from_included<T: Into<FixedBitSet>>(included: T) -> Self {
-        let included = included.into();
-        let len = included.count_ones(..);
+    pub(super) fn from_included<T: Into<FixedBitSet>>(
+        included: T,
+        graph: &Graph<G::Node, G::Edge, Directed, G::Ix>,
+    ) -> Self {
         Self {
-            included,
-            len,
-            _phantom: PhantomData,
+            included: IxSet::from_bits(included.into(), graph.node_count()),
         }
     }
 
     pub(super) fn len(&self) -> usize {
-        self.len
+        self.included.len()
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.len == 0
+        self.included.is_empty()
     }
 
     pub(super) fn contains(&self, ix: NodeIndex<G::Ix>) -> bool {
-        self.included.is_visited(&ix)
+        self.included.contains(ix)
     }
 
     // ---
@@ -140,30 +127,20 @@ impl<G: GraphSpec> ResolveCore<G> {
 
     pub(super) fn union_with(&mut self, other: &Self) {
         self.included.union_with(&other.included);
-        self.invalidate_caches();
     }
 
     pub(super) fn intersect_with(&mut self, other: &Self) {
         self.included.intersect_with(&other.included);
-        self.invalidate_caches();
     }
 
-    // fixedbitset 0.2.0 doesn't have a difference_with :(
     pub(super) fn difference(&self, other: &Self) -> Self {
-        Self::from_included(
-            self.included
-                .difference(&other.included)
-                .collect::<FixedBitSet>(),
-        )
+        Self {
+            included: self.included.difference(&other.included),
+        }
     }
 
     pub(super) fn symmetric_difference_with(&mut self, other: &Self) {
         self.included.symmetric_difference_with(&other.included);
-        self.invalidate_caches();
-    }
-
-    pub(super) fn invalidate_caches(&mut self) {
-        self.len = self.included.count_ones(..);
     }
 
     /// Returns the root metadatas in the specified direction.
@@ -211,7 +188,7 @@ impl<G: GraphSpec> ResolveCore<G> {
         Topo {
             node_iter,
             included: &self.included,
-            remaining: self.len,
+            remaining: self.included.len(),
         }
     }
 
@@ -246,18 +223,7 @@ impl<G: GraphSpec> ResolveCore<G> {
 
 impl<G: GraphSpec> PartialEq for ResolveCore<G> {
     fn eq(&self, other: &Self) -> bool {
-        if self.len != other.len {
-            return false;
-        }
-        if self.included == other.included {
-            return true;
-        }
-        // At the moment we don't normalize the capacity across self.included instances, so check
-        // the symmetric difference.
-        self.included
-            .symmetric_difference(&other.included)
-            .next()
-            .is_none()
+        self.included == other.included
     }
 }
 
@@ -267,7 +233,7 @@ impl<G: GraphSpec> Eq for ResolveCore<G> {}
 #[derive(Clone, Debug)]
 pub(super) struct Topo<'g, G: GraphSpec> {
     node_iter: NodeIter<'g, G::Ix>,
-    included: &'g FixedBitSet,
+    included: &'g IxSet<G>,
     remaining: usize,
 }
 
@@ -276,7 +242,7 @@ impl<G: GraphSpec> Iterator for Topo<'_, G> {
 
     fn next(&mut self) -> Option<Self::Item> {
         for ix in &mut self.node_iter {
-            if !self.included.is_visited(&ix) {
+            if !self.included.contains(ix) {
                 continue;
             }
             self.remaining -= 1;
@@ -301,7 +267,7 @@ impl<G: GraphSpec> ExactSizeIterator for Topo<'_, G> {
 #[allow(clippy::type_complexity)]
 pub(super) struct Links<'g, G: GraphSpec> {
     graph: DebugIgnore<&'g Graph<G::Node, G::Edge, Directed, G::Ix>>,
-    included: &'g FixedBitSet,
+    included: &'g IxSet<G>,
     edge_dfs: EdgeDfs<EdgeIndex<G::Ix>, NodeIndex<G::Ix>, FixedBitSet>,
     direction: DependencyDirection,
 }

--- a/guppy/tests/graph-tests/graph_tests.rs
+++ b/guppy/tests/graph-tests/graph_tests.rs
@@ -738,6 +738,63 @@ mod small {
     }
 
     // No need for proptests because this is a really simple test.
+
+    #[test]
+    fn resolve_set_equality() {
+        let metadata1 = JsonFixture::metadata1();
+        let graph = metadata1.graph();
+
+        assert_eq!(
+            graph.resolve_none(),
+            graph
+                .resolve_ids(iter::empty::<&PackageId>())
+                .expect("resolved empty package ID list"),
+            "resolve_none matches resolving an empty package ID list"
+        );
+        assert_eq!(
+            graph.resolve_all(),
+            graph
+                .resolve_ids(graph.package_ids())
+                .expect("resolved all package IDs"),
+            "resolve_all matches resolving every package ID"
+        );
+        assert_eq!(
+            graph.resolve_all(),
+            graph
+                .query_forward(graph.package_ids())
+                .expect("queried all package IDs")
+                .resolve(),
+            "resolve_all matches a forward query from every package ID"
+        );
+
+        let feature_graph = graph.feature_graph();
+        assert_eq!(
+            feature_graph.resolve_none(),
+            feature_graph
+                .resolve_ids(iter::empty::<FeatureId>())
+                .expect("resolved empty feature ID list"),
+            "resolve_none matches resolving an empty feature ID list"
+        );
+        let all_feature_ids: Vec<FeatureId> = feature_graph
+            .resolve_all()
+            .feature_ids(DependencyDirection::Forward)
+            .collect();
+        assert_eq!(
+            feature_graph.resolve_all(),
+            feature_graph
+                .resolve_ids(all_feature_ids.clone())
+                .expect("resolved all feature IDs"),
+            "resolve_all matches resolving every feature ID"
+        );
+        assert_eq!(
+            feature_graph.resolve_all(),
+            feature_graph
+                .query_forward(all_feature_ids)
+                .expect("queried all feature IDs")
+                .resolve(),
+            "resolve_all matches a forward query from every feature ID"
+        );
+    }
 }
 
 mod large {


### PR DESCRIPTION
Add `IxSet`, which represents a dense-bitset index set type, capacity-normalized to the graph's node bound.

This is the first step towards unifying the `PackageQuery` and `PackageSet` representations.