### PR TITLE
[cargo-hakari] fix the dry-run/yes conflict on init

### DIFF
--- a/tools/cargo-hakari/src/command.rs
+++ b/tools/cargo-hakari/src/command.rs
@@ -93,7 +93,7 @@ enum Command {
         dry_run: bool,
 
         /// Proceed with the operation without prompting for confirmation.
-        #[clap(long, short, conflicts_with = "dry-run")]
+        #[clap(long, short, conflicts_with = "dry_run")]
         yes: bool,
     },
 


### PR DESCRIPTION
clap argument IDs are field names, so `conflicts_with = "dry-run"` referred to an argument that doesn't exist. In debug builds clap's debug assertions caught this and `cargo hakari init` panicked; in release builds the conflict was silently unenforced, so `--dry-run --yes` was accepted. The other subcommands already used `dry_run`.