### PR TITLE
[guppy] change CargoOptionsSummary to CargoSetInputsSummary

### DIFF
--- a/guppy/CHANGELOG.md
+++ b/guppy/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Fixed
 
+- With the `summaries` feature, rebuilding Cargo options from a summary no
+  longer silently drops the features-only set.
 - `FeatureSet::union`, `intersection`, `difference` and `symmetric_difference`
   now panic, as documented, if the two sets were built from different package
   graphs. Previously the check compared `self`'s graph against itself and could
@@ -49,6 +51,9 @@
   - With the `proptest1` feature, `Prop010Resolver` is now `Prop010LinkVisitor`
     and `PackageGraph::proptest1_resolver_strategy` is now
     `proptest1_link_visitor_strategy`.
+- A new `CargoSetInputs` struct in `guppy::graph::cargo` combines `CargoOptions` and the features-only set.
+- With the `summaries` feature, `CargoOptionsSummary` is renamed to
+  `CargoSetInputsSummary`. The serialized format is unchanged.
 - With the `summaries` feature, `toml` is updated to 1.1.4. `Error::TomlSerializeError`
   now wraps `toml` 1.x's `ser::Error`, a breaking change for code that names that type.
   Summary parsing follows the TOML 1.1 specification strictly.

--- a/guppy/src/errors.rs
+++ b/guppy/src/errors.rs
@@ -55,6 +55,19 @@ pub enum Error {
         /// Third-party packages that weren't known to the `PackageGraph`.
         unknown_third_party: Vec<crate::graph::summaries::ThirdPartySummary>,
     },
+    /// While resolving the features-only set of a
+    /// [`CargoSetInputsSummary`](crate::graph::summaries::CargoSetInputsSummary), some
+    /// elements were unknown to the `PackageGraph`.
+    ///
+    /// This is present if the `summaries` feature is enabled.
+    #[cfg(feature = "summaries")]
+    UnknownFeaturesOnlySummary {
+        /// Summary IDs that weren't known to the `PackageGraph`.
+        unknown_summary_ids: Vec<crate::graph::summaries::SummaryId>,
+        /// Features and optional dependencies that weren't known to the `FeatureGraph`, grouped
+        /// by package. Each entry lists only the unknown ones.
+        unknown_features: Vec<crate::graph::summaries::FeaturesOnlySummary>,
+    },
     /// While resolving a [`PackageSetSummary`](crate::graph::summaries::PackageSetSummary),
     /// an unknown external registry was encountered.
     #[cfg(feature = "summaries")]
@@ -133,6 +146,36 @@ impl fmt::Display for Error {
                 Ok(())
             }
             #[cfg(feature = "summaries")]
+            UnknownFeaturesOnlySummary {
+                unknown_summary_ids,
+                unknown_features,
+            } => {
+                writeln!(f, "unknown elements: resolving features-only")?;
+                if !unknown_summary_ids.is_empty() {
+                    writeln!(f, "* unknown summary IDs:")?;
+                    for summary_id in unknown_summary_ids {
+                        writeln!(f, "  - {summary_id}")?;
+                    }
+                }
+                if !unknown_features.is_empty() {
+                    writeln!(f, "* unknown features:")?;
+                    for entry in unknown_features {
+                        writeln!(f, "  - {}:", entry.summary_id)?;
+                        if !entry.features.is_empty() {
+                            writeln!(f, "    - features: {}", join_names(&entry.features))?;
+                        }
+                        if !entry.optional_deps.is_empty() {
+                            writeln!(
+                                f,
+                                "    - optional-deps: {}",
+                                join_names(&entry.optional_deps)
+                            )?;
+                        }
+                    }
+                }
+                Ok(())
+            }
+            #[cfg(feature = "summaries")]
             UnknownRegistryName {
                 message,
                 summary,
@@ -168,11 +211,22 @@ impl error::Error for Error {
             #[cfg(feature = "summaries")]
             UnknownPackageSetSummary { .. } => None,
             #[cfg(feature = "summaries")]
+            UnknownFeaturesOnlySummary { .. } => None,
+            #[cfg(feature = "summaries")]
             UnknownRegistryName { .. } => None,
             #[cfg(feature = "summaries")]
             TomlSerializeError(err) => Some(err),
         }
     }
+}
+
+#[cfg(feature = "summaries")]
+fn join_names(names: &std::collections::BTreeSet<String>) -> String {
+    names
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 /// Describes warnings emitted during feature graph construction.

--- a/guppy/src/graph/cargo/cargo_api.rs
+++ b/guppy/src/graph/cargo/cargo_api.rs
@@ -314,6 +314,47 @@ impl Default for InitialsPlatform {
     }
 }
 
+/// The inputs to a `CargoSet` other than the initials.
+///
+/// The initials are kept separate so that one `CargoSetInputs` can be reused
+/// across many `CargoSet`s via [`to_cargo_set`](Self::to_cargo_set).
+///
+/// Both fields must refer to the same `PackageGraph` as the initials they
+/// are used with.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct CargoSetInputs<'g> {
+    /// The Cargo options used to build the `CargoSet`.
+    pub options: CargoOptions<'g>,
+
+    /// The features-only set: see [`CargoSet::new`].
+    pub features_only: FeatureSet<'g>,
+}
+
+assert_covariant!(CargoSetInputs);
+
+impl<'g> CargoSetInputs<'g> {
+    /// Creates a new `CargoSetInputs` from the given inputs.
+    pub fn new(options: CargoOptions<'g>, features_only: FeatureSet<'g>) -> Self {
+        Self {
+            options,
+            features_only,
+        }
+    }
+
+    /// Simulates a Cargo build of `initials` with these inputs.
+    ///
+    /// This is a shorthand for [`CargoSet::new`].
+    ///
+    /// ## Panics
+    ///
+    /// Panics if `initials` was built from a different package graph than
+    /// these inputs.
+    pub fn to_cargo_set(&self, initials: FeatureSet<'g>) -> Result<CargoSet<'g>, Error> {
+        CargoSet::new(initials, self.features_only.clone(), &self.options)
+    }
+}
+
 /// A set of packages and features, as would be built by Cargo.
 ///
 /// Cargo implements a set of algorithms to figure out which packages or features are built in

--- a/guppy/src/graph/summaries.rs
+++ b/guppy/src/graph/summaries.rs
@@ -11,8 +11,8 @@ use crate::{
     Error,
     graph::{
         DependencyDirection, PackageGraph, PackageMetadata, PackageSet, PackageSource,
-        cargo::{CargoOptions, CargoResolverVersion, CargoSet, InitialsPlatform},
-        feature::FeatureSet,
+        cargo::{CargoOptions, CargoResolverVersion, CargoSet, CargoSetInputs, InitialsPlatform},
+        feature::{FeatureId, FeatureSet},
     },
     platform::PlatformSpecSummary,
 };
@@ -27,8 +27,11 @@ impl CargoSet<'_> {
     /// Requires the `summaries` feature to be enabled.
     pub fn to_summary(&self, opts: &CargoOptions<'_>) -> Result<Summary, Error> {
         let initials = self.initials();
-        let metadata =
-            CargoOptionsSummary::new(initials.graph().package_graph, self.features_only(), opts)?;
+        let metadata = CargoSetInputsSummary::from_parts(
+            initials.graph().package_graph,
+            self.features_only(),
+            opts,
+        )?;
         let target_features = self.target_features();
         let host_features = self.host_features();
 
@@ -96,19 +99,20 @@ impl PackageGraph {
             SummarySource::Workspace { workspace_path } => {
                 self.workspace().member_by_path(workspace_path)
             }
-            _ => {
+            SummarySource::Path { .. }
+            | SummarySource::CratesIo
+            | SummarySource::External { .. } => {
                 // Do a linear search for now -- this appears to be the easiest thing to do and is
                 // pretty fast. This could potentially be sped up by building an index by name, but
                 // at least for reasonably-sized graphs it's really fast.
                 //
                 // TODO: consider optimizing this in the future.
-                let mut filter = self.packages().filter(|package| {
-                    package.name() == summary_id.name
-                        && package.version() == &summary_id.version
-                        && package.source() == summary_id.source
-                });
-                filter
-                    .next()
+                self.packages()
+                    .find(|package| {
+                        package.name() == summary_id.name
+                            && package.version() == &summary_id.version
+                            && package.source() == summary_id.source
+                    })
                     .ok_or_else(|| Error::UnknownSummaryId(summary_id.clone()))
             }
         }
@@ -128,13 +132,13 @@ impl PackageMetadata<'_> {
     }
 }
 
-/// A summary of Cargo options used to build a `CargoSet`.
+/// A summary of the [`CargoSetInputs`] used to build a `CargoSet`.
 ///
 /// Requires the `summaries` feature to be enabled.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-pub struct CargoOptionsSummary {
+pub struct CargoSetInputsSummary {
     /// The Cargo resolver version used.
     ///
     /// For more information, see the documentation for [`CargoResolverVersion`].
@@ -165,9 +169,17 @@ pub struct CargoOptionsSummary {
     pub features_only: Vec<FeaturesOnlySummary>,
 }
 
-impl CargoOptionsSummary {
-    /// Creates a new `CargoOptionsSummary` from the given Cargo options.
-    pub fn new(
+impl CargoSetInputsSummary {
+    /// Creates a new `CargoSetInputsSummary` from the given inputs.
+    pub fn new(inputs: &CargoSetInputs<'_>) -> Result<Self, Error> {
+        Self::from_parts(
+            inputs.features_only.graph().package_graph,
+            &inputs.features_only,
+            &inputs.options,
+        )
+    }
+
+    fn from_parts(
         graph: &PackageGraph,
         features_only: &FeatureSet<'_>,
         opts: &CargoOptions<'_>,
@@ -204,16 +216,23 @@ impl CargoOptionsSummary {
         })
     }
 
-    /// Creates a new `CargoOptions` from this summary.
-    pub fn to_cargo_options<'g>(
+    /// Creates a new [`CargoSetInputs`] from this summary.
+    ///
+    /// The summary does not record base features, so the rebuilt features-only
+    /// set includes the base feature of every package listed in
+    /// `features_only`. See [`FeaturesOnlySummary`].
+    ///
+    /// Returns an error if any of the omitted packages, the platforms, or the
+    /// features-only elements could not be resolved against `package_graph`.
+    pub fn to_cargo_set_inputs<'g>(
         &'g self,
         package_graph: &'g PackageGraph,
-    ) -> Result<CargoOptions<'g>, Error> {
+    ) -> Result<CargoSetInputs<'g>, Error> {
         let omitted_packages = self
             .omitted_packages
             .to_package_set(package_graph, "resolving omitted-packages")?;
 
-        // TODO: return the features-only set
+        let features_only = self.to_features_only(package_graph)?;
 
         let mut options = CargoOptions::new();
         options
@@ -229,7 +248,74 @@ impl CargoOptionsSummary {
                 Error::TargetSpecError("parsing target platform".to_string(), err)
             })?)
             .add_omitted_packages(omitted_packages.package_ids(DependencyDirection::Forward));
-        Ok(options)
+        Ok(CargoSetInputs {
+            options,
+            features_only,
+        })
+    }
+
+    fn to_features_only<'g>(
+        &'g self,
+        package_graph: &'g PackageGraph,
+    ) -> Result<FeatureSet<'g>, Error> {
+        let feature_graph = package_graph.feature_graph();
+        let mut feature_ids = Vec::new();
+        let mut unknown_summary_ids = Vec::new();
+        let mut unknown_features = Vec::new();
+
+        for features_only in &self.features_only {
+            let metadata = match package_graph.metadata_by_summary_id(&features_only.summary_id) {
+                Ok(metadata) => metadata,
+                Err(Error::UnknownWorkspacePath(_) | Error::UnknownSummaryId(_)) => {
+                    unknown_summary_ids.push(features_only.summary_id.clone());
+                    continue;
+                }
+                Err(err) => return Err(err),
+            };
+            let package_id = metadata.id();
+
+            // The summary doesn't record base features, so always enable the
+            // base feature for a listed package.
+            feature_ids.push(FeatureId::base(package_id));
+
+            let mut unknown = FeaturesOnlySummary {
+                summary_id: features_only.summary_id.clone(),
+                features: BTreeSet::new(),
+                optional_deps: BTreeSet::new(),
+            };
+            for feature in &features_only.features {
+                let feature_id = FeatureId::named(package_id, feature);
+                if feature_graph.contains(feature_id) {
+                    feature_ids.push(feature_id);
+                } else {
+                    unknown.features.insert(feature.clone());
+                }
+            }
+            for dep_name in &features_only.optional_deps {
+                let feature_id = FeatureId::optional_dependency(package_id, dep_name);
+                if feature_graph.contains(feature_id) {
+                    feature_ids.push(feature_id);
+                } else {
+                    unknown.optional_deps.insert(dep_name.clone());
+                }
+            }
+            if !unknown.features.is_empty() || !unknown.optional_deps.is_empty() {
+                unknown_features.push(unknown);
+            }
+        }
+
+        if !unknown_summary_ids.is_empty() || !unknown_features.is_empty() {
+            return Err(Error::UnknownFeaturesOnlySummary {
+                unknown_summary_ids,
+                unknown_features,
+            });
+        }
+
+        // Every ID above was checked against the feature graph, so a failure
+        // here is a programmer error.
+        Ok(feature_graph
+            .resolve_ids(feature_ids)
+            .expect("feature IDs were checked against the feature graph"))
     }
 }
 
@@ -272,13 +358,13 @@ impl From<InitialsPlatformSummary> for InitialsPlatform {
 
 /// Summary information for a features-only package.
 ///
-/// These packages are stored in `CargoOptionsSummary` because they may or may not be in the final
+/// These packages are stored in `CargoSetInputsSummary` because they may or may not be in the final
 /// build set.
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct FeaturesOnlySummary {
-    /// The summary ID for this feature.
+    /// The summary ID for this package.
     #[serde(flatten)]
     pub summary_id: SummaryId,
 
@@ -339,10 +425,45 @@ include-dev = true
 proc-macros-on-target = false
 ";
 
-        let summary: CargoOptionsSummary = toml::from_str(metadata).expect("parsed correctly");
+        let summary: CargoSetInputsSummary = toml::from_str(metadata).expect("parsed correctly");
         assert_eq!(
             InitialsPlatform::from(summary.initials_platform),
             InitialsPlatform::Standard
+        );
+    }
+
+    #[test]
+    fn parse_features_only_metadata() {
+        let metadata = "\
+resolver = '2'
+include-dev = false
+initials-platform = 'standard'
+
+[[features-only]]
+name = 'guppy'
+version = '0.5.0'
+workspace-path = 'guppy'
+features = ['guppy-summaries', 'summaries']
+optional-deps = ['guppy-summaries']
+";
+
+        let summary: CargoSetInputsSummary = toml::from_str(metadata).expect("parsed correctly");
+        let features_only = match summary.features_only.as_slice() {
+            [features_only] => features_only,
+            other => panic!("expected exactly one features-only entry, found {other:?}"),
+        };
+        assert_eq!(features_only.summary_id.name, "guppy");
+        assert_eq!(
+            features_only.summary_id.source,
+            SummarySource::workspace("guppy")
+        );
+        assert_eq!(
+            features_only.features.iter().collect::<Vec<_>>(),
+            ["guppy-summaries", "summaries"]
+        );
+        assert_eq!(
+            features_only.optional_deps.iter().collect::<Vec<_>>(),
+            ["guppy-summaries"]
         );
     }
 }

--- a/guppy/tests/graph-tests/main.rs
+++ b/guppy/tests/graph-tests/main.rs
@@ -16,4 +16,6 @@ mod cargo_set_tests;
 mod feature_helpers;
 mod graph_tests;
 mod invalid_tests;
+#[cfg(feature = "summaries")]
+mod summary_tests;
 mod weak_namespaced;

--- a/guppy/tests/graph-tests/proptest_helpers.rs
+++ b/guppy/tests/graph-tests/proptest_helpers.rs
@@ -32,6 +32,12 @@ macro_rules! proptest_suite {
                 run_summary_id_roundtrip(JsonFixture::$name().graph());
             }
 
+            #[cfg(feature = "summaries")]
+            #[test]
+            fn proptest_features_only_summary_roundtrip() {
+                run_features_only_summary_roundtrip(JsonFixture::$name().graph());
+            }
+
             #[test]
             fn proptest_query_depends_on() {
                 run_query_depends_on(JsonFixture::$name().graph());
@@ -148,6 +154,78 @@ pub(super) fn run_summary_id_roundtrip(graph: &'static PackageGraph) {
             .metadata_by_summary_id(&summary_id)
             .expect("summary ID is valid");
         prop_assert_eq!(package_id, package2.id(), "roundtrip successful");
+    })
+}
+
+#[cfg(feature = "summaries")]
+pub(super) fn run_features_only_summary_roundtrip(graph: &'static PackageGraph) {
+    use guppy::graph::{
+        cargo::{CargoSet, CargoSetInputs},
+        summaries::CargoSetInputsSummary,
+    };
+
+    let feature_graph = graph.feature_graph();
+
+    proptest!(|(
+        initial_ids in hash_set(graph.workspace().proptest1_id_strategy(), 0..8),
+        initials_filter in prop::sample::select(StandardFeatures::VALUES.as_slice()),
+        features_only in feature_graph.proptest1_set_strategy(),
+        opts in graph.proptest1_cargo_options_strategy(),
+    )| {
+        let initials = graph
+            .resolve_ids(initial_ids.iter().copied())
+            .expect("valid package IDs")
+            .to_feature_set(initials_filter);
+
+        let inputs = CargoSetInputs::new(opts, features_only);
+        let summary = CargoSetInputsSummary::new(&inputs).expect("inputs summary generated");
+        let rebuilt = summary
+            .to_cargo_set_inputs(graph)
+            .expect("cargo set inputs rebuilt from the summary");
+
+        // The summary doesn't record base features, so the rebuilt set is the
+        // original plus the base feature of every package in it.
+        let base_features = feature_graph
+            .resolve_ids(
+                inputs
+                    .features_only
+                    .packages_with_features(DependencyDirection::Forward)
+                    .map(|feature_list| FeatureId::base(feature_list.package().id())),
+            )
+            .expect("valid base feature IDs");
+        let normalized_features_only = inputs.features_only.union(&base_features);
+        prop_assert_eq!(
+            &rebuilt.features_only,
+            &normalized_features_only,
+            "features-only set rebuilt from the summary, plus base features"
+        );
+
+        let rebuilt_summary =
+            CargoSetInputsSummary::new(&rebuilt).expect("inputs summary regenerated");
+        prop_assert_eq!(
+            &rebuilt_summary,
+            &summary,
+            "inputs summary regenerated from the rebuilt inputs"
+        );
+
+        // Base features affect the simulated build, so compare against the
+        // normalized set rather than the original one.
+        let normalized_set =
+            CargoSet::new(initials.clone(), normalized_features_only, &inputs.options)
+                .expect("cargo set built from the normalized inputs");
+        let rebuilt_set = rebuilt
+            .to_cargo_set(initials)
+            .expect("cargo set built from the rebuilt inputs");
+        prop_assert_eq!(
+            rebuilt_set.target_features(),
+            normalized_set.target_features(),
+            "target features match after the round trip"
+        );
+        prop_assert_eq!(
+            rebuilt_set.host_features(),
+            normalized_set.host_features(),
+            "host features match after the round trip"
+        );
     })
 }
 

--- a/guppy/tests/graph-tests/summary_tests.rs
+++ b/guppy/tests/graph-tests/summary_tests.rs
@@ -1,0 +1,182 @@
+// Copyright (c) The cargo-guppy Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use fixtures::json::JsonFixture;
+use guppy::{
+    Error, Version,
+    graph::{
+        PackageGraph,
+        cargo::{CargoOptions, CargoSet},
+        feature::{FeatureSet, StandardFeatures},
+        summaries::{CargoSetInputsSummary, Summary, SummaryId, SummarySource},
+    },
+};
+use pretty_assertions::assert_eq;
+
+fn feature_sets_for_guppy_c9b4f76(graph: &PackageGraph) -> (FeatureSet<'_>, FeatureSet<'_>) {
+    let initials = graph
+        .resolve_workspace_names(["fixtures"])
+        .expect("fixtures is a workspace member")
+        .to_feature_set(StandardFeatures::Default);
+    let features_only = graph
+        .resolve_workspace_names(["guppy"])
+        .expect("guppy is a workspace member")
+        .to_feature_set(StandardFeatures::All);
+    (initials, features_only)
+}
+
+#[test]
+fn features_only_changes_resolution() {
+    let graph = JsonFixture::metadata_guppy_c9b4f76().graph();
+    let (initials, features_only) = feature_sets_for_guppy_c9b4f76(graph);
+    let opts = CargoOptions::new();
+
+    let with_features_only = CargoSet::new(initials.clone(), features_only, &opts)
+        .expect("cargo set built with a features-only set");
+    let without_features_only =
+        CargoSet::new(initials, graph.feature_graph().resolve_none(), &opts)
+            .expect("cargo set built without a features-only set");
+
+    assert_ne!(
+        with_features_only.target_features(),
+        without_features_only.target_features(),
+        "features-only set alters the resolution",
+    );
+}
+
+#[test]
+fn features_only_summary_round_trip() {
+    let graph = JsonFixture::metadata_guppy_c9b4f76().graph();
+    let (initials, features_only) = feature_sets_for_guppy_c9b4f76(graph);
+    let opts = CargoOptions::new();
+
+    let cargo_set = CargoSet::new(initials.clone(), features_only.clone(), &opts)
+        .expect("cargo set built with a features-only set");
+    let summary = cargo_set.to_summary(&opts).expect("summary generated");
+
+    let serialized = summary.to_string().expect("summary serialized to TOML");
+    let parsed = Summary::parse(&serialized).expect("summary parsed from TOML");
+    assert_eq!(parsed, summary, "summary round-tripped through TOML");
+
+    let metadata: CargoSetInputsSummary = parsed
+        .metadata
+        .try_into()
+        .expect("metadata deserialized as a CargoSetInputsSummary");
+    let inputs = metadata
+        .to_cargo_set_inputs(graph)
+        .expect("cargo set inputs rebuilt from the summary");
+
+    assert_eq!(
+        inputs.features_only, features_only,
+        "features-only set rebuilt from the summary",
+    );
+
+    let rebuilt = inputs
+        .to_cargo_set(initials)
+        .expect("cargo set rebuilt from the summary");
+    assert_eq!(
+        rebuilt
+            .to_summary(&inputs.options)
+            .expect("rebuilt summary generated"),
+        summary,
+        "resolution rebuilt from the summary matches the original",
+    );
+}
+
+#[test]
+fn features_only_summary_unknown_elements() {
+    let graph = JsonFixture::metadata_guppy_c9b4f76().graph();
+    let metadata = "\
+resolver = '2'
+include-dev = false
+initials-platform = 'standard'
+
+[[features-only]]
+name = 'guppy'
+version = '0.5.0'
+workspace-path = 'guppy'
+features = ['summaries', 'no-such-feature']
+optional-deps = ['guppy-summaries', 'no-such-dep']
+
+[[features-only]]
+name = 'not-a-member'
+version = '0.1.0'
+workspace-path = 'not-a-member'
+features = []
+
+[[features-only]]
+name = 'no-such-crate'
+version = '1.0.0'
+crates-io = true
+features = []
+";
+
+    let summary: CargoSetInputsSummary =
+        toml::from_str(metadata).expect("summary parsed from TOML");
+    let err = summary
+        .to_cargo_set_inputs(graph)
+        .expect_err("unknown features-only elements rejected");
+
+    #[cfg_attr(guppy_nightly, expect(non_exhaustive_omitted_patterns))]
+    match &err {
+        Error::UnknownFeaturesOnlySummary {
+            unknown_summary_ids,
+            unknown_features,
+        } => {
+            assert_eq!(
+                unknown_summary_ids,
+                &[
+                    SummaryId::new(
+                        "not-a-member",
+                        Version::new(0, 1, 0),
+                        SummarySource::workspace("not-a-member"),
+                    ),
+                    SummaryId::new(
+                        "no-such-crate",
+                        Version::new(1, 0, 0),
+                        SummarySource::crates_io(),
+                    ),
+                ],
+                "every unknown package is reported",
+            );
+            let entry = match unknown_features.as_slice() {
+                [entry] => entry,
+                other => panic!("expected exactly one unknown-features entry, found {other:?}"),
+            };
+            assert_eq!(
+                entry.summary_id,
+                SummaryId::new(
+                    "guppy",
+                    Version::new(0, 5, 0),
+                    SummarySource::workspace("guppy")
+                ),
+            );
+            assert_eq!(
+                entry.features.iter().collect::<Vec<_>>(),
+                ["no-such-feature"],
+                "only the unknown named features are reported",
+            );
+            assert_eq!(
+                entry.optional_deps.iter().collect::<Vec<_>>(),
+                ["no-such-dep"],
+                "only the unknown optional deps are reported",
+            );
+        }
+        other => panic!("expected UnknownFeaturesOnlySummary, found {other:?}"),
+    }
+
+    assert_eq!(
+        err.to_string(),
+        "\
+unknown elements: resolving features-only
+* unknown summary IDs:
+  - { name = \"not-a-member\", version = \"0.1.0\", source = \"path 'not-a-member'\"}
+  - { name = \"no-such-crate\", version = \"1.0.0\", source = \"crates.io\"}
+* unknown features:
+  - { name = \"guppy\", version = \"0.5.0\", source = \"path 'guppy'\"}:
+    - features: no-such-feature
+    - optional-deps: no-such-dep
+",
+        "error message lists every unknown element",
+    );
+}

--- a/internal-tools/fixture-manager/src/summaries.rs
+++ b/internal-tools/fixture-manager/src/summaries.rs
@@ -7,7 +7,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use fixtures::json::JsonFixture;
 use guppy::graph::{
     cargo::CargoSet,
-    summaries::{Summary, diff::SummaryDiff},
+    summaries::{CargoSetInputsSummary, Summary, diff::SummaryDiff},
 };
 use guppy_cmdlib::PackagesAndFeatures;
 use hakari::diffy::{PatchFormatter, create_patch};
@@ -69,13 +69,34 @@ impl<'g> ContextImpl<'g> for SummaryContext {
                 .generate(&cargo_opts_strategy);
             let cargo_set = CargoSet::new(initials, features_only, &cargo_opts)
                 .expect("into_cargo_set succeeded");
+            let summary = cargo_set
+                .to_summary(&cargo_opts)
+                .expect("generated summaries should serialize correctly");
 
-            (
-                idx,
-                cargo_set
-                    .to_summary(&cargo_opts)
-                    .expect("generated summaries should serialize correctly"),
-            )
+            let metadata: CargoSetInputsSummary = summary
+                .metadata
+                .clone()
+                .try_into()
+                .expect("metadata deserialized as a CargoSetInputsSummary");
+            let inputs = metadata
+                .to_cargo_set_inputs(graph)
+                .expect("cargo set inputs rebuilt from the summary");
+            assert_eq!(
+                &inputs.features_only,
+                cargo_set.features_only(),
+                "features-only set rebuilt from the summary",
+            );
+            let rebuilt_summary = inputs
+                .to_cargo_set(cargo_set.initials().clone())
+                .expect("cargo set rebuilt from the summary")
+                .to_summary(&inputs.options)
+                .expect("rebuilt summary generated");
+            assert_eq!(
+                rebuilt_summary, summary,
+                "resolution rebuilt from the summary matches the original",
+            );
+
+            (idx, summary)
         });
 
         Box::new(iter)


### PR DESCRIPTION
This represents both Cargo options and the features-only set, so `CargoOptionsSummary` isn't quite an accurate description of what it is.